### PR TITLE
Font refinements

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,7 +63,7 @@
 
 	--ifm-code-font-size: 95%;
 	--docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-	--ifm-font-family-base: "EuclidSquare";
+	--ifm-font-family-base: "EuclidSquare", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,7 +63,10 @@
 
 	--ifm-code-font-size: 95%;
 	--docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-	--ifm-font-family-base: "EuclidSquare", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--ifm-font-family-base: "EuclidSquare", ui-sans-serif, system-ui,
+		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+		Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+		"Segoe UI Symbol", "Noto Color Emoji";
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
This is a follow up from #433 to improve the initial load. This specifies a sans-serif font stack which is less jarring on initial load than Times New Roman. It also removes the redundant font declaration from headings, since those inherit from the base font family.

## Before
https://github.com/ngrok/ngrok-docs/assets/1369864/7ac0102e-0cc4-4c7c-81a1-4be4a8341a70

## After
https://github.com/ngrok/ngrok-docs/assets/1369864/154af2ea-e2a4-463e-9c58-eb3000e45b5d

You can scrub through the attached videos to see the improvement here. Before, it'd flash Times New Roman and have much more layout jumps.