### PR TITLE
ketch: reduce block padding on action buttons in the consent banner

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -470,7 +470,8 @@ a .ngrok--card svg {
  * operation: make the banner smaller
 */
 #lanyard_root [class^="content"] {
-  padding-block: 12px;
+  padding-top: 12px;
+  padding-bottom: 12px;
   line-height: 14px;
 }
 
@@ -480,6 +481,11 @@ a .ngrok--card svg {
 
 #lanyard_root #banner-description {
   min-height: min-content;
+}
+
+#lanyard_root [class^="buttons"] button {
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 #lanyard_root #banner-description + div {


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/34115417/231517108-b6d69c59-9b34-47c3-a60f-a66eb0c61e28.png)

### After

![image](https://user-images.githubusercontent.com/34115417/231516758-009c974e-6111-44f4-b00c-ce5166cc0fc8.png)

![image](https://user-images.githubusercontent.com/34115417/231517023-e3313e4a-1a37-4fd3-a841-14792b6df209.png)
