### PR TITLE
Markdown text colors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,9 +229,13 @@ span.breadcrumbs__link:focus {
 
 h1,
 h2,
-h3 {
+h3,
+h4,
+h5,
+h6 {
 	font-family: "EuclidSquare";
 	font-weight: 500;
+	color: var(--ifm-h1-primary-header);
 }
 
 h1 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -253,7 +253,7 @@ h6 {
 	font-size: 12px;
 }
 
-p {
+.theme-doc-markdown {
 	color: var(--ifm-p-primary-body);
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -80,7 +80,7 @@
 	/* FIX this here, clean up code I didn't use. */
 	--ifm-h1-primary-header: #ffffff;
 	--ifm-h2-primary-subheader: #ffffff;
-	--ifm-p-primary-body: #5F5F5F5;
+	--ifm-p-primary-body: #dadada;
 	--ifm-p-secondary-mini: #8c8c8c;
 
 	--ifm-footer-background-color: #262626;


### PR DESCRIPTION
We were only applying our text color to the paragraph element. This spec's that color on the entire markdown body, and then applies a darker color to headers only. This should solve the issue of lists and tables have darker text than paragraphs.