### PR TITLE
chore(config.md): use env=prod instead of region

### DIFF
--- a/docs/secure-tunnels/ngrok-agent/reference/config.md
+++ b/docs/secure-tunnels/ngrok-agent/reference/config.md
@@ -418,7 +418,7 @@ Below is an example configuration file with all the options filled in.
       
       my-cool-website:
         labels:
-          - region=us-east
+          - env=prod
           - team=infra
         addr: 8000
         oauth:

--- a/docs/secure-tunnels/ngrok-agent/reference/config.md
+++ b/docs/secure-tunnels/ngrok-agent/reference/config.md
@@ -338,7 +338,7 @@ Each tunnel you define is a map of configuration option names to values. The nam
     tunnels:
       my-cool-website:
         labels:
-          - region=us-east
+          - env=prod
           - team=infra
         addr: 8000
         inspect: false


### PR DESCRIPTION
The example mentions region under labels which causes confusion for new users thinking that setting region in the label will affect the agent region.