### PR TITLE
Update a few links that went to the wrong place

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -14,19 +14,16 @@ Here you will find a set of guides to help you with common (and not so common) t
 | [Upgrading to ngrok Agent v3](/guides/upgrade-v2-v3) | Learn about the key differences between the v2 and v3 ngrok agent |
 | [Corporate Firewalls](/guides/running-behind-firewalls) | Learn how to use ngrok securely behind your corporate firewalls |
 | [Configure Okta Single Sign-On for your ngrok Account](/guides/dashboard-sso-okta-setup) | Learn how to enable Single Sign-On (SSO) for logging into your ngrok dashboard |
-| [Forwarding to HTTPS Service](/secure-tunnels#http-tunnels-local-https) | Learn how to use the ngrok agent to route traffic to a local TLS service |
-| [Forwarding to Another Machine](/secure-tunnels#non-local) | Learn how to leverage a single ngrok agent to route to any machine in your network |
-| [Installing your Authtoken](/secure-tunnels#tunnel-authtokens) | Learn how to install your ngrok Authtoken with a single command |
+| [Forwarding to HTTPS Service](/secure-tunnels/tunnels/http-tunnels#local-https) | Learn how to use the ngrok agent to route traffic to a local TLS service |
+| [Forwarding to Another Machine](/secure-tunnels/non-local) | Learn how to leverage a single ngrok agent to route to any machine in your network |
+| [Installing your Authtoken](/secure-tunnels/ngrok-agent/tunnel-authtokens) | Learn how to install your ngrok Authtoken with a single command |
 | [Setting Up a Custom Domain](/guides/how-to-set-up-a-custom-domain) | Bring your own custom domain to ngrok to host your service on your own brand |
-| [Inspecting / Replaying Traffic](/secure-tunnels#inspecting-requests) | Learn how to speed up local development by using the ngrok agent Inspect UI to replay requests |
-| [Reserved TCP Address](/secure-tunnels#tcp-remote-addr) | Reserve a TCP Address and use it to reconnect to the same address each time |
-| [Per-client Authtokens](/secure-tunnels#authtoken-per-agent) | Learn best practices when deploying many ngrok agents |
-| [Rewriting the Host Header](/secure-tunnels#http-tunnels-host-header) | Learn how to rewrite the incoming host header for routing traffic to different local services |
-| [non-HTTP Services on TLS Tunnels](/secure-tunnels#tls-agnostic) | Learn how to configure non-HTTP services using our TLS tunnels |
-| [Multiple Tunnels Same ngrok Agent](/ngrok-agent/config#config-ngrok-tunnel-definitions) | Learn how to use a single ngrok agent session to open many tunnels |
+| [Inspecting / Replaying Traffic](/secure-tunnels/ngrok-agent/web-inspection-interface) | Learn how to speed up local development by using the ngrok agent Inspect UI to replay requests |
+| [Reserved TCP Address](/secure-tunnels/tunnels/tcp-tunnels#tcp-remote-addr) | Reserve a TCP Address and use it to reconnect to the same address each time |
+| [Per-client Authtokens](secure-tunnels/ngrok-agent/tunnel-authtokens#per-agent-authtokens) | Learn best practices when deploying many ngrok agents |
+| [Rewriting the Host Header](/secure-tunnels/tunnels/http-tunnels#host-header) | Learn how to rewrite the incoming host header for routing traffic to different local services |
+| [non-HTTP Services on TLS Tunnels](/secure-tunnels/tunnels/tls-tunnels#tls-agnostic) | Learn how to configure non-HTTP services using our TLS tunnels |
+| [Multiple Tunnels Same ngrok Agent](/ngrok-agent/config#tunnel-definitions) | Learn how to use a single ngrok agent session to open many tunnels |
 | [Securing your Tunnels](/guides/securing-your-tunnels) | Learn how to secure your ngrok tunnels from prying eyes |
-| [Serving Local Directories](/secure-tunnels#http-tunnels-file-urls) | Learn how to use ngrok as a file server to quickly share directories with anyone |
-| [Tunneling only HTTP or HTTPS Traffic](/secure-tunnels#http-tunnels-schemes) | Learn how to configure the ngrok agent to only serve traffic on HTTP or HTTPS. |
-| [Wildcard Domains](/secure-tunnels#wildcard-domains) | Learn how wildcard domains work in ngrok and configure your own |
-
-
+| [Serving Local Directories](/secure-tunnels/tunnels/http-tunnels#file-url) | Learn how to use ngrok as a file server to quickly share directories with anyone |
+| [Wildcard Domains](/cloud-edge/endpoints#wildcard-domains) | Learn how wildcard domains work in ngrok and configure your own |

--- a/docs/secure-tunnels/index.md
+++ b/docs/secure-tunnels/index.md
@@ -14,7 +14,7 @@ Using ngrok Secure Tunnels means that you can treat every device as being local,
 
 ngrok Secure Tunnels work by using a locally installed ngrok agent to establish a connection to the ngrok service. Once the connection is established, you get a public endpoint that you or others can use to access your local service.
 
-When a user hits the public ngrok endpoint, the ngrok edge figures out where to route the request to and forwards it over an encrypted connection to the locally running ngrok agent. From there, the local ngrok agent takes care of sending traffic to your upstream service. The communication between the ngrok edge and agent is secure and encrypted. Traffic from the user to the ngrok edge, and from the ngrok agent to the upstream service rely on the protocol you are using for encryption. For protocols that support end to end encryption using TLS, we provide a [TLS tunnel](/secure-tunnels#tls-tunnels) option.
+When a user hits the public ngrok endpoint, the ngrok edge figures out where to route the request to and forwards it over an encrypted connection to the locally running ngrok agent. From there, the local ngrok agent takes care of sending traffic to your upstream service. The communication between the ngrok edge and agent is secure and encrypted. Traffic from the user to the ngrok edge, and from the ngrok agent to the upstream service rely on the protocol you are using for encryption. For protocols that support end to end encryption using TLS, we provide a [TLS tunnel](/secure-tunnels/tunnels/tls-tunnels) option.
 
 ## Integrating with Cloud Edge
 


### PR DESCRIPTION
docusaurus doesn't currently detect dead anchor links ("#foo"), but we had several dead anchor links.

I fixed the ones in "guides", and the one I originally ran into in secure tunnels.

I think we probably want to setup some CI to spot this type of broken link so we can find and fix all the others more easily than trying all of em by hand.