### PR TITLE
increase memory space for yarn builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
netlify is failing for JavaScript out of memory errors, and adding this flag fixes builds locally for the large builds. this fix is intended as a stopgap measure while the docs get re-organized into less intensive files. 