### PR TITLE
adds ketch (cookie consent) to ngrok docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,27 +1,29 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
-require('dotenv').config();
+require("dotenv").config();
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const lightCodeTheme = require("prism-react-renderer/themes/github");
+const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
-const docsRepo = 'https://github.com/ngrok/ngrok-docs'
+const docsRepo = "https://github.com/ngrok/ngrok-docs";
+
+const isProduction = /production/i.test(process.env.NODE_ENV || "development");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'ngrok documentation',
-  tagline: 'online in one line',
-  url: 'https://ngrok.com',
-  baseUrl: '/docs/',
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
-  favicon: 'img/favicon.ico',
+  title: "ngrok documentation",
+  tagline: "online in one line",
+  url: "https://ngrok.com",
+  baseUrl: "/docs/",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "throw",
+  favicon: "img/favicon.ico",
   trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'ngrok', // Usually your GitHub org/user name.
-  projectName: 'ngrok-docs', // Usually your repo name.
+  organizationName: "ngrok", // Usually your GitHub org/user name.
+  projectName: "ngrok-docs", // Usually your repo name.
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -32,52 +34,60 @@ const config = {
   // },
 
   plugins: [
-    './src/plugins/ngrok-parse-integrations',
-    '@stackql/docusaurus-plugin-hubspot', 
-    '@docusaurus/theme-mermaid'
+    "./src/plugins/ngrok-parse-integrations",
+    "@stackql/docusaurus-plugin-hubspot",
+    "@docusaurus/theme-mermaid",
+  ],
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        name: "ketch-tag-id",
+        content: isProduction ? "ngrok_ketch_tag" : "ngrok_ketch_tag_local",
+      },
+    },
   ],
 
   scripts: [
     {
-      src:
-        '/docs/scripts/fix-redirect.js',
+      src: "/docs/scripts/ketch.js",
+    },
+    {
+      src: "/docs/scripts/fix-redirect.js",
       async: true,
     },
     {
-      src:
-        '/docs/scripts/anchor-scroll-to.js',
+      src: "/docs/scripts/anchor-scroll-to.js",
       async: true,
-    }
+    },
   ],
-  staticDirectories: [
-    'static',
-  ],
+  staticDirectories: ["static"],
 
   presets: [
     [
-      'classic',
+      "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          routeBasePath: '/',
+          sidebarPath: require.resolve("./sidebars.js"),
+          routeBasePath: "/",
           editUrl: `${docsRepo}/edit/main`,
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },
         blog: false,
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: require.resolve("./src/css/custom.css"),
         },
         googleAnalytics: {
-          trackingID: 'UA-41575845-1',
+          trackingID: "UA-41575845-1",
         },
         sitemap: {
-          changefreq: 'hourly',
+          changefreq: "hourly",
           priority: 0.5,
-          ignorePatterns: ['/docs/tags/**', '/docs/**/toc/**'],
-          filename: 'sitemap.xml',
-        }
+          ignorePatterns: ["/docs/tags/**", "/docs/**/toc/**"],
+          filename: "sitemap.xml",
+        },
       }),
     ],
   ],
@@ -86,187 +96,195 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       metadata: [
-        {name: 'keywords', content: 'ngrok, documentation, api, errors, reference, getting started, tutorials'}
+        {
+          name: "keywords",
+          content:
+            "ngrok, documentation, api, errors, reference, getting started, tutorials",
+        },
       ],
-      image: 'img/ngrok-docs-opengraph.png',
+      image: "img/ngrok-docs-opengraph.png",
       navbar: {
         logo: {
-          alt: 'ngrok',
-          src: 'img/ngrok-black.svg',
-          srcDark: 'img/ngrok-white.svg',
-          href: 'https://ngrok.com',
-          width: '100%',
-          height: '100%',
+          alt: "ngrok",
+          src: "img/ngrok-black.svg",
+          srcDark: "img/ngrok-white.svg",
+          href: "https://ngrok.com",
+          width: "100%",
+          height: "100%",
         },
         items: [
           {
-            label: 'Product',
-            to: 'https://ngrok.com/product',
-            position: 'left',
+            label: "Product",
+            to: "https://ngrok.com/product",
+            position: "left",
           },
           {
-            label: 'Solutions',
-            to: 'https://ngrok.com/solutions',
-            position: 'left',
+            label: "Solutions",
+            to: "https://ngrok.com/solutions",
+            position: "left",
           },
           {
-            label: 'Customers',
-            to: 'https://ngrok.com/customers',
-            position: 'left',
+            label: "Customers",
+            to: "https://ngrok.com/customers",
+            position: "left",
           },
           {
-            label: 'Docs',
-            to: '/docs',
-            position: 'left',
+            label: "Docs",
+            to: "/docs",
+            position: "left",
           },
           {
-            label: 'Pricing',
-            to: 'https://ngrok.com/pricing',
-            position: 'left',
+            label: "Pricing",
+            to: "https://ngrok.com/pricing",
+            position: "left",
           },
           {
-            label: 'Download',
-            to: 'https://ngrok.com/download',
-            position: 'left',
+            label: "Download",
+            to: "https://ngrok.com/download",
+            position: "left",
           },
           {
-            type: 'search',
-            position: 'right',
+            type: "search",
+            position: "right",
           },
           {
-            label: 'Login',
-            to: 'https://dashboard.ngrok.com/login',
-            position: 'right',
-            className: 'dev-portal-signup dev-portal-link',
+            label: "Login",
+            to: "https://dashboard.ngrok.com/login",
+            position: "right",
+            className: "dev-portal-signup dev-portal-link",
           },
           {
-            label: 'Sign Up',
-            to: 'https://ngrok.com/signup',
-            position: 'right',
-            className: 'dev-portal-signup dev-portal-link',
+            label: "Sign Up",
+            to: "https://ngrok.com/signup",
+            position: "right",
+            className: "dev-portal-signup dev-portal-link",
           },
         ],
       },
       algolia: {
-       appId: 'SPPRT3GDNI',
-       apiKey: 'e02fb8e0c4d8c7968396981d7ecb9fa8',
-       indexName: (process.env.DEPLOY_ENV || 'dev') + '_ngrok',
+        appId: "SPPRT3GDNI",
+        apiKey: "e02fb8e0c4d8c7968396981d7ecb9fa8",
+        indexName: (process.env.DEPLOY_ENV || "dev") + "_ngrok",
       },
       hubspot: {
         accountId: 21124867,
       },
       footer: {
-        style: 'light',
+        style: "light",
         links: [
           {
-            title: 'ngrok Service',
+            title: "ngrok Service",
             items: [
               {
-                label: 'Get Started',
-                to: '/getting-started',
+                label: "Get Started",
+                to: "/getting-started",
               },
               {
-                label: 'Sign up',
-                to: 'https://dashboard.ngrok.com/signup',
+                label: "Sign up",
+                to: "https://dashboard.ngrok.com/signup",
               },
               {
-                label: 'Login',
-                to: 'https://dashboard.ngrok.com/login',
+                label: "Login",
+                to: "https://dashboard.ngrok.com/login",
               },
               {
-                label: 'Download',
-                to: 'https://ngrok.com/download',
+                label: "Download",
+                to: "https://ngrok.com/download",
               },
               {
-                label: 'Docs',
-                to: 'https://ngrok.com/docs',
+                label: "Docs",
+                to: "https://ngrok.com/docs",
               },
               {
-                label: 'Status',
-                to: 'https://status.ngrok.com',
+                label: "Status",
+                to: "https://status.ngrok.com",
               },
             ],
           },
           {
-            title: 'ngrok.com',
+            title: "ngrok.com",
             items: [
               {
-                label: 'Product',
-                to: 'https://ngrok.com/product',
+                label: "Product",
+                to: "https://ngrok.com/product",
               },
               {
-                label: 'Pricing',
-                to: 'https://ngrok.com/pricing',
+                label: "Pricing",
+                to: "https://ngrok.com/pricing",
               },
               {
-                label: 'Customers',
-                to: 'https://ngrok.com/customers',
+                label: "Customers",
+                to: "https://ngrok.com/customers",
               },
               {
-                label: 'Solutions',
-                to: 'https://ngrok.com/solutions',
+                label: "Solutions",
+                to: "https://ngrok.com/solutions",
               },
               {
-                label: 'Partners',
-                to: 'https://ngrok.com/partners',
+                label: "Partners",
+                to: "https://ngrok.com/partners",
               },
               {
-                label: 'Trust Portal',
-                to: 'https://trust.ngrok.com',
+                label: "Trust Portal",
+                to: "https://trust.ngrok.com",
               },
             ],
           },
           {
-            title: 'Legal',
+            title: "Legal",
             items: [
               {
-                label: 'Abuse',
-                to: 'https://ngrok.com/abuse',
+                label: "Abuse",
+                to: "https://ngrok.com/abuse",
               },
               {
-                label: 'DPA',
-                to: 'https://ngrok.com/dpa',
+                label: "DPA",
+                to: "https://ngrok.com/dpa",
               },
               {
-                label: 'Privacy',
-                to: 'https://ngrok.com/privacy',
+                label: "Privacy",
+                to: "https://ngrok.com/privacy",
               },
               {
-                label: 'Security',
-                to: 'https://ngrok.com/security',
+                label: "Security",
+                to: "https://ngrok.com/security",
               },
               {
-                label: 'Terms of service',
-                to: 'https://ngrok.com/tos',
+                label: "Terms of service",
+                to: "https://ngrok.com/tos",
+              },
+              {
+                label: "Privacy Preferences",
+                to: "https://ngrok.com/privacy-preferences",
               },
             ],
           },
           {
-            title: 'More',
+            title: "More",
             items: [
               {
-                label: 'Careers',
-                to: 'https://ngrok.com/careers',
+                label: "Careers",
+                to: "https://ngrok.com/careers",
               },
               {
-                label: 'Blog',
-                to: 'https://blog.ngrok.com',
+                label: "Blog",
+                to: "https://blog.ngrok.com",
               },
               {
-                label: 'Community',
-                to: 'https://ngrok.com/slack',
+                label: "Community",
+                to: "https://ngrok.com/slack",
               },
               {
-                label: 'Twitter',
-                to: 'https://twitter.com/ngrokHQ',
+                label: "Twitter",
+                to: "https://twitter.com/ngrokHQ",
               },
               {
-                label: 'LinkedIn',
-                to: 'https://www.linkedin.com/company/ngrok',
+                label: "LinkedIn",
+                to: "https://www.linkedin.com/company/ngrok",
               },
               {
-                label: 'GitHub',
-                to: 'https://github.com/ngrok',
+                label: "GitHub",
+                to: "https://github.com/ngrok",
               },
             ],
           },
@@ -276,7 +294,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['hcl', 'rust'],
+        additionalLanguages: ["hcl", "rust"],
       },
       docs: {
         sidebar: {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "redocusaurus": "^1.4.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.4.0"
+    "@docusaurus/module-type-aliases": "^2.4.0",
+    "@docusaurus/types": "2.4.0"
   },
   "browserslist": {
     "production": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
     version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2)
   '@docusaurus/plugin-client-redirects':
     specifier: ^2.4.0
-    version: 2.4.0(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2)
+    version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2)
   '@docusaurus/plugin-google-analytics':
     specifier: ^2.4.0
     version: 2.4.0(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2)
@@ -53,6 +53,9 @@ dependencies:
 devDependencies:
   '@docusaurus/module-type-aliases':
     specifier: ^2.4.0
+    version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
+  '@docusaurus/types':
+    specifier: 2.4.0
     version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
 
 packages:
@@ -1754,7 +1757,7 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-client-redirects@2.4.0(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2):
+  /@docusaurus/plugin-client-redirects@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.2):
     resolution: {integrity: sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==}
     engines: {node: '>=16.14'}
     peerDependencies:

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,32 +4,35 @@
  * work well for content-centric websites.
  */
 
- @font-face {
+@font-face {
   font-family: "EuclidSquare";
   font-display: swap;
   src: local("sans-serif"),
-       url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2"),  
-       url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2"),
-       url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
- }
+    url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2"),
+    url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2"),
+    url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
+}
 
- @font-face {
+@font-face {
   font-family: "EuclidSquare-regular";
   font-display: swap;
-  src: local("sans-serif"), url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2");
- }
+  src: local("sans-serif"),
+    url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2");
+}
 
- @font-face {
+@font-face {
   font-family: "EuclidSquare-medium";
   font-display: swap;
-  src: local("sans-serif"),url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2");
- }
+  src: local("sans-serif"),
+    url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2");
+}
 
- @font-face {
+@font-face {
   font-family: "EuclidSquare-light";
   font-display: swap;
-  src: local("sans-serif"), url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
- }
+  src: local("sans-serif"),
+    url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
+}
 /* You can override the default Infima variables here. */
 
 /* Global text color */
@@ -43,8 +46,8 @@
   --ifm-color-primary-lighter: #5473ee;
   --ifm-color-primary-lightest: #7a92f2;
 
-  --ifm-pagination-nav-color-hover: #597EF7;
-  --ifm-active-drawer-active-color:  #597EF7;
+  --ifm-pagination-nav-color-hover: #597ef7;
+  --ifm-active-drawer-active-color: #597ef7;
   --ifm-heading-font-weight: 00;
 
   --docusaurus-collapse-button-bg-hover: rgb(0 0 0 / 0%);
@@ -52,19 +55,17 @@
   --ifm-h1-primary-header: #000000;
   --ifm-h2-primary-subheader: #000000;
   --ifm-p-primary-body: #595959;
-  --ifm-p-secondary-mini: #8C8C8C;
+  --ifm-p-secondary-mini: #8c8c8c;
 
-  --ifm-footer-background-color: #F0F2F5;
+  --ifm-footer-background-color: #f0f2f5;
 
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  --ifm-font-family-base: 'EuclidSquare-regular';
+  --ifm-font-family-base: "EuclidSquare-regular";
 }
 
-
-
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #85a5ff;
   --ifm-color-primary-dark: #5e88ff;
   --ifm-color-primary-darker: #4b7aff;
@@ -75,31 +76,29 @@
   --ifm-background-color: #1b1b1d;
 
   /* FIX this here, clean up code I didn't use. */
-  --ifm-h1-primary-header: #FFFFFF;
-  --ifm-h2-primary-subheader: #FFFFFF;
+  --ifm-h1-primary-header: #ffffff;
+  --ifm-h2-primary-subheader: #ffffff;
   --ifm-p-primary-body: #5F5F5F5;
-  --ifm-p-secondary-mini: #8C8C8C;
+  --ifm-p-secondary-mini: #8c8c8c;
 
   --ifm-footer-background-color: #262626;
-
 }
 
 /* Header */
 
 .navbar {
-  
 }
-
 
 /* Footer */
 
 .footer {
-  background-color: var(--ifm-footer-background-color)
+  background-color: var(--ifm-footer-background-color);
 }
 
 .footer__title {
   color: var(--ifm-h1-primary-header);
-  font: var(--ifm-h4-font-size) / var(--ifm-heading-line-height) var(--ifm-font-family-base);
+  font: var(--ifm-h4-font-size) / var(--ifm-heading-line-height)
+    var(--ifm-font-family-base);
   margin-top: 40px;
   margin-bottom: var(--ifm-heading-margin-bottom);
 }
@@ -114,12 +113,11 @@
   color: var(--ifm-p-secondary-mini);
 }
 
-
 /* Prev Next pagination buttons */
 
-.pagination-nav__link{
+.pagination-nav__link {
   border-radius: 4px;
-  border-color: #D9D9D9;
+  border-color: #d9d9d9;
 }
 
 .pagination-nav__link:hover {
@@ -140,26 +138,25 @@ a.menu__link {
   color: var(--ifm-menu-color);
   flex: 1;
   line-height: 1.25;
-  padding: var(--ifm-menu-link-padding-vertical) var(--ifm-menu-link-padding-horizontal);
-  font-family: 'EuclidSquare-medium';
-  
+  padding: var(--ifm-menu-link-padding-vertical)
+    var(--ifm-menu-link-padding-horizontal);
+  font-family: "EuclidSquare-medium";
 }
 
 li.menu__list-item:not([class*="level-1"]) a {
-  font-family: 'EuclidSquare-regular';
+  font-family: "EuclidSquare-regular";
   font-size: smaller;
 }
 
 .menu__link.menu__link--active {
   color: var(--ifm-active-drawer-active-color);
-  background-color: rgba(0,0,0,0.02);
+  background-color: rgba(0, 0, 0, 0.02);
 }
 
 /*b readcrumbs and directory */
 
 .breadcrumbs {
   margin-bottom: 40px;
-  
 }
 
 .breadcrumbs__link {
@@ -167,15 +164,16 @@ li.menu__list-item:not([class*="level-1"]) a {
 }
 
 .breadcrumbs__item--active .breadcrumbs__link {
-  background: rgba(0,0,0,0.0);
+  background: rgba(0, 0, 0, 0);
   color: var(--ifm-p-primary-body);
 }
 
-
 /*titles */
 
-h1, h2, h3{
-  font-family: 'EuclidSquare-medium';
+h1,
+h2,
+h3 {
+  font-family: "EuclidSquare-medium";
 }
 
 h1 {
@@ -187,13 +185,13 @@ h2 {
 h3 {
   font-size: 20px;
 }
-h4{
+h4 {
   font-size: 18px;
 }
-h5{
+h5 {
   font-size: 16px;
 }
-h6{
+h6 {
   font-size: 12px;
 }
 
@@ -206,8 +204,7 @@ p {
 }
 
 .card {
-  
-  border-color: #D9D9D9;
+  border-color: #d9d9d9;
   border-radius: 4px;
   box-shadow: 0;
 }
@@ -225,7 +222,7 @@ p {
 
 .ping::after {
   display: inline-block;
-  content: '';
+  content: "";
   background: var(--docs-color-primary);
   width: 4px;
   height: 4px;
@@ -244,7 +241,7 @@ p {
 }
 
 .pseudo-icon::before {
-  content: '';
+  content: "";
   display: block;
   width: 32px;
   height: 32px;
@@ -256,7 +253,7 @@ p {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23000000' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 }
 
-html[data-theme='dark'] .github-icon::before {
+html[data-theme="dark"] .github-icon::before {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' aria-hidden='true' focusable='false' fill='%23b4b4b4' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 }
 
@@ -266,7 +263,7 @@ html[data-theme='dark'] .github-icon::before {
 }
 
 .navbar-sidebar .pseudo-icon::after {
-  content: 'GitHub';
+  content: "GitHub";
   margin-left: 12px;
 }
 
@@ -275,7 +272,7 @@ html[data-theme='dark'] .github-icon::before {
 }
 
 .navbar-sidebar .github-icon::after {
-  content: 'GitHub';
+  content: "GitHub";
 }
 
 .dev-portal-link {
@@ -320,7 +317,7 @@ html[data-theme='dark'] .github-icon::before {
 /* VIDEO */
 .player-wrapper {
   position: relative;
-  padding-top: 56.25% /* Player ratio: 100 / (1280 / 720) */
+  padding-top: 56.25%; /* Player ratio: 100 / (1280 / 720) */
 }
 
 .react-player {
@@ -389,7 +386,7 @@ html[data-theme='dark'] .github-icon::before {
   display: flex;
   flex-direction: column;
   gap: 1em;
-  transition: border-color .2s;
+  transition: border-color 0.2s;
 }
 
 a:hover .ngrok--card {
@@ -405,7 +402,7 @@ a .ngrok--card svg {
 }
 
 [data-theme="dark"] a .ngrok--card svg {
-  fill: #FFFFFF !important;
+  fill: #ffffff !important;
 }
 
 .ngrok--card-lg {
@@ -466,4 +463,25 @@ a .ngrok--card svg {
   .ngrok--cards-row {
     flex-direction: column;
   }
+}
+
+/**
+ * KETCH CSS overrides 
+ * operation: make the banner smaller
+*/
+#lanyard_root [class^="content"] {
+  padding-block: 12px;
+  line-height: 14px;
+}
+
+#lanyard_root [class^="titleWrapper"] {
+  margin-bottom: 8px;
+}
+
+#lanyard_root #banner-description {
+  min-height: min-content;
+}
+
+#lanyard_root #banner-description + div {
+  display: none;
 }

--- a/static/scripts/ketch.js
+++ b/static/scripts/ketch.js
@@ -1,0 +1,19 @@
+!(function () {
+  var e = document.head.querySelector('meta[name="ketch-tag-id"]'),
+    t = "ngrok_ketch_tag_local";
+  e && "content" in e && (t = e.content),
+    (window.semaphore = window.semaphore || []),
+    (window.ketch = function () {
+      window.semaphore.push(arguments);
+    });
+  var n = new URLSearchParams(document.location.search),
+    o = n.has("property") ? n.get("property") : t,
+    a = document.createElement("script");
+  (a.type = "text/javascript"),
+    (a.src = "https://global.ketchcdn.com/web/v2/config/ngrok/".concat(
+      o,
+      "/boot.js"
+    )),
+    (a.defer = a.async = !0),
+    document.getElementsByTagName("head")[0].appendChild(a);
+})();


### PR DESCRIPTION
- adds `<meta name="ketch-tag-id">` tag to head
  - flexes content based on `NODE_ENV`
- adds init script to `<head>`
  - reads which tag we should use based on `<meta name="ketch-tag-id">` ☝️ 
- adds footer link to ngrok.com/privacy-preferences which allows users to configure their cookie consent preferences via ketch
- docusaurus.config.js was formatted by prettier (we should probably add that as a dep and CI step to this repo 😉 )
- adds global css to minimize the size of the ketch banner