### PR TITLE
refactor mTLS documentation

### DIFF
--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -182,7 +182,7 @@ string string "bad certificate".
 
 This example assumes you have an x509 private key and certificate encoded as
 PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
-certificate must be signed by one of the CA certificates you provied to the
+certificate must be signed by one of the CA certificates you provided to the
 Mutual TLS module.
 
 Run `curl` with the following command:

--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -101,7 +101,7 @@ tracking its implementation.
 ### Edges
 
 Mutual TLS is a supported Edge module. When the Mutual TLS module is configured
-via an Edge, you will specify one or more references to Certificate Authority
+via an Edge, you must specify one or more references to Certificate Authority
 objects.
 
 The Mutual TLS Edge module is applied to the edge directly and not to any

--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -1,6 +1,204 @@
 # Mutual TLS
 ----------------
 
-Also known as "TLS client authentication", connections must complete a mutual TLS handshake in which the client presents a valid certificate signed by any of the root certificate authorities that you upload.
+## Overview
 
-Note: Mutual TLS applies to all routes in an HTTPS edge.
+This module performs mutual TLS (mTLS) authentication when the ngrok edge terminates
+TLS on incoming connections to your HTTP endpoint. The client must present a
+valid TLS certificate that is signed by one of the specified CAs or the
+connection will be rejected.
+
+ngrok injects [headers](#upstream-headers) into upstream HTTP requests with
+information about the client certificate presented.
+
+Mutual TLS is supported on both HTTP and TLS endpoints.
+
+## Quickstart
+
+### Agent CLI
+
+```
+ngrok http --mutual-tls-cas /path/to/cas.pem 80
+```
+
+### Agent Configuration File
+
+```
+tunnels:
+  example:
+    proto: http
+    addr: 80
+    mutual_tls_cas: /path/to/cas.pem
+```
+
+### Go SDK
+
+```
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
+)
+
+func listenMutualTLS(ctx context.Context) net.Listener {
+	caBytes, _ := os.ReadFile("/path/to/cas.pem")
+	der, _ := pem.Decode(caBytes)
+	certs, _ := x509.ParseCertificates(der.Bytes)
+
+	listener, _ := ngrok.Listen(ctx,
+		config.HTTPEndpoint(
+			config.WithMutualTLSCA(certs...),
+		),
+		ngrok.WithAuthtokenFromEnv(),
+	)
+
+	return listener
+}
+```
+
+### Rust SDK
+
+```
+use ngrok::prelude::*;
+
+async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
+    let ca_cert: &[u8] = load_bytes!("/path/to/cas.pem");
+
+    let sess = ngrok::Session::builder()
+        .authtoken_from_env()
+        .connect()
+        .await?;
+
+    let tun = sess
+        .http_endpoint()
+        .mutual_tlsca(ca_cert.into())
+        .listen()
+        .await?;
+
+    println!("Listening on URL: {:?}", tun.url());
+
+    Ok(tun)
+}
+```
+
+### Kubernetes Ingress Controller
+
+:::note
+
+Mutual TLS is not yet supported with the Kubernetes Ingress Controller.
+
+:::
+
+You can [+1 the GitHub
+issue](https://github.com/ngrok/kubernetes-ingress-controller/issues/133)
+tracking its implementation.
+
+### Edges
+
+Mutual TLS is a supported Edge module. When the Mutual TLS module is configured
+via an Edge, you will specify one or more references to Certificate Authority
+objects.
+
+The Mutual TLS Edge module is applied to the edge directly and not to any
+individual route. This is because Mutual TLS is enforced before any HTTP
+processing can begin.
+
+- [Mutual TLS Edge Module API Resource](/api/resources/https-edge-mutual-tls-module/)
+- [Certificate Authority API Resource](/api/resources/certificate-authorities/)
+
+## Behavior
+
+### Upstream Headers {#upstream-headers}
+
+When the Mutual TLS module is enabled, ngrok will insert headers into the HTTP
+request sent to your upstream server with details about the client certificate
+that was presented for the Mutual TLS handshake.
+
+| Header Name | Value |
+| ----------- | ----- |
+| `ngrok-mtls-subject-cn` | The client certificate subject common name |
+| `ngrok-mtls-subject-alt-name-dns` | The client certificate's DNS subject alternative names |
+| `ngrok-mtls-email-addresses` | The client certificate's email subject alternative names  |
+| `ngrok-mtls-serial-number` | The client certificate's serial number |
+
+### Events
+
+When the mutual TLS module is enabled, it populates the following fields in
+[http\_request\_complete.v0](/events/reference/#http-request-complete) events.
+
+| Fields |
+| ------ |
+| `tls.client_cert.serial_number` |
+| `tls.client_cert.subject.cn` |
+
+No event data is captured when the module is enabled on TLS endpoints.
+
+### Multiple CAs
+
+You may specify multiple CAs to be used for mTLS authentication. A
+connection is considered authenticated if it presents a certificate signed by
+any of the specified CAs. Most agents allow you to specify multiple CAs by
+simply specifying a PEM file that contains multiple x509 CA certificates
+concatenated together. A file like that might look like:
+
+```
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+```
+
+### CA Basic Constraint
+
+x509 certificates contain a basic constraint attribute  called `cA` which
+defines whether or not the certificate may be used as a CA.
+
+ngrok will refuse to accept a certificate as an mTLS certificate authority
+unless this constraint is set to true.
+
+See [RFC 5280 4.2.1.9](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9).
+
+### Errors
+
+If the client does not present any certificate or it does not present a valid
+certificate signed by the CA, the TLS handshake will be aborted. Because the
+connection is aborted during the TLS handshake, the client will not receive an
+HTTP error response or an ngrok error code.
+
+Instead, the TLS connection aborts with a TLS error as defined by [RFC
+5246](https://datatracker.ietf.org/doc/html/rfc5246#section-7.2). The most
+common alert code returned for a failed mutual TLS handshake is code 42
+(`bad_certificate`) which most TLS implementations will report with the error
+string string "bad certificate".
+
+## Try it out
+
+This example assumes you have an x509 private key and certificate encoded as
+PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
+certificate must be signed by one of the CA certificates you provied to the
+Mutual TLS module.
+
+Run `curl` with the following command:
+
+```
+curl --client client-cert.pem --key client-key.pem https://yourapp.ngrok.app
+```
+
+`curl` has a shortcut to pass a single file if the private key and certificate
+are concatenated together.
+
+```
+cat client-cert.pem client-key.pem > client-cert-and-key.pem
+curl --cert client-cert-and-key.pem https://yourapp.ngrok.app
+```
+
+## Licensing
+
+Mutual TLS is available on the Enterprise plan only.


### PR DESCRIPTION
This commit refactors the mTLS documentation to improve it with:

- Example usage in each of the SDKs, the Agent CLI, config file, Kubernetes Ingress controller and Edges.
- Upstream header behavior
- Validation of certificate basic constraints
- Usage and behavior with multiple CAs
- Error condition behaviors
- Which plans it is available on
- A simple example of how to try it out with curl
- The fields that are populated in the http_request_complete.v0 event when mTLS is enabled