### PR TITLE
feat: add gtm to docs pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,8 +82,8 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
-        googleAnalytics: {
-          trackingID: "UA-41575845-1",
+        googleTagManager: {
+          containerId: 'GTM-P4F37ZW',
         },
         sitemap: {
           changefreq: "hourly",


### PR DESCRIPTION
google tag manager seemed to be missing from the docs pages. this adds it. also, GA tracking is managed via tag manager, so we don't need that anymore.