### PR TITLE
Reorganize existing modules to match new format.

### DIFF
--- a/docs/cloud-edge/modules/compression.md
+++ b/docs/cloud-edge/modules/compression.md
@@ -16,13 +16,13 @@ ngrok takes no action.
 
 ### Agent CLI
 
-```
+```bash
 ngrok http 80 --compression
 ```
 
 ### Agent Configuration File
 
-```
+```yaml
 tunnels:
   example:
     proto: http
@@ -32,13 +32,13 @@ tunnels:
 
 ### SSH
 
-```
+```bash
 ssh -R 443:localhost:80 connect.ngrok-agent.com http --compression
 ```
 
 ### Go SDK
 
-```
+```go
 import (
 	"context"
 	"net"
@@ -61,7 +61,7 @@ func listenCompressed(ctx context.Context) net.Listener {
 
 ### Rust SDK
 
-```
+```rust
 use ngrok::prelude::*;
 
 async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
@@ -121,85 +121,6 @@ has no configuration parameters. It is either enabled or disabled.
 
 - [Compression Edge Module API Resource](/api/resources/https-edge-route-compression-module/)
 
-## Try it out
-
-For testing purposes, create a directory with a file in it and then enter that
-directory.
-
-```
-mkdir test-dir
-cd test-dir
-echo "hello world" > t.txt
-```
-
-ngrok can serve files from any directory (just like Python's Simple HTTP
-Server) by forwarding to a `file://` URL. We're going to use that capability
-for our compression testing.
-
-First let's see what this looks like without using compression by running the
-following in your `test-dir` directory:
-
-```
-ngrok http file://`pwd` --domain your-domain.ngrok.app
-```
-
-Then in another terminal while ngrok is still running:
-
-```
-curl --compressed -D - https://your-domain.ngrok.app/
-```
-
-- `--compressed` instructs curl to set the `Accept-Encoding` header to request
-  compressed content
-- `-D -` instructs curl to show the HTTP response headers
-
-You should get a response that looks like:
-
-```
-HTTP/2 200
-content-type: text/html; charset=utf-8
-date: Tue, 18 Jul 2023 09:52:49 GMT
-last-modified: Tue, 18 Jul 2023 09:52:34 GMT
-ngrok-agent-ips: 71.227.75.230
-ngrok-trace-id: 24e925dd0f348c1040d7ff62b06606cd
-content-length: 39
-
-<pre>
-<a href="t.txt">t.txt</a>
-</pre>
-```
-
-Now let's try it again with compression. Stop your ngrok agent and restart it
-by changing the command to:
-
-```
-ngrok http file://`pwd` --domain your-domain.ngrok.app --compression
-```
-
-Rerun the same curl command:
-
-```
-curl --compressed -D - https://your-domain.ngrok.app/
-```
-
-This time you should see that HTTP response headers include `content-encoding:
-deflate` indicating that the response was compressed.
-
-```
-HTTP/2 200
-content-encoding: deflate
-content-type: text/html; charset=utf-8
-date: Tue, 18 Jul 2023 10:03:22 GMT
-last-modified: Tue, 18 Jul 2023 09:52:34 GMT
-ngrok-agent-ips: 71.227.75.230
-ngrok-trace-id: b6b6cdce029e94123188ce53c0febee4
-vary: Accept-Encoding
-
-<pre>
-<a href="t.txt">t.txt</a>
-</pre>
-```
-
 ## Behavior
 
 ### Streaming Compression
@@ -245,13 +166,22 @@ automatically chooses a value that provides a reasonable tradeoff.
 
 ## Reference
 
+### Configuration
+
+This module does not support any configuration. It is either enabled or
+disabled.
+
 ### Upstream Headers {#upstream-headers}
 
-No additional upstream headers are added by the Compression module.
+This module does not add any upstream headers.
+
+### Errors
+
+This module does not return any errors.
 
 ### Events
 
-When the compression module is enabled, it populates the following fields in
+When this module is enabled, it populates the following fields in
 [http_request_complete.v0](/events/reference/#http-request-complete) events.
 
 | Fields                    |
@@ -259,10 +189,85 @@ When the compression module is enabled, it populates the following fields in
 | `compression.algorithm`   |
 | `compression.bytes_saved` |
 
-### Errors
+### Limits
 
-The compression module does not return any errors.
+This module is available on all plans.
 
-### Licensing
+## Try it out
 
-The compression module is available on the Free tier.
+For testing purposes, create a directory with a file in it and then enter that
+directory.
+
+```bash
+mkdir test-dir
+cd test-dir
+echo "hello world" > t.txt
+```
+
+ngrok can serve files from any directory (just like Python's Simple HTTP
+Server) by forwarding to a `file://` URL. We're going to use that capability
+for our compression testing.
+
+First let's see what this looks like without using compression by running the
+following in your `test-dir` directory:
+
+```bash
+ngrok http file://`pwd` --domain your-domain.ngrok.app
+```
+
+Then in another terminal while ngrok is still running:
+
+```bash
+curl --compressed -D - https://your-domain.ngrok.app/
+```
+
+- `--compressed` instructs curl to set the `Accept-Encoding` header to request
+  compressed content
+- `-D -` instructs curl to show the HTTP response headers
+
+You should get a response that looks like:
+
+```http
+HTTP/2 200
+content-type: text/html; charset=utf-8
+date: Tue, 18 Jul 2023 09:52:49 GMT
+last-modified: Tue, 18 Jul 2023 09:52:34 GMT
+ngrok-agent-ips: 71.227.75.230
+ngrok-trace-id: 24e925dd0f348c1040d7ff62b06606cd
+content-length: 39
+
+<pre>
+<a href="t.txt">t.txt</a>
+</pre>
+```
+
+Now let's try it again with compression. Stop your ngrok agent and restart it
+by changing the command to:
+
+```bash
+ngrok http file://`pwd` --domain your-domain.ngrok.app --compression
+```
+
+Rerun the same curl command:
+
+```bash
+curl --compressed -D - https://your-domain.ngrok.app/
+```
+
+This time you should see that HTTP response headers include `content-encoding:
+deflate` indicating that the response was compressed.
+
+```http
+HTTP/2 200
+content-encoding: deflate
+content-type: text/html; charset=utf-8
+date: Tue, 18 Jul 2023 10:03:22 GMT
+last-modified: Tue, 18 Jul 2023 09:52:34 GMT
+ngrok-agent-ips: 71.227.75.230
+ngrok-trace-id: b6b6cdce029e94123188ce53c0febee4
+vary: Accept-Encoding
+
+<pre>
+<a href="t.txt">t.txt</a>
+</pre>
+```

--- a/docs/cloud-edge/modules/mutual-tls.md
+++ b/docs/cloud-edge/modules/mutual-tls.md
@@ -18,18 +18,18 @@ Mutual TLS is supported on both HTTP and TLS endpoints.
 
 ### Agent CLI
 
-```
+```bash
 ngrok http 80 --mutual-tls-cas /path/to/cas.pem
 ```
 
 ### Agent Configuration File
 
-```
+```yaml
 tunnels:
   example:
-    proto: http
+    proto: "http"
     addr: 80
-    mutual_tls_cas: /path/to/cas.pem
+    mutual_tls_cas: "/path/to/cas.pem"
 ```
 
 ### SSH
@@ -42,7 +42,7 @@ Mutual TLS is not supported via SSH.
 
 ### Go SDK
 
-```
+```go
 import (
 	"context"
 	"crypto/x509"
@@ -72,7 +72,7 @@ func listenMutualTLS(ctx context.Context) net.Listener {
 
 ### Rust SDK
 
-```
+```rust
 use ngrok::prelude::*;
 
 async fn start_tunnel() -> anyhow::Result<impl Tunnel> {
@@ -120,38 +120,17 @@ processing can begin.
 - [Mutual TLS Edge Module API Resource](/api/resources/https-edge-mutual-tls-module/)
 - [Certificate Authority API Resource](/api/resources/certificate-authorities/)
 
-## Try it out
-
-This example assumes you have an x509 private key and certificate encoded as
-PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
-certificate must be signed by one of the CA certificates you provided to the
-Mutual TLS module.
-
-Run `curl` with the following command:
-
-```
-curl --client client-cert.pem --key client-key.pem https://yourapp.ngrok.app
-```
-
-`curl` has a shortcut to pass a single file if the private key and certificate
-are concatenated together.
-
-```
-cat client-cert.pem client-key.pem > client-cert-and-key.pem
-curl --cert client-cert-and-key.pem https://yourapp.ngrok.app
-```
-
 ## Behavior
 
 ### Multiple CAs
 
-You may specify multiple CAs to be used for mTLS authentication. A
-connection is considered authenticated if it presents a certificate signed by
-any of the specified CAs. Most agents allow you to specify multiple CAs by
-simply specifying a PEM file that contains multiple x509 CA certificates
-concatenated together. A file like that might look like:
+You may specify multiple CAs to be used for mTLS authentication. A connection
+is considered authenticated if it presents a certificate signed by any of the
+specified CAs. Agents allow you to specify multiple CAs by simply specifying a
+PEM file that contains multiple x509 CA certificates concatenated together. A
+file like that might look like:
 
-```
+```pem
 -----BEGIN CERTIFICATE-----
 ...
 -----END CERTIFICATE-----
@@ -172,11 +151,25 @@ See [RFC 5280 4.2.1.9](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2
 
 ## Reference
 
+### Configuration
+
+###### **Agent Configuration**
+
+| Parameter                   | Description                                                                                                                                        |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Certificate Authorities** | PEM-encoded certificate authorities. You may concatenate CAs to multiple together. A client certificate must be signed by at least one of the CAs. |
+
+###### **Edge Configuration**
+
+| Parameter                     | Description                                                                                                                                                                                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Certificate Authority IDs** | A set of certificates authorities. A client certificate must be signed by at least one of the configured CAs. See the [HTTPS Edge IP Restrictions Module API Resource](/api/resources/https-edge-route-ip-restriction-module/) for additional details. Max of 10. |
+
 ### Upstream Headers {#upstream-headers}
 
-When the Mutual TLS module is enabled, ngrok will insert headers into the HTTP
-request sent to your upstream server with details about the client certificate
-that was presented for the Mutual TLS handshake.
+This module adds headers to the HTTP request sent to your upstream server with
+details about the client certificate that was presented for the Mutual TLS
+handshake.
 
 | Header Name                       | Value                                                    |
 | --------------------------------- | -------------------------------------------------------- |
@@ -184,18 +177,6 @@ that was presented for the Mutual TLS handshake.
 | `ngrok-mtls-subject-alt-name-dns` | The client certificate's DNS subject alternative names   |
 | `ngrok-mtls-email-addresses`      | The client certificate's email subject alternative names |
 | `ngrok-mtls-serial-number`        | The client certificate's serial number                   |
-
-### Events
-
-When the mutual TLS module is enabled, it populates the following fields in
-[http_request_complete.v0](/events/reference/#http-request-complete) events.
-
-| Fields                          |
-| ------------------------------- |
-| `tls.client_cert.serial_number` |
-| `tls.client_cert.subject.cn`    |
-
-No event data is captured when the module is enabled on TLS endpoints.
 
 ### Errors
 
@@ -210,6 +191,39 @@ common alert code returned for a failed mutual TLS handshake is code 42
 (`bad_certificate`) which most TLS implementations will report with the error
 string string "bad certificate".
 
-### Licensing
+### Events
 
-Mutual TLS is available on the Enterprise plan only.
+When the mutual TLS module is enabled, it populates the following fields in
+[http_request_complete.v0](/events/reference/#http-request-complete) events.
+
+| Fields                          |
+| ------------------------------- |
+| `tls.client_cert.serial_number` |
+| `tls.client_cert.subject.cn`    |
+
+No event data is captured when the module is enabled on TLS endpoints.
+
+### Limits
+
+This module is available on the Enterprise plan.
+
+## Try it out
+
+This example assumes you have an x509 private key and certificate encoded as
+PEM files called `client-key.pem` and `client-cert.pem`, respectively. The
+certificate must be signed by one of the CA certificates you provided to the
+Mutual TLS module.
+
+Run `curl` with the following command:
+
+```bash
+curl --client client-cert.pem --key client-key.pem https://yourapp.ngrok.app
+```
+
+`curl` has a shortcut to pass a single file if the private key and certificate
+are concatenated together.
+
+```bash
+cat client-cert.pem client-key.pem > client-cert-and-key.pem
+curl --cert client-cert-and-key.pem https://yourapp.ngrok.app
+```

--- a/docs/cloud-edge/modules/openid-connect.md
+++ b/docs/cloud-edge/modules/openid-connect.md
@@ -1,4 +1,4 @@
-# OpenID Connect (OIDC)
+# OpenID Connect
 
 ---
 

--- a/docs/events/index.mdx
+++ b/docs/events/index.mdx
@@ -25,7 +25,7 @@ They break down into two important classes of event:
 - **[Configuration Events](/docs/events/reference/#configuration-events)**: Changes to your account like create/update/delete of Domains, API Keys, IP Policies, etc.
 - **[Traffic Events](/docs/events/reference/#traffic-events)**: When traffic transits through your endpoints like processing an HTTP request or TCP connection
 
-### Definitions
+### Concepts
 
 ngrok's event logging system is composed of three simple primitives. You create
 an **Event Subscription** to _subscribe_ to a set of **Event Sources** and


### PR DESCRIPTION
There are no meaningful changes in this changeset, it just moves around sections and text in the docs of existing modules to match the new format used by the docs for request/response headers and the oauth modules.

It also adds syntax highlighting to existing examples + normalizes how we display variables that need to be added by the user in example code.