### PR TITLE
refactor compression module docs.

### DIFF
--- a/docs/cloud-edge/modules/compression.md
+++ b/docs/cloud-edge/modules/compression.md
@@ -1,4 +1,261 @@
 # Compression
 ----------------
 
-If an HTTP request includes an `Accept-Encoding` header, HTTP responses will be automatically compressed and a `Content-Encoding` response header will be added. If the response was already compressed by the upstream server, ngrok takes no action. `gzip` and `deflate` encodings are supported.
+## Overview
+
+This module improves the performance of your web applications by compressing
+HTTP response bodies returned by your upstream application.
+
+If an HTTP request includes an `Accept-Encoding` header, HTTP responses will be
+automatically compressed and a `Content-Encoding` response header will be
+added. If the response was already compressed by your upstream application,
+ngrok takes no action.
+
+## Quickstart
+
+### Agent CLI
+
+```
+ngrok http --compression 80
+```
+
+### Agent Configuration File
+
+```
+tunnels:
+  example:
+    proto: http
+    addr: 80
+    compression: true
+```
+
+### Go SDK
+
+```
+import (
+	"context"
+	"net"
+
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
+)
+
+func listenCompressed(ctx context.Context) net.Listener {
+	listener, _ := ngrok.Listen(ctx,
+		config.HTTPEndpoint(
+			config.WithCompression(),
+		),
+		ngrok.WithAuthtokenFromEnv(),
+	)
+
+	return listener
+}
+```
+
+### Rust SDK
+
+```
+use ngrok::prelude::*;
+
+async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
+    let sess = ngrok::Session::builder()
+        .authtoken_from_env()
+        .connect()
+        .await?;
+
+    let tun = sess
+        .http_endpoint()
+        .compression()
+        .listen()
+        .await?;
+
+    println!("Listening on URL: {:?}", tun.url());
+
+    Ok(tun)
+}
+```
+
+### Kubernetes Ingress Controller
+
+```yaml
+kind: NgrokModuleSet
+apiVersion: ingress.k8s.ngrok.com/v1alpha1
+metadata:
+  name: ngrok-module-set
+modules:
+  compression:
+    enabled: true
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    k8s.ngrok.com/modules: ngrok-module-set
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: your-domain.ngrok.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: example-service
+                port:
+                  number: 80
+```
+
+### Edges
+
+Compression is a supported Edge module. Unlike most edge modules, Compression
+has no configuration parameters. It is either enabled or disabled.
+
+- [Compression Edge Module API Resource](/api/resources/https-edge-route-compression-module/)
+
+## Try it out
+
+For testing purposes, create a directory with a file in it and then enter that
+directory.
+
+```
+mkdir test-dir
+cd test-dir
+echo "hello world" > t.txt
+```
+
+ngrok can serve files from any directory (just like Python's Simple HTTP
+Server) by forwarding to a `file://` URL. We're going to use that capability
+for our compression testing.
+
+First let's see what this looks like without using compression by running the
+following in your `test-dir` directory:
+
+```
+ngrok http file://`pwd` --domain your-domain.ngrok.app
+```
+
+Then in another terminal while ngrok is still running:
+
+```
+curl --compressed -D - https://your-domain.ngrok.app/
+```
+
+- `--compressed` instructs curl to set the `Accept-Encoding` header to request
+  compressed content
+- `-D -` instructs curl to show the HTTP response headers
+
+You should get a response that looks like:
+
+```
+HTTP/2 200
+content-type: text/html; charset=utf-8
+date: Tue, 18 Jul 2023 09:52:49 GMT
+last-modified: Tue, 18 Jul 2023 09:52:34 GMT
+ngrok-agent-ips: 71.227.75.230
+ngrok-trace-id: 24e925dd0f348c1040d7ff62b06606cd
+content-length: 39
+
+<pre>
+<a href="t.txt">t.txt</a>
+</pre>
+```
+
+Now let's try it again with compression. Stop your ngrok agent and restart it
+by changing the command to:
+
+```
+ngrok http file://`pwd` --domain your-domain.ngrok.app --compression
+```
+
+Rerun the same curl command:
+
+```
+curl --compressed -D - https://your-domain.ngrok.app/
+```
+
+This time you should see that HTTP response headers include `content-encoding:
+deflate` indicating that the response was compressed.
+
+```
+HTTP/2 200
+content-encoding: deflate
+content-type: text/html; charset=utf-8
+date: Tue, 18 Jul 2023 10:03:22 GMT
+last-modified: Tue, 18 Jul 2023 09:52:34 GMT
+ngrok-agent-ips: 71.227.75.230
+ngrok-trace-id: b6b6cdce029e94123188ce53c0febee4
+vary: Accept-Encoding
+
+<pre>
+<a href="t.txt">t.txt</a>
+</pre>
+```
+
+## Behavior
+
+### Streaming Compression
+
+When ngrok performs compression, the response body is not buffered; the
+response body is compressed as it is streamed through the ngrok edge. 
+
+### Algorithm Choice
+
+If a request specifies `Accept-Encoding` but no requested values are supported,
+ngrok takes no action and the upstream response is returned without
+modification.
+
+ngrok negotiates the encoding type as defined by the RFC for `Accept-Encoding`.
+It respects q-values and chooses the `Accept-Encoding` supported algorithm with
+the highest q-value.
+
+ngrok supports the following compression algorithms in the `Accept-Encoding`
+header.
+
+| Algorithm | Supported |
+| ------ | ----- |
+| `br` | no |
+| `compress` | no |
+| `deflate` | yes |
+| `gzip` | yes |
+
+### Response Headers
+
+When ngrok performs compression, the following changes are made to
+the HTTP response header:
+
+- The `Content-Length` header is removed
+- A `Content-Encoding` header is added with the negotiated algorithm
+- A `Vary: Accept-Encoding` header is added
+
+### Compression Level
+
+The compression level is a value which indicates whether the compression
+algorithm should prefer to save more space at the expense of being slower and
+using more compute.  This value is not currently configurable. ngrok
+automatically chooses a value that provides a reasonable tradeoff.
+
+## Reference
+
+### Upstream Headers {#upstream-headers}
+
+No additional upstream headers are added by the Compression module.
+
+### Events
+
+When the compression module is enabled, it populates the following fields in
+[http\_request\_complete.v0](/events/reference/#http-request-complete) events.
+
+| Fields |
+| ------ |
+| `compression.algorithm` |
+| `compression.bytes_saved` |
+
+### Errors
+
+The compression module does not return any errors.
+
+### Licensing
+
+The compression module is available on the Free tier.

--- a/docs/cloud-edge/modules/ip-restrictions.md
+++ b/docs/cloud-edge/modules/ip-restrictions.md
@@ -98,7 +98,7 @@ spec:
 kind: NgrokModuleSet
 apiVersion: ingress.k8s.ngrok.com/v1alpha1
 metadata:
-  name: ip-restrictions
+  name: ngrok-module-set
 modules:
   ipRestriction:
     policies:
@@ -143,58 +143,6 @@ be configured via the ngrok dashboard or API.
 - [IP Policy API Resource](/api/resources/ip-policies/)
 - [IP Policy Rule API Resource](/api/resources/ip-policy-rules/)
 
-## Behavior
-
-### Upstream Headers {#upstream-headers}
-
-No additional upstream headers are injected when IP Restrictions are enforced.
-
-### Events
-
-When the IP Restrictions module is enforced, it populates the following fields
-in both the
-[http\_request\_complete.v0](/events/reference/#http-request-complete) and the
-[tcp\_connection\_closed.v0](/events/reference/#tcp-connection-closed) events.
-
-| Fields |
-| ------ |
-| `ip_policy.decision` |
-
-### Rule Evaluation
-
-A connection is allowed only if its source IP matches at least one rule with an
-'allow' action and does not match any rule with a 'deny' action.
-
-When using Edges and the Kubernetes Ingress Controller, if the IP Restrictions
-module references multiple IP Policies, then the rules of all referenced IP
-Policies are unioned together for evaluation.
-
-### IPv6
-
-ngrok supports IPv6 addresses for all IP rules. You may use standard abbreviated
-notations.
-
-```
-ngrok http --allow-cidr "::/0" --deny-cidr "2600:1f16:d83:1202::6e:2/128" 80
-```
-
-Don't forget to create IPv6 rules. It's easy to test only with IPv4 and then
-suddenly things don't work when your software starts using IPv6 because you've
-forgotten to create rules to allow traffic from your IPv6 addresses.
-
-### Source IP
-
-The IP Restrictions module always evaluates the true source IP of a connection.
-IPs in HTTP headers like `forwarded-for` are never evaluated by this module.
-
-### Errors
-
-For TCP and TLS endpoints, if a connection is disallowed by IP Restrictions
-then the connection will simply be closed.
-
-For HTTP endpoints, an HTTP response will return
-[ERR\_NGROK\_3205](/errors/err_ngrok_3205/) with a 403 Forbidden status.
-
 ## Try it out
 
 First, grab your IPv4 and IPv6 addresses:
@@ -220,6 +168,60 @@ curl -4 https://your-domain.ngrok.app
 curl -6 https://your-domain.ngrok.app
 ```
 
-## Licensing
+## Behavior
+
+### Rule Evaluation
+
+A connection is allowed only if its source IP matches at least one rule with an
+'allow' action and does not match any rule with a 'deny' action.
+
+When using Edges and the Kubernetes Ingress Controller, if the IP Restrictions
+module references multiple IP Policies, then the rules of all referenced IP
+Policies are unioned together for evaluation.
+
+### IPv6
+
+ngrok supports IPv6 addresses for all IP rules. You may use standard abbreviated
+notations.
+
+```
+ngrok http --allow-cidr "::/0" --deny-cidr "2600:1f16:d83:1202::6e:2/128" 80
+```
+
+Don't forget to create IPv6 rules. It's easy to test only with IPv4 and then
+suddenly things don't work when your software starts using IPv6 because you've
+forgotten to create rules to allow traffic from IPv6 addresses.
+
+### Source IP
+
+The IP Restrictions module evaluates the layer 4 source IP of a connection.
+HTTP headers like `forwarded-for` are never consulted by this module.
+
+## Reference
+
+### Upstream Headers {#upstream-headers}
+
+No additional upstream headers are added by the Compression module.
+
+### Events
+
+When the IP Restrictions module is enforced, it populates the following fields
+in both the
+[http\_request\_complete.v0](/events/reference/#http-request-complete) and the
+[tcp\_connection\_closed.v0](/events/reference/#tcp-connection-closed) events.
+
+| Fields |
+| ------ |
+| `ip_policy.decision` |
+
+### Errors
+
+For TCP and TLS endpoints, if a connection is disallowed by IP Restrictions
+then the connection will simply be closed.
+
+For HTTP endpoints, an HTTP response will return
+[ERR\_NGROK\_3205](/errors/err_ngrok_3205/) with a 403 Forbidden status.
+
+### Licensing
 
 IP Restrictions is available on the Pro or Enterprise plans.

--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -111,32 +111,28 @@ processing can begin.
 - [Mutual TLS Edge Module API Resource](/api/resources/https-edge-mutual-tls-module/)
 - [Certificate Authority API Resource](/api/resources/certificate-authorities/)
 
+## Try it out
+
+This example assumes you have an x509 private key and certificate encoded as
+PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
+certificate must be signed by one of the CA certificates you provided to the
+Mutual TLS module.
+
+Run `curl` with the following command:
+
+```
+curl --client client-cert.pem --key client-key.pem https://yourapp.ngrok.app
+```
+
+`curl` has a shortcut to pass a single file if the private key and certificate
+are concatenated together.
+
+```
+cat client-cert.pem client-key.pem > client-cert-and-key.pem
+curl --cert client-cert-and-key.pem https://yourapp.ngrok.app
+```
+
 ## Behavior
-
-### Upstream Headers {#upstream-headers}
-
-When the Mutual TLS module is enabled, ngrok will insert headers into the HTTP
-request sent to your upstream server with details about the client certificate
-that was presented for the Mutual TLS handshake.
-
-| Header Name | Value |
-| ----------- | ----- |
-| `ngrok-mtls-subject-cn` | The client certificate subject common name |
-| `ngrok-mtls-subject-alt-name-dns` | The client certificate's DNS subject alternative names |
-| `ngrok-mtls-email-addresses` | The client certificate's email subject alternative names  |
-| `ngrok-mtls-serial-number` | The client certificate's serial number |
-
-### Events
-
-When the mutual TLS module is enabled, it populates the following fields in
-[http\_request\_complete.v0](/events/reference/#http-request-complete) events.
-
-| Fields |
-| ------ |
-| `tls.client_cert.serial_number` |
-| `tls.client_cert.subject.cn` |
-
-No event data is captured when the module is enabled on TLS endpoints.
 
 ### Multiple CAs
 
@@ -165,6 +161,33 @@ unless this constraint is set to true.
 
 See [RFC 5280 4.2.1.9](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9).
 
+## Reference
+
+### Upstream Headers {#upstream-headers}
+
+When the Mutual TLS module is enabled, ngrok will insert headers into the HTTP
+request sent to your upstream server with details about the client certificate
+that was presented for the Mutual TLS handshake.
+
+| Header Name | Value |
+| ----------- | ----- |
+| `ngrok-mtls-subject-cn` | The client certificate subject common name |
+| `ngrok-mtls-subject-alt-name-dns` | The client certificate's DNS subject alternative names |
+| `ngrok-mtls-email-addresses` | The client certificate's email subject alternative names  |
+| `ngrok-mtls-serial-number` | The client certificate's serial number |
+
+### Events
+
+When the mutual TLS module is enabled, it populates the following fields in
+[http\_request\_complete.v0](/events/reference/#http-request-complete) events.
+
+| Fields |
+| ------ |
+| `tls.client_cert.serial_number` |
+| `tls.client_cert.subject.cn` |
+
+No event data is captured when the module is enabled on TLS endpoints.
+
 ### Errors
 
 If the client does not present any certificate or it does not present a valid
@@ -178,27 +201,6 @@ common alert code returned for a failed mutual TLS handshake is code 42
 (`bad_certificate`) which most TLS implementations will report with the error
 string string "bad certificate".
 
-## Try it out
-
-This example assumes you have an x509 private key and certificate encoded as
-PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
-certificate must be signed by one of the CA certificates you provided to the
-Mutual TLS module.
-
-Run `curl` with the following command:
-
-```
-curl --client client-cert.pem --key client-key.pem https://yourapp.ngrok.app
-```
-
-`curl` has a shortcut to pass a single file if the private key and certificate
-are concatenated together.
-
-```
-cat client-cert.pem client-key.pem > client-cert-and-key.pem
-curl --cert client-cert-and-key.pem https://yourapp.ngrok.app
-```
-
-## Licensing
+### Licensing
 
 Mutual TLS is available on the Enterprise plan only.


### PR DESCRIPTION
i made a few other small changes as part of this commit:

- the kubernetes ingress example for ip restrictions was expanded to include the ingress object
- standardized on the organization of the module documentation (a `reference` section which always contains "errors", "upstream headers", "events" and "licensing" and then a `behavior` section which has module-specific topics). shuffling this around makes the diff look messier than it actually is