### PR TITLE
fix: module set circuit breaker documentation

### DIFF
--- a/docs/cloud-edge/modules/circuit-breaker.md
+++ b/docs/cloud-edge/modules/circuit-breaker.md
@@ -97,7 +97,7 @@ apiVersion: ingress.k8s.ngrok.com/v1alpha1
 metadata:
   name: ngrok-module-set
 modules:
-  circuit_breaker:
+  circuitBreaker:
     errorThresholdPercentage: "0.50"
     trippedDuration: 10s
     rollingWindow: 10s


### PR DESCRIPTION
We have it right in the other integration pages and I noticed the error when trying to copy/paste this into a new moduleset I was making. 