### PR TITLE
use-with-rust: drop anyhow dependency from example

### DIFF
--- a/docs/using-ngrok-with/rust.md
+++ b/docs/using-ngrok-with/rust.md
@@ -42,9 +42,10 @@ Getting started with ngrok and the ngrok-rs crate is simple:
     ```rust showLineNumbers
     use axum::{routing::get, Router};
     use ngrok::prelude::*;
+    use std::error::Error;
 
     #[tokio::main]
-    async fn main() -> anyhow::Result<()> {
+    async fn main() -> Result<(), Box<dyn Error>> {
         // build our application with a route
         let app = Router::new().route("/", get(|| async { "Hello from ngrok-rs!" }));
 
@@ -102,9 +103,10 @@ The ngrok-rs library provides functions and configuration for all features avail
 ```rust showLineNumbers
 use axum::{routing::get, Router};
 use ngrok::prelude::*;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // build our application with a route
     let app = Router::new().route("/", get(|| async { "Hello World!" }));
 


### PR DESCRIPTION
It's missing from the `cargo add` section, and we can just use the std
Error type anyway.

