### PR TITLE
Use signin link instead of signup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,7 +81,7 @@ const config = {
           },
           {
             label: 'Login',
-            to: 'https://ngrok.com/signup',
+            to: 'https://dashboard.ngrok.com/login',
             position: 'right',
             className: 'dev-portal-signup dev-portal-link',
           },


### PR DESCRIPTION
Send the user to the login dashboard page instead of the signup page. Seemed like a copy-paste error, but maybe intentional?