### PR TITLE
Fix create credential request example

### DIFF
--- a/docs/api/resources/examples/_credentials_create_request.md
+++ b/docs/api/resources/examples/_credentials_create_request.md
@@ -2,6 +2,7 @@
 #### Example Request
 ```bash
 curl \
+-XPOST \
 -H "Authorization: Bearer {API_KEY}" \
 -H "Content-Type: application/json" \
 -H "Ngrok-Version: 2" \

--- a/docs/api/resources/examples/_credentials_create_request.md
+++ b/docs/api/resources/examples/_credentials_create_request.md
@@ -2,7 +2,7 @@
 #### Example Request
 ```bash
 curl \
--XPOST \
+-X POST \
 -H "Authorization: Bearer {API_KEY}" \
 -H "Content-Type: application/json" \
 -H "Ngrok-Version: 2" \


### PR DESCRIPTION
The request is required to be a POST but this seems to be missing from the example use of `curl`.