### PR TITLE
reroute deploys to correct s3 bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Deploy
         run: |
-          aws s3 sync ./build s3://docs.dev-ngrok.com --acl bucket-owner-full-control
-          aws s3 sync ./build s3://docs.stage-ngrok.com --acl bucket-owner-full-control 
-          aws s3 sync ./build s3://docs.ngrok.com --acl bucket-owner-full-control
+          aws s3 sync ./build s3://docs-s3.dev-ngrok.com --acl bucket-owner-full-control
+          aws s3 sync ./build s3://docs-s3.stage-ngrok.com --acl bucket-owner-full-control 
+          aws s3 sync ./build s3://docs-s3.ngrok.com --acl bucket-owner-full-control


### PR DESCRIPTION
contributes towards https://github.com/ngrok-private/ngrok/issues/14164

we're putting everything behind a different cloudfront/s3 bucket situation so we can reroute `docs.ngrok.com` correctly