### PR TITLE
events: add account_id and principal information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn.lock*
 package-lock.json
 
 *.zip
+
+# ide specific
+.idea

--- a/docs/events/event-sources.mdx
+++ b/docs/events/event-sources.mdx
@@ -29,12 +29,12 @@ Events are sent as JSON to the configured destinations. These event payloads are
 
 The principal object in every event contains details about the principal or actor who actioned an event. Typically populated on configuration events.
 
-| Name       | Description                                                                                                | Example                                                                                                               |
-|------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| id         | unique identifier for the principal, either a user or bot                                                  | `usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H`                                                                                     |
-| subject    | human readable unique identifier for the principal, either a user email or a bot name                      | `foo@example.com`                                                                                                     |
-| source     | mode of ingress into ngrok, typically Dashboard or API                                                     | `API`                                                                                                                 |
-| credential | id and uri resource for the credential used for authentication, only defined for programmatic access (API) | ```{"id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub","uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"}``` |
+| Name       | Description                                                                                                         | Example                                                                                                               |
+|------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| id         | unique identifier for the principal, either a user or bot                                                           | `usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H`                                                                                     |
+| subject    | human readable unique identifier for the principal, either a user email or a bot name                               | `foo@example.com`                                                                                                     |
+| source     | mode of ingress into ngrok, typically Dashboard or API                                                              | `API`                                                                                                                 |
+| credential | id and uri resource for the credential used for authentication, only defined for programmatic access (API, Tunnels) | ```{"id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub","uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"}``` |
 
 ### Event Payloads Examples
 

--- a/docs/events/event-sources.mdx
+++ b/docs/events/event-sources.mdx
@@ -15,12 +15,26 @@ Some event types support filters and selectable fields. Not all selectable field
 
 Events are sent as JSON to the configured destinations. These event payloads are purposefully identical to the ngrok API responses. All events include the following fields:
 
-| Name | Description | Example |
-| --- | --- | --- |
-| `event_id` | unique identifier for this event, always prefixed with ev_ | `ev_1vPlyBW3OR44bpPphS4HIZyajDD` |
-| `event_type` | identifies the object, action, and version of the event | `ip_policy_created.v0` |
-| `event_timestamp` | timestamp of when the event fired in RFC 3339 format | `2021-07-16T21:44:37Z` |
-| `object` | a JSON object describing the resource where the event occurred | See examples below |
+| Name              | Description                                                                  | Example                          |
+|-------------------|------------------------------------------------------------------------------|----------------------------------|
+| `account_id`      | unique identifier for the account, always prefixed with ac_                  | `ac_2OtNvAlhso10Gx6s7eupzX3F98q` |
+| `event_id`        | unique identifier for this event, always prefixed with ev_                   | `ev_1vPlyBW3OR44bpPphS4HIZyajDD` |
+| `event_type`      | identifies the object, action, and version of the event                      | `ip_policy_created.v0`           |
+| `event_timestamp` | timestamp of when the event fired in RFC 3339 format                         | `2021-07-16T21:44:37Z`           |
+| `object`          | a JSON object describing the resource where the event occurred               | See examples below               |
+| `principal`       | a JSON object containing details about the principal who actioned this event | See example below                |
+
+
+#### Principal Object
+
+The principal object in every event contains details about the principal or actor who actioned an event. Typically populated on configuration events.
+
+| Name       | Description                                                                                                | Example                                                                                                               |
+|------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| id         | unique identifier for the principal, either a user or bot                                                  | `usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H`                                                                                     |
+| subject    | human readable unique identifier for the principal, either a user email or a bot name                      | `API`                                                                                                                 |
+| source     | mode of ingress into ngrok, typically Dashboard or API                                                     | `foo@example.com`                                                                                                     |
+| credential | id and uri resource for the credential used for authentication, only defined for programmatic access (API) | ```{"id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub","uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"}``` |
 
 ### Event Payloads Examples
 
@@ -30,6 +44,16 @@ Events are sent as JSON to the configured destinations. These event payloads are
         "event_id": "ev_25X2AsJ5xpvuOParTYUQWe12XKo",
         "event_type": "ip_policy_created.v0",
         "event_timestamp": "2022-02-23T23:29:29Z",
+        "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
+        "principal": {
+            "id": "usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H",
+            "subject": "foo@example.com",
+            "source": "API",
+            "credential": {
+                "id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub",
+                "uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"
+            }
+        },
         "object": {
             "id": "ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
             "uri": "https://api.ngrok.com/ip_policies/ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
@@ -46,6 +70,7 @@ Events are sent as JSON to the configured destinations. These event payloads are
         "event_id": "ev_25X3yFS6TDkig1KDJWIc4nnJO0c",
         "event_type": "http_request_complete.v0",
         "event_timestamp": "2022-02-23T23:44:16Z",
+        "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
         "object": {
             "conn": {
                 "client_ip": "2601:0:8200:9e:4cd7:0:c97f:7823",
@@ -78,6 +103,7 @@ Events are sent as JSON to the configured destinations. These event payloads are
         "event_id": "ev_25X4osod1q306srserDeFyghTC4",
         "event_type": "tcp_connection_closed.v0",
         "event_timestamp": "2022-02-23T23:51:14Z",
+        "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
         "object": {
             "conn": {
                 "bytes_in": 3437,

--- a/docs/events/event-sources.mdx
+++ b/docs/events/event-sources.mdx
@@ -32,8 +32,8 @@ The principal object in every event contains details about the principal or acto
 | Name       | Description                                                                                                | Example                                                                                                               |
 |------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | id         | unique identifier for the principal, either a user or bot                                                  | `usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H`                                                                                     |
-| subject    | human readable unique identifier for the principal, either a user email or a bot name                      | `API`                                                                                                                 |
-| source     | mode of ingress into ngrok, typically Dashboard or API                                                     | `foo@example.com`                                                                                                     |
+| subject    | human readable unique identifier for the principal, either a user email or a bot name                      | `foo@example.com`                                                                                                     |
+| source     | mode of ingress into ngrok, typically Dashboard or API                                                     | `API`                                                                                                                 |
 | credential | id and uri resource for the credential used for authentication, only defined for programmatic access (API) | ```{"id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub","uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"}``` |
 
 ### Event Payloads Examples


### PR DESCRIPTION
Adding new documented fields for account_id and principal in event envelopes.

Screenshots:

![2023-04-26_11-05](https://user-images.githubusercontent.com/5667236/234620380-329caaa4-8170-4844-b34e-fd8f87c7ffb1.png)
![2023-04-26_11-08](https://user-images.githubusercontent.com/5667236/234620379-ea101495-0f3c-498b-a261-6eb6729aa246.png)
![2023-04-26_11-08_1](https://user-images.githubusercontent.com/5667236/234620374-fe88909a-31ff-42fc-b04e-25eea86f0482.png)
