### PR TITLE
add SSH commands, fix other bugs

### DIFF
--- a/docs/cloud-edge/modules/circuit-breaker.md
+++ b/docs/cloud-edge/modules/circuit-breaker.md
@@ -36,6 +36,12 @@ tunnels:
     circuit_breaker: 0.5
 ```
 
+### SSH
+
+```
+ssh -R 443:localhost:80 connect.ngrok-agent.com http --circuit-breaker 0.5
+```
+
 ### Go SDK
 
 ```

--- a/docs/cloud-edge/modules/compression.md
+++ b/docs/cloud-edge/modules/compression.md
@@ -16,7 +16,7 @@ ngrok takes no action.
 ### Agent CLI
 
 ```
-ngrok http --compression 80
+ngrok http 80 --compression
 ```
 
 ### Agent Configuration File
@@ -27,6 +27,12 @@ tunnels:
     proto: http
     addr: 80
     compression: true
+```
+
+### SSH
+
+```
+ssh -R 443:localhost:80 connect.ngrok-agent.com http --compression
 ```
 
 ### Go SDK

--- a/docs/cloud-edge/modules/ip-restrictions.md
+++ b/docs/cloud-edge/modules/ip-restrictions.md
@@ -19,7 +19,7 @@ The IP Restrictions module is supported on HTTP, TCP and TLS endpoints.
 ### Agent CLI
 
 ```
-ngrok http 80 --allow-cidr 110.0.0.0/8 --allow-cidr 220.12.0.0/16 --deny-cidr 110.2.3.4/32
+ngrok http 80 --cidr-allow 110.0.0.0/8 --cidr-allow 220.12.0.0/16 --cidr-deny 110.2.3.4/32
 ```
 
 ### Agent Configuration File
@@ -31,6 +31,15 @@ tunnels:
     addr: 80
     allow_cidrs: [110.0.0.0/8, 220.12.0.0/16]
     deny_cidrs: [110.2.3.4/32]
+```
+
+### SSH
+
+```
+ssh -R 443:localhost:80 connect.ngrok-agent.com http \
+  --cidr-allow 110.0.0.0/8 \
+  --cidr-allow 220.12.0.0/16 \
+  --cidr-deny 110.2.3.4/32
 ```
 
 ### Go SDK
@@ -201,7 +210,7 @@ HTTP headers like `forwarded-for` are never consulted by this module.
 
 ### Upstream Headers {#upstream-headers}
 
-No additional upstream headers are added by the Compression module.
+No additional upstream headers are added.
 
 ### Events
 

--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -31,6 +31,14 @@ tunnels:
     mutual_tls_cas: /path/to/cas.pem
 ```
 
+### SSH
+
+:::note
+
+Mutual TLS is not supported via SSH.
+
+:::
+
 ### Go SDK
 
 ```

--- a/docs/cloud-edge/modules/webhook-verification.md
+++ b/docs/cloud-edge/modules/webhook-verification.md
@@ -45,6 +45,14 @@ tunnels:
       secret: "twilio-auth-token"
 ```
 
+### SSH
+
+```
+ssh -R 443:localhost:80 connect.ngrok-agent.com http \
+  --verify-webhook slack \
+  --verify-webhook-secret slack_signing_secret
+```
+
 ### Go SDK
 
 ```
@@ -165,19 +173,20 @@ that.
 
 Otherwise, ngrok uses a tolerance of **180 seconds**.
 
-### Preflight Request Verification
+### Endpoint Verification
 
-Some webhook providers require a [one-time
+Some webhook providers require [endpoint
 verification](https://webhooks.fyi/security/one-time-verification-challenge)
 from your application before they will begin sending webhook requests. This
 helps providers prevent their webhook infrastructure from being used for DOS
 attacks.
 
-When you configure verification for the following providers, ngrok will
-automatically handle the pre-flight verification request for your application.
+When you configure webhook verification for the following providers, ngrok will
+automatically handle the endpoint verification request for your application.
 
 - Twitter
 - Wordline
+- Xero
 - Zoom
 
 ## Reference


### PR DESCRIPTION
adds and SSH section to each module's docs page

fixes a couple other bugs including:

- the ip restrictions agent CLI flags were wrong
- the headers section of the ip restrction docs page incorrectly said it was about the compression module
- update compression agent cli docs to put the port first like other module docs do
- consolidate terminology of webhook verification section from 'preflight verification' and 'one-time verification' to 'endpoint verification' which is more accurate