### PR TITLE
ngrok-rust, ngrok-nodejs and ngrok-python naming

### DIFF
--- a/docs/using-ngrok-with.md
+++ b/docs/using-ngrok-with.md
@@ -27,7 +27,7 @@ Here you will find notes on using ngrok with particular technologies. Think we'r
 | [Puppet](/using-ngrok-with/puppet) | Manage the ngrok Agent using Puppet |
 | [Python](/using-ngrok-with/python) | Learn how to integrate with your Python application |
 | [RDP](/using-ngrok-with/rdp) | Use ngrok with Windows Remote Desktop Protocol (RDP) |
-| [Rust](/using-ngrok-with/rust) | Run ngrok programmatically with the ngrok-rs crate |
+| [Rust](/using-ngrok-with/rust) | Run ngrok programmatically with the ngrok-rust crate |
 | [SMTP](/using-ngrok-with/smtp) | Use ngrok with SMTP mail servers |
 | [SSH](/using-ngrok-with/ssh) | Learn how to SSH to a machine from anywhere in the world |
 | [Virtual hosts (MAMP, WAMP, etc.)](/using-ngrok-with/virtualHosts) | Rewrite the host header for forwarding to virtual hosts |

--- a/docs/using-ngrok-with/django.md
+++ b/docs/using-ngrok-with/django.md
@@ -14,8 +14,8 @@ This article assumes you have Python, PIP, and Django already installed.
 If you're looking to natively embed the ngrok agent into your Django application, you can leverage the [pyngrok project](https://pyngrok.readthedocs.io/en/latest/integrations.html#django) to start a tunnel anytime you start the Django Dev Server.
 
 ### Python SDK (beta)
-You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-py) to start a tunnel to the Django server via a [ngrok ASGI runner](https://github.com/ngrok/ngrok-py#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) or embedding in [manage.py or asgi.py](https://github.com/ngrok/ngrok-py#frameworks).
+You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Django server via a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) or embedding in [manage.py or asgi.py](https://github.com/ngrok/ngrok-python#frameworks).
 
 *   [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
-*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-py)
-*   [Reference Documentation](https://ngrok.github.io/ngrok-py/)
+*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)
+*   [Reference Documentation](https://ngrok.github.io/ngrok-python/)

--- a/docs/using-ngrok-with/flask.md
+++ b/docs/using-ngrok-with/flask.md
@@ -18,8 +18,8 @@ Note: For users on the latest MacOS, there is an issue where the default port of
 If you're looking to natively embed the ngrok agent into your Flask development flow, you can leverage the [pyngrok project](https://pyngrok.readthedocs.io/en/latest/integrations.html#flask) so that a tunnel is created each time you type `flask run`.
 
 ### Python SDK (beta)
-You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-py) to start a tunnel to the Flask dev server via [python code](https://github.com/ngrok/ngrok-py#frameworks), or using a [ngrok ASGI runner](https://github.com/ngrok/ngrok-py#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) with an [ASGI Wrapper](https://flask.palletsprojects.com/en/2.3.x/deploying/asgi/).
+You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Flask dev server via [python code](https://github.com/ngrok/ngrok-python#frameworks), or using a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) with an [ASGI Wrapper](https://flask.palletsprojects.com/en/2.3.x/deploying/asgi/).
 
 *   [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
-*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-py)
-*   [Reference Documentation](https://ngrok.github.io/ngrok-py/)
+*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)
+*   [Reference Documentation](https://ngrok.github.io/ngrok-python/)

--- a/docs/using-ngrok-with/node-js.md
+++ b/docs/using-ngrok-with/node-js.md
@@ -19,8 +19,8 @@ If you need to manage the ngrok agent for starting tunnels, use bubenshchykov's 
 If you'd like to programmatically access the ngrok API for configuring ngrok Edges and modules, use our [ngrok Javascript/Typescript Client](https://github.com/ngrok/ngrok-api-typescript).
 
 ### NodeJS SDK (beta)
-Embed ngrok secure ingress into your Node.js apps with a single line of code with our beta [ngrok NodeJS SDK](https://github.com/ngrok/ngrok-js).
+Embed ngrok secure ingress into your Node.js apps with a single line of code with our beta [ngrok NodeJS SDK](https://github.com/ngrok/ngrok-nodejs).
 
 *   [@ngrok/ngrok module on npm](https://www.npmjs.com/package/@ngrok/ngrok)
-*   [@ngrok/ngrok npm module on Github](https://github.com/ngrok/ngrok-js)
-*   [Reference Documentation](https://ngrok.github.io/ngrok-js/)
+*   [@ngrok/ngrok npm module on Github](https://github.com/ngrok/ngrok-nodejs)
+*   [Reference Documentation](https://ngrok.github.io/ngrok-nodejs/)

--- a/docs/using-ngrok-with/python.md
+++ b/docs/using-ngrok-with/python.md
@@ -16,8 +16,8 @@ If you'd like to programmatically manage your ngrok account and resources (regis
 If you're looking to programmatically start tunnels with the ngrok agent, check out Alex's [pyngrok](https://github.com/alexdlaird/pyngrok) library.
 
 ### Python SDK (beta)
-Embed ngrok secure ingress into your Python apps with a single line of code with our beta [ngrok Python SDK](https://github.com/ngrok/ngrok-py).
+Embed ngrok secure ingress into your Python apps with a single line of code with our beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python).
 
 *   [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
-*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-py)
-*   [Reference Documentation](https://ngrok.github.io/ngrok-py/)
+*   [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)
+*   [Reference Documentation](https://ngrok.github.io/ngrok-python/)

--- a/docs/using-ngrok-with/rust.md
+++ b/docs/using-ngrok-with/rust.md
@@ -2,22 +2,22 @@
 title: Rust
 ---
 
-# Using ngrok with the ngrok-rs crate
+# Using ngrok with the ngrok-rust crate
 ------------
 
 ## Introduction
 
-ngrok-rs is an idiomatic Rust crate for embedding secure ingress directly into your Rust applications. If you’ve used the ngrok agent before, you can think of ngrok-rs as the agent packaged as a Rust crate. [ngrok-rs is open source](http://github.com/ngrok/ngrok-rs) with [API reference available on docs.rs](https://docs.rs/ngrok).
+ngrok-rust is an idiomatic Rust crate for embedding secure ingress directly into your Rust applications. If you’ve used the ngrok agent before, you can think of ngrok-rust as the agent packaged as a Rust crate. [ngrok-rust is open source](http://github.com/ngrok/ngrok-rust) with [API reference available on docs.rs](https://docs.rs/ngrok).
 
-ngrok-rs lets developers serve Rust services on the internet in a single line of code without setting up low-level network primitives like IPs, certificates, load balancers, and even ports. Applications using ngrok-rs listen on ngrok’s global ingress network using an incoming stream with tokio’s `AsyncRead` and `AsyncWrite` traits — compatible with `axium::Server::builder()` and `hyper::Server::builder()`. This makes it easy to add ngrok-rs into any application that uses axium or hyper — the most beloved Web Framework and HTTP implementations in Rust. 
+ngrok-rust lets developers serve Rust services on the internet in a single line of code without setting up low-level network primitives like IPs, certificates, load balancers, and even ports. Applications using ngrok-rust listen on ngrok’s global ingress network using an incoming stream with tokio’s `AsyncRead` and `AsyncWrite` traits — compatible with `axium::Server::builder()` and `hyper::Server::builder()`. This makes it easy to add ngrok-rust into any application that uses axium or hyper — the most beloved Web Framework and HTTP implementations in Rust. 
 
 In this tutorial, you will build a Rust app with ingress access and security provided by ngrok.
 
 **Note**: This tutorial assumes you have Rust already installed.
 
-## Get started with ngrok-rs
+## Get started with ngrok-rust
 
-Getting started with ngrok and the ngrok-rs crate is simple: 
+Getting started with ngrok and the ngrok-rust crate is simple: 
 
 1. To start, [sign up for ngrok](https://ngrok.com/signup).
 1. In the [ngrok Dashboard](https://dashboard.ngrok.com), copy your Authtoken.
@@ -47,7 +47,7 @@ Getting started with ngrok and the ngrok-rs crate is simple:
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn Error>> {
         // build our application with a route
-        let app = Router::new().route("/", get(|| async { "Hello from ngrok-rs!" }));
+        let app = Router::new().route("/", get(|| async { "Hello from ngrok-rust!" }));
 
         // listen on localhost:8000
         // axum::Server::bind(&"0.0.0.0:8000".parse().unwrap())
@@ -86,12 +86,12 @@ Getting started with ngrok and the ngrok-rs crate is simple:
 
 1. The terminal will display an ngrok URL. 
     
-    Access it to confirm you see the message `Hello from ngrok-rs`.
+    Access it to confirm you see the message `Hello from ngrok-rust`.
     Your Rust application is now live on the internet, with a public url that anyone in the world can access.
 
 ## Add edge functionality to your app
 
-The ngrok-rs library provides functions and configuration for all features available in ngrok. Everything you can do with the ngrok agent is available using our library. In this example, you can modify main.rs to:
+The ngrok-rust library provides functions and configuration for all features available in ngrok. Everything you can do with the ngrok agent is available using our library. In this example, you can modify main.rs to:
 
 - **Line 21**: Use my-rust-app.ngrok.dev as a custom subdomain
 - **Line 22**: Apply a circuit breaker if the Rust app returns errors over 50% of the time


### PR DESCRIPTION
It was decided to rename these repos, reflecting the change in the docs.