### PR TITLE
Correctly map custom font weights

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -5,37 +5,35 @@
  */
 
 @font-face {
-	font-family: "EuclidSquare";
+	font-family: EuclidSquare;
+	font-style: normal;
+	font-weight: normal;
 	font-display: swap;
-	src:
-		local("sans-serif"),
-		url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2"),
-		url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2"),
-		url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
+	src: url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff");
 }
 
 @font-face {
-	font-family: "EuclidSquare-regular";
+	font-family: EuclidSquare;
+	font-style: italic;
+	font-weight: normal;
 	font-display: swap;
-	src:
-		local("sans-serif"),
-		url("/static/fonts/EuclidSquare-Regular-WebS.woff2") format("woff2");
+	src: url("/static/fonts/EuclidSquare-RegularItalic-WebS.woff2") format("woff");
 }
 
 @font-face {
-	font-family: "EuclidSquare-medium";
+	font-family: EuclidSquare;
+	font-style: normal;
+	font-weight: 500;
 	font-display: swap;
-	src:
-		local("sans-serif"),
-		url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff2");
+	src: url("/static/fonts/EuclidSquare-Medium-WebS.woff2") format("woff");
 }
 
 @font-face {
-	font-family: "EuclidSquare-light";
+	font-family: EuclidSquare;
+	font-style: normal;
+	font-weight: 600;
 	font-display: swap;
-	src:
-		local("sans-serif"),
-		url("/static/fonts/EuclidSquare-Light-WebS.woff2") format("woff2");
+	src: url("/static/fonts/EuclidSquare-Semibold-WebS.woff2") format("woff");
 }
 /* You can override the default Infima variables here. */
 
@@ -65,7 +63,7 @@
 
 	--ifm-code-font-size: 95%;
 	--docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-	--ifm-font-family-base: "EuclidSquare-regular";
+	--ifm-font-family-base: "EuclidSquare";
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -167,11 +165,11 @@ a.menu__link {
 	line-height: 1.25;
 	padding: var(--ifm-menu-link-padding-vertical)
 		var(--ifm-menu-link-padding-horizontal);
-	font-family: "EuclidSquare-medium";
+	font-weight: 500;
 }
 
 li.menu__list-item:not([class*="level-1"]) a {
-	font-family: "EuclidSquare-regular";
+	font-weight: 400;
 	font-size: smaller;
 }
 
@@ -232,7 +230,8 @@ span.breadcrumbs__link:focus {
 h1,
 h2,
 h3 {
-	font-family: "EuclidSquare-medium";
+	font-family: "EuclidSquare";
+	font-weight: 500;
 }
 
 h1 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -259,6 +259,11 @@ p {
 
 .theme-last-updated {
 	color: var(--ifm-p-secondary-mini);
+	font-style: normal;
+}
+
+.theme-last-updated b {
+	font-weight: 600;
 }
 
 .theme-edit-this-page {


### PR DESCRIPTION
This PR modifies our font declarations to properly map to our font weights. Currently, we don't map Euclid Semibold to the `600` weight. This causes browsers to render a faux bold which affects readability. This PR fixes that by spec'ing those weights to a single `EuclidSquare` font name, and changing font files per weight.

In the overview, you'll see lots of faux bold fonts get changed to a real semibold. You'll notice the top menu also got a little thicker, since it was intended to be the "medium" font weight. Now it's actually rendered as such.

## Before
![Screenshot 2023-10-05 at 9 43 56 AM](https://github.com/ngrok/ngrok-docs/assets/1369864/22e2dde7-9d3a-412f-bbab-7337a382c10f)

## After
![Screenshot 2023-10-05 at 9 45 15 AM](https://github.com/ngrok/ngrok-docs/assets/1369864/a84f772b-1332-4765-9e77-3a3cbe7d32a0)