### PR TITLE
fix: adding trailing slash

### DIFF
--- a/docs/ngrok-agent/config.md
+++ b/docs/ngrok-agent/config.md
@@ -55,7 +55,7 @@ The following is a list of options that can be configured at the root of your co
 
 ### `api_key`
 
-This option specifies the API key used to access the ngrok API through the [`ngrok api`](ngrok#ngrok-api) command. This is only needed when using the [ngrok API](/api) and not the local ngrok agent API (available at `localhost:4040/api`). You can generate an API Key in the [ngrok Dashboard](https://dashboard.ngrok.com/api) and install it using the `ngrok config add-api-key` command.
+This option specifies the API key used to access the ngrok API through the [`ngrok api`](/docs/ngrok-agent/ngrok#ngrok-api) command. This is only needed when using the [ngrok API](/api) and not the local ngrok agent API (available at `localhost:4040/api`). You can generate an API Key in the [ngrok Dashboard](https://dashboard.ngrok.com/api) and install it using the `ngrok config add-api-key` command.
 
 ##### ngrok.yml specifying an API key
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,7 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Adds a trailing slash to our docs urls in the sitemap and when navigating to avoid a 302 redirect.