### PR TITLE
Improve integrations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,6 +37,7 @@ const config = {
 		"./src/plugins/ngrok-parse-integrations",
 		"@stackql/docusaurus-plugin-hubspot",
 		"@docusaurus/theme-mermaid",
+		"./src/plugins/tailwindcss",
 	],
 	headTags: [
 		{

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "@docusaurus/types": "2.4.3",
     "@types/react": "17.0.69",
     "@types/react-dom": "17.0.22",
-    "prettier": "3.0.3"
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "prettier": "3.0.3",
+    "tailwindcss": "3.3.5"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
     "react-dom": "17.0.2",
     "react-hubspot-form": "^1.3.7",
     "react-player": "2.13.0",
-    "redocusaurus": "1.6.4"
+    "redocusaurus": "1.6.4",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.3",
     "@docusaurus/plugin-content-docs": "2.4.3",
     "@docusaurus/types": "2.4.3",
+    "@types/react": "17.0.69",
+    "@types/react-dom": "17.0.22",
     "prettier": "3.0.3"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
   '@docusaurus/preset-classic':
     specifier: 2.4.3
-    version: 2.4.3(@algolia/client-search@4.20.0)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2)
+    version: 2.4.3(@algolia/client-search@4.20.0)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2)
   '@docusaurus/theme-mermaid':
     specifier: 2.4.3
     version: 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
@@ -59,6 +59,9 @@ dependencies:
   redocusaurus:
     specifier: 1.6.4
     version: 1.6.4(@babel/core@7.23.2)(@docusaurus/theme-common@2.4.3)(@docusaurus/utils@2.4.3)(core-js@3.33.2)(mobx@6.10.2)(react-dom@17.0.2)(react-is@18.2.0)(react@17.0.2)(styled-components@5.3.11)(webpack@5.89.0)
+  zod:
+    specifier: 3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@docusaurus/module-type-aliases':
@@ -70,6 +73,12 @@ devDependencies:
   '@docusaurus/types':
     specifier: 2.4.3
     version: 2.4.3(react-dom@17.0.2)(react@17.0.2)
+  '@types/react':
+    specifier: 17.0.69
+    version: 17.0.69
+  '@types/react-dom':
+    specifier: 17.0.22
+    version: 17.0.22
   prettier:
     specifier: 3.0.3
     version: 3.0.3
@@ -1492,7 +1501,7 @@ packages:
     resolution: {integrity: sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==}
     dev: false
 
-  /@docsearch/react@3.5.2(@algolia/client-search@4.20.0)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0):
+  /@docsearch/react@3.5.2(@algolia/client-search@4.20.0)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0):
     resolution: {integrity: sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -1512,6 +1521,7 @@ packages:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.20.0)(algoliasearch@4.20.0)(search-insights@2.9.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.20.0)(algoliasearch@4.20.0)
       '@docsearch/css': 3.5.2
+      '@types/react': 17.0.69
       algoliasearch: 4.20.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -1678,7 +1688,7 @@ packages:
       '@docusaurus/react-loadable': 5.5.2(react@17.0.2)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2)(react@17.0.2)
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       '@types/react-router-config': 5.0.9
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
@@ -1848,7 +1858,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug@2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2):
+  /@docusaurus/plugin-debug@2.4.3(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2):
     resolution: {integrity: sha512-LkUbuq3zCmINlFb+gAd4ZvYr+bPAzMC0hwND4F7V9bZ852dCX8YoWyovVUBKq4er1XsOwSQaHmNGtObtn8Av8Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -1861,7 +1871,7 @@ packages:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-json-view: 1.21.3(react-dom@17.0.2)(react@17.0.2)
+      react-json-view: 1.21.3(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -2012,7 +2022,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic@2.4.3(@algolia/client-search@4.20.0)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2):
+  /@docusaurus/preset-classic@2.4.3(@algolia/client-search@4.20.0)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2):
     resolution: {integrity: sha512-tRyMliepY11Ym6hB1rAFSNGwQDpmszvWYJvlK1E+md4SW8i6ylNHtpZjaYFff9Mdk3i/Pg8ItQq9P0daOJAvQw==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -2023,14 +2033,14 @@ packages:
       '@docusaurus/plugin-content-blog': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-content-docs': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-content-pages': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
-      '@docusaurus/plugin-debug': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
+      '@docusaurus/plugin-debug': 2.4.3(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-google-analytics': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-google-gtag': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-google-tag-manager': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/plugin-sitemap': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/theme-classic': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
-      '@docusaurus/theme-search-algolia': 2.4.3(@algolia/client-search@4.20.0)(@docusaurus/types@2.4.3)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2)
+      '@docusaurus/theme-search-algolia': 2.4.3(@algolia/client-search@4.20.0)(@docusaurus/types@2.4.3)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -2061,7 +2071,7 @@ packages:
     peerDependencies:
       react: '*'
     dependencies:
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       prop-types: 15.8.1
       react: 17.0.2
 
@@ -2132,7 +2142,7 @@ packages:
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3)
       '@docusaurus/utils-common': 2.4.3(@docusaurus/types@2.4.3)
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       '@types/react-router-config': 5.0.9
       clsx: 1.2.1
       parse-numeric-range: 1.3.0
@@ -2196,14 +2206,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia@2.4.3(@algolia/client-search@4.20.0)(@docusaurus/types@2.4.3)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2):
+  /@docusaurus/theme-search-algolia@2.4.3(@algolia/client-search@4.20.0)(@docusaurus/types@2.4.3)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)(typescript@5.2.2):
     resolution: {integrity: sha512-jziq4f6YVUB5hZOB85ELATwnxBz/RmSLD3ksGQOLDPKVzat4pmI8tddNWtriPpxR04BNT+ZfpPUMFkNFetSW1Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.5.2(@algolia/client-search@4.20.0)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)
+      '@docsearch/react': 3.5.2(@algolia/client-search@4.20.0)(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.9.0)
       '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3)(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
       '@docusaurus/logger': 2.4.3
       '@docusaurus/plugin-content-docs': 2.4.3(react-dom@17.0.2)(react@17.0.2)(typescript@5.2.2)
@@ -2258,7 +2268,7 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       commander: 5.1.0
       joi: 17.11.0
       react: 17.0.2
@@ -2828,28 +2838,34 @@ packages:
   /@types/range-parser@1.2.6:
     resolution: {integrity: sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==}
 
+  /@types/react-dom@17.0.22:
+    resolution: {integrity: sha512-wHt4gkdSMb4jPp1vc30MLJxoWGsZs88URfmt3FRXoOEYrrqK3I8IuZLE/uFBb4UT6MRfI0wXFu4DS7LS0kUC7Q==}
+    dependencies:
+      '@types/react': 17.0.69
+    dev: true
+
   /@types/react-router-config@5.0.9:
     resolution: {integrity: sha512-a7zOj9yVUtM3Ns5stoseQAAsmppNxZpXDv6tZiFV5qlRmV4W96u53on1vApBX1eRSc8mrFOiB54Hc0Pk1J8GFg==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       '@types/react-router': 5.1.20
 
   /@types/react-router-dom@5.3.3:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
       '@types/react-router': 5.1.20
 
   /@types/react-router@5.1.20:
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.2.33
+      '@types/react': 17.0.69
 
-  /@types/react@18.2.33:
-    resolution: {integrity: sha512-v+I7S+hu3PIBoVkKGpSYYpiBT1ijqEzWpzQD62/jm4K74hPpSP7FF9BnKG6+fg2+62weJYkkBWDJlZt5JO/9hg==}
+  /@types/react@17.0.69:
+    resolution: {integrity: sha512-klEeru//GhiQvXUBayz0Q4l3rKHWsBR/EUOhOeow6hK2jV7MlO44+8yEk6+OtPeOlRfnpUnrLXzGK+iGph5aeg==}
     dependencies:
       '@types/prop-types': 15.7.9
       '@types/scheduler': 0.16.5
@@ -7197,7 +7213,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
 
-  /react-json-view@1.21.3(react-dom@17.0.2)(react@17.0.2):
+  /react-json-view@1.21.3(@types/react@17.0.69)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -7208,7 +7224,7 @@ packages:
       react-base16-styling: 0.6.0
       react-dom: 17.0.2(react@17.0.2)
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.5.3(react@17.0.2)
+      react-textarea-autosize: 8.5.3(@types/react@17.0.69)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - encoding
@@ -7292,7 +7308,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-textarea-autosize@8.5.3(react@17.0.2):
+  /react-textarea-autosize@8.5.3(@types/react@17.0.69)(react@17.0.2):
     resolution: {integrity: sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -7301,7 +7317,7 @@ packages:
       '@babel/runtime': 7.23.2
       react: 17.0.2
       use-composed-ref: 1.3.0(react@17.0.2)
-      use-latest: 1.2.1(react@17.0.2)
+      use-latest: 1.2.1(@types/react@17.0.69)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -8533,7 +8549,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-isomorphic-layout-effect@1.1.2(react@17.0.2):
+  /use-isomorphic-layout-effect@1.1.2(@types/react@17.0.69)(react@17.0.2):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -8542,10 +8558,11 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.69
       react: 17.0.2
     dev: false
 
-  /use-latest@1.2.1(react@17.0.2):
+  /use-latest@1.2.1(@types/react@17.0.69)(react@17.0.2):
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
     peerDependencies:
       '@types/react': '*'
@@ -8554,8 +8571,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.69
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2(react@17.0.2)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@17.0.69)(react@17.0.2)
     dev: false
 
   /use-sync-external-store@1.2.0(react@17.0.2):
@@ -8972,6 +8990,10 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
 
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,9 +79,18 @@ devDependencies:
   '@types/react-dom':
     specifier: 17.0.22
     version: 17.0.22
+  autoprefixer:
+    specifier: 10.4.16
+    version: 10.4.16(postcss@8.4.31)
+  postcss:
+    specifier: 8.4.31
+    version: 8.4.31
   prettier:
     specifier: 3.0.3
     version: 3.0.3
+  tailwindcss:
+    specifier: 3.3.5
+    version: 3.3.5
 
 packages:
 
@@ -222,6 +231,11 @@ packages:
       '@algolia/logger-common': 4.20.0
       '@algolia/requester-common': 4.20.0
     dev: false
+
+  /@alloc/quick-lru@5.2.0:
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -3161,6 +3175,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  /any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+    dev: true
+
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -3170,7 +3188,6 @@ packages:
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3672,6 +3689,11 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  /commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -4501,11 +4523,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: true
+
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+
+  /dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: true
 
   /dns-equal@1.0.0:
     resolution: {integrity: sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==}
@@ -5123,6 +5153,17 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  /glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -6213,6 +6254,14 @@ packages:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
+  /mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+    dev: true
+
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6355,6 +6404,11 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  /object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
@@ -6588,6 +6642,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  /pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+    engines: {node: '>= 6'}
+    dev: true
+
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -6683,6 +6747,45 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
+
+  /postcss-import@15.1.0(postcss@8.4.31):
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+    dev: true
+
+  /postcss-js@4.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.31
+    dev: true
+
+  /postcss-load-config@4.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.31
+      yaml: 2.3.3
+    dev: true
 
   /postcss-loader@7.3.3(postcss@8.4.31)(typescript@5.2.2)(webpack@5.89.0):
     resolution: {integrity: sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==}
@@ -6807,6 +6910,16 @@ packages:
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
+
+  /postcss-nested@6.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.31
+      postcss-selector-parser: 6.0.13
+    dev: true
 
   /postcss-normalize-charset@5.1.0(postcss@8.4.31):
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
@@ -7328,6 +7441,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+
+  /read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    dependencies:
+      pify: 2.3.0
+    dev: true
 
   /readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
@@ -8172,6 +8291,20 @@ packages:
     resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
     dev: false
 
+  /sucrase@3.34.0:
+    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      commander: 4.1.1
+      glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.6
+      ts-interface-checker: 0.1.13
+    dev: true
+
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -8229,6 +8362,37 @@ packages:
       - encoding
     dev: false
 
+  /tailwindcss@3.3.5:
+    resolution: {integrity: sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.1
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.31
+      postcss-import: 15.1.0(postcss@8.4.31)
+      postcss-js: 4.0.1(postcss@8.4.31)
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      postcss-nested: 6.0.1(postcss@8.4.31)
+      postcss-selector-parser: 6.0.13
+      resolve: 1.22.8
+      sucrase: 3.34.0
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
   /tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
@@ -8272,6 +8436,19 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  /thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      thenify: 3.3.1
+    dev: true
+
+  /thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    dependencies:
+      any-promise: 1.3.0
+    dev: true
 
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -8339,6 +8516,10 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: false
+
+  /ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -8950,6 +9131,11 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  /yaml@2.3.3:
+    resolution: {integrity: sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==}
+    engines: {node: '>= 14'}
+    dev: true
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {},
+	},
+};

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import NgrokCard from "./NgrokCard";
 import { usePluginData } from "@docusaurus/useGlobalData";
+import { ReactNode } from "react";
 
 type Integration = {
 	name: string;
 	path: string;
-	docs: Array<IntegrationDoc>;
+	docs?: Array<IntegrationDoc> | undefined;
 };
 
 type IntegrationDoc = {
@@ -13,14 +14,32 @@ type IntegrationDoc = {
 	excerpt: string;
 	content: string;
 	contentTitle: string;
-	frontMatter: any;
+	frontMatter?: FrontMatter | undefined;
 };
 
-export default function IntegrationPageList({ name }) {
-	const integrations: any = usePluginData("ngrok-parse-integrations");
-	const data: Integration = integrations.find(
-		(x: Integration) => x.name === name,
-	);
+type FrontMatter = {
+	title?: string | undefined;
+	description?: string | undefined;
+};
+
+const pluginKey = "ngrok-parse-integrations" as const;
+
+type Props = {
+	name: string;
+};
+
+export default function IntegrationPageList({ name }: Props) {
+	const pluginData = usePluginData(pluginKey);
+	console.log("IntegrationPageList", { name, pluginData });
+	const integrations: Array<Integration> = Array.isArray(pluginData)
+		? pluginData
+		: [];
+	const data = integrations.find((x: Integration) => x.name === name);
+
+	if (!data || !data.docs) {
+		return null;
+	}
+
 	const cards: any = [];
 	let group: any = [];
 

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -16,7 +16,7 @@ export default function IntegrationPageList({ name }: Props) {
 	return (
 		<ul className="m-0 mb-5 grid list-none grid-cols-2 gap-5 p-0" role="list">
 			{integration.docs.map((doc) => (
-				<li key={doc.path}>
+				<li className="last-of-type:col-span-full" key={doc.path}>
 					<NgrokCard
 						to={doc.path}
 						size="sm"

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -14,7 +14,7 @@ export default function IntegrationPageList({ name }: Props) {
 	}
 
 	return (
-		<ul className="m-0 mb-5 list-none grid grid-cols-2 gap-5" role="list">
+		<ul className="m-0 mb-5 grid list-none grid-cols-2 gap-5 p-0" role="list">
 			{integration.docs.map((doc) => (
 				<li key={doc.path}>
 					<NgrokCard

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -1,70 +1,30 @@
 import React from "react";
 import NgrokCard from "./NgrokCard";
-import { usePluginData } from "@docusaurus/useGlobalData";
-import { ReactNode } from "react";
-
-type Integration = {
-	name: string;
-	path: string;
-	docs?: Array<IntegrationDoc> | undefined;
-};
-
-type IntegrationDoc = {
-	path: string;
-	excerpt: string;
-	content: string;
-	contentTitle: string;
-	frontMatter?: FrontMatter | undefined;
-};
-
-type FrontMatter = {
-	title?: string | undefined;
-	description?: string | undefined;
-};
-
-const pluginKey = "ngrok-parse-integrations" as const;
+import { useIntegration } from "./integrations/use-integrations";
 
 type Props = {
 	name: string;
 };
 
 export default function IntegrationPageList({ name }: Props) {
-	const pluginData = usePluginData(pluginKey);
-	console.log("IntegrationPageList", { name, pluginData });
-	const integrations: Array<Integration> = Array.isArray(pluginData)
-		? pluginData
-		: [];
-	const data = integrations.find((x: Integration) => x.name === name);
+	const integration = useIntegration(name);
 
-	if (!data || !data.docs) {
+	if (!integration) {
 		return null;
 	}
 
-	const cards: any = [];
-	let group: any = [];
-
-	for (let i = 0; i < data.docs.length; i++) {
-		const { contentTitle, excerpt, path, frontMatter } = data.docs[i];
-
-		group.push(
-			<NgrokCard
-				to={path}
-				size="sm"
-				title={frontMatter?.title || contentTitle}
-				description={frontMatter?.description || excerpt}
-			/>,
-		);
-
-		if (
-			group.length == 2 ||
-			data.docs.length < 2 ||
-			i == data.docs.length - 1
-		) {
-			cards.push(<div className="ngrok--cards ngrok--cards-row">{group}</div>);
-
-			group = [];
-		}
-	}
-
-	return <>{cards}</>;
+	return (
+		<ul className="m-0 mb-5 list-none grid grid-cols-2 gap-5" role="list">
+			{integration.docs.map((doc) => (
+				<li key={doc.path}>
+					<NgrokCard
+						to={doc.path}
+						size="sm"
+						title={doc.frontMatter?.title || doc.contentTitle}
+						description={doc.frontMatter?.description || doc.excerpt}
+					/>
+				</li>
+			))}
+		</ul>
+	);
 }

--- a/src/components/IntegrationsList.tsx
+++ b/src/components/IntegrationsList.tsx
@@ -8,7 +8,7 @@ export default function IntegrationsList() {
 	return (
 		<ul className="m-0 mb-5 grid list-none grid-cols-2 gap-5 p-0" role="list">
 			{integrations.map((integration) => (
-				<li key={integration.name}>
+				<li className="last-of-type:col-span-full" key={integration.name}>
 					<NgrokCard
 						to={integration.path}
 						size="sm"

--- a/src/components/IntegrationsList.tsx
+++ b/src/components/IntegrationsList.tsx
@@ -1,31 +1,23 @@
 import React from "react";
 import NgrokCard from "./NgrokCard";
-import useGlobalData, { usePluginData } from "@docusaurus/useGlobalData";
+import { useIntegrations } from "./integrations/use-integrations";
 
 export default function IntegrationsList() {
-	const data: any = usePluginData("ngrok-parse-integrations");
-	const cards: any = [];
-	let group: any = [];
+	const integrations = useIntegrations();
 
-	for (let i = 0; i < data.length; i++) {
-		const { name, path, metadata } = data[i];
-
-		group.push(
-			<NgrokCard
-				to={path}
-				size="sm"
-				img={metadata?.logo || false}
-				title={metadata?.sidebar_label || name}
-				description={metadata?.excerpt}
-			/>,
-		);
-
-		if (group.length == 2 || data.length < 2 || i == data.length - 1) {
-			cards.push(<div className="ngrok--cards ngrok--cards-row">{group}</div>);
-
-			group = [];
-		}
-	}
-
-	return <>{cards}</>;
+	return (
+		<ul className="m-0 mb-5 list-none grid grid-cols-2 gap-5" role="list">
+			{integrations.map((integration) => (
+				<li key={integration.name}>
+					<NgrokCard
+						to={integration.path}
+						size="sm"
+						img={integration.metadata?.logo}
+						title={integration.metadata?.sidebar_label || integration.name}
+						description={integration.metadata?.excerpt}
+					/>
+				</li>
+			))}
+		</ul>
+	);
 }

--- a/src/components/IntegrationsList.tsx
+++ b/src/components/IntegrationsList.tsx
@@ -16,7 +16,7 @@ export default function IntegrationsList() {
 				size="sm"
 				img={metadata?.logo || false}
 				title={metadata?.sidebar_label || name}
-				description={metadata?.excerpt || false}
+				description={metadata?.excerpt}
 			/>,
 		);
 

--- a/src/components/IntegrationsList.tsx
+++ b/src/components/IntegrationsList.tsx
@@ -6,7 +6,7 @@ export default function IntegrationsList() {
 	const integrations = useIntegrations();
 
 	return (
-		<ul className="m-0 mb-5 list-none grid grid-cols-2 gap-5" role="list">
+		<ul className="m-0 mb-5 grid list-none grid-cols-2 gap-5 p-0" role="list">
 			{integrations.map((integration) => (
 				<li key={integration.name}>
 					<NgrokCard

--- a/src/components/NgrokCard.tsx
+++ b/src/components/NgrokCard.tsx
@@ -37,6 +37,17 @@ function CardHeading({ size, title, icon }) {
 	return null;
 }
 
+type Props = {
+	to: string;
+	note?: boolean;
+	size?: string;
+	title: string;
+	img?: string;
+	icon?: React.ReactNode;
+	description?: string | undefined;
+	descriptionLink?: string | undefined;
+};
+
 export default function NgrokCard({
 	to,
 	note = false,
@@ -44,8 +55,8 @@ export default function NgrokCard({
 	title,
 	img = "",
 	icon = false,
-	description = false,
-	descriptionLink = false,
+	description,
+	descriptionLink,
 }) {
 	size = size.toLowerCase();
 

--- a/src/components/NgrokCard.tsx
+++ b/src/components/NgrokCard.tsx
@@ -37,39 +37,43 @@ function CardHeading({ size, title, icon }) {
 	return null;
 }
 
+const sizes = ["sm", "lg", "xl"] as const;
+type Size = (typeof sizes)[number];
+
 type Props = {
-	to: string;
-	note?: boolean;
-	size?: string;
-	title: string;
-	img?: string;
-	icon?: React.ReactNode;
 	description?: string | undefined;
 	descriptionLink?: string | undefined;
+	icon?: React.ReactNode;
+	img?: string;
+	note?: boolean;
+	size?: Size;
+	title: string;
+	to: string;
 };
 
 export default function NgrokCard({
-	to,
-	note = false,
-	size = "",
-	title,
-	img = "",
-	icon = false,
 	description,
 	descriptionLink,
-}) {
-	size = size.toLowerCase();
-
-	let classNames = clsx("ngrok--card", {
-		"ngrok--card-note": note,
-		"ngrok--card-sm": size == "sm",
-		"ngrok--card-lg": size == "lg",
-		"ngrok--card-xl": size == "xl",
-	});
-
+	icon,
+	img,
+	note = false,
+	size,
+	title,
+	to,
+}: Props) {
 	return (
-		<Link to={to}>
-			<div className={classNames}>
+		<Link
+			to={to}
+			className="rounded-md text-inherit no-underline hover:text-inherit hover:no-underline focus:text-inherit focus:no-underline"
+		>
+			<div
+				className={clsx("ngrok--card h-full", {
+					"ngrok--card-note": note,
+					"ngrok--card-sm": size == "sm",
+					"ngrok--card-lg": size == "lg",
+					"ngrok--card-xl": size == "xl",
+				})}
+			>
 				{img && <img src={img} />}
 				<CardHeading size={size} title={title} icon={icon} />
 				{description && <p>{description}</p>}

--- a/src/components/integrations/schema.ts
+++ b/src/components/integrations/schema.ts
@@ -1,23 +1,21 @@
 import { z } from "zod";
 
-export const docFrontMatterSchema = z.object({
+const docFrontMatterSchema = z.object({
 	description: z.string().optional(),
 	sidebar_label: z.string().optional(),
 	tags: z.array(z.string()).optional(),
 	title: z.string().optional(),
 });
-export type DocFrontMatter = z.infer<typeof docFrontMatterSchema>;
 
-export const integrationDocSchema = z.object({
+const integrationDocSchema = z.object({
 	content: z.string().trim().min(1),
 	contentTitle: z.string().trim().min(1),
 	excerpt: z.string().trim().min(1),
 	frontMatter: docFrontMatterSchema.optional(),
 	path: z.string().trim().min(1),
 });
-export type IntegrationDoc = z.infer<typeof integrationDocSchema>;
 
-export const IntegrationMetadataSchema = z.object({
+const integrationMetadataSchema = z.object({
 	description: z.string().trim(),
 	excerpt: z.string().trim().optional(),
 	logo: z.string().trim().optional(),
@@ -25,15 +23,23 @@ export const IntegrationMetadataSchema = z.object({
 	sidebar_label: z.string().trim(),
 	title: z.string().trim(),
 });
-export type IntegrationMetadata = z.infer<typeof IntegrationMetadataSchema>;
 
-export const integrationSchema = z.object({
+const integrationSchema = z.object({
 	docs: z.array(integrationDocSchema),
-	metadata: IntegrationMetadataSchema,
+	metadata: integrationMetadataSchema,
 	name: z.string().trim().toLowerCase().min(1),
 	path: z.string().trim().min(1),
 });
 export type Integration = z.infer<typeof integrationSchema>;
 
-export const integrationsSchema = z.array(integrationSchema);
+const integrationsSchema = z.array(integrationSchema);
 export type Integrations = z.infer<typeof integrationsSchema>;
+
+export function parseIntegrations(data: unknown): Integrations {
+	try {
+		return integrationsSchema.parse(data);
+	} catch (error) {
+		console.error(error);
+		return [];
+	}
+}

--- a/src/components/integrations/schema.ts
+++ b/src/components/integrations/schema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const frontMatterSchema = z.object({
+	title: z.string().optional(),
+	description: z.string().optional(),
+});
+
+export type FrontMatter = z.infer<typeof frontMatterSchema>;
+
+export const integrationDocSchema = z.object({
+	path: z.string().trim().min(1),
+	excerpt: z.string().trim().min(1),
+	content: z.string().trim().min(1),
+	contentTitle: z.string().trim().min(1),
+	frontMatter: frontMatterSchema,
+});
+
+export type IntegrationDoc = z.infer<typeof integrationDocSchema>;
+
+export const IntegrationMetadataSchema = z.object({
+	name: z.string().trim(),
+	title: z.string().trim(),
+	sidebar_label: z.string().trim(),
+	description: z.string().trim(),
+	excerpt: z.string().trim(),
+});
+
+export type IntegrationMetadata = z.infer<typeof IntegrationMetadataSchema>;
+
+export const integrationSchema = z.object({
+	name: z.string().trim().min(1),
+	path: z.string().trim().min(1),
+	metadata: IntegrationMetadataSchema,
+	docs: z.array(integrationDocSchema),
+});
+
+export type Integration = z.infer<typeof integrationSchema>;

--- a/src/components/integrations/schema.ts
+++ b/src/components/integrations/schema.ts
@@ -1,37 +1,39 @@
 import { z } from "zod";
 
-export const frontMatterSchema = z.object({
-	title: z.string().optional(),
+export const docFrontMatterSchema = z.object({
 	description: z.string().optional(),
+	sidebar_label: z.string().optional(),
+	tags: z.array(z.string()).optional(),
+	title: z.string().optional(),
 });
-
-export type FrontMatter = z.infer<typeof frontMatterSchema>;
+export type DocFrontMatter = z.infer<typeof docFrontMatterSchema>;
 
 export const integrationDocSchema = z.object({
-	path: z.string().trim().min(1),
-	excerpt: z.string().trim().min(1),
 	content: z.string().trim().min(1),
 	contentTitle: z.string().trim().min(1),
-	frontMatter: frontMatterSchema,
+	excerpt: z.string().trim().min(1),
+	frontMatter: docFrontMatterSchema.optional(),
+	path: z.string().trim().min(1),
 });
-
 export type IntegrationDoc = z.infer<typeof integrationDocSchema>;
 
 export const IntegrationMetadataSchema = z.object({
-	name: z.string().trim(),
-	title: z.string().trim(),
-	sidebar_label: z.string().trim(),
 	description: z.string().trim(),
-	excerpt: z.string().trim(),
+	excerpt: z.string().trim().optional(),
+	logo: z.string().trim().optional(),
+	name: z.string().trim(),
+	sidebar_label: z.string().trim(),
+	title: z.string().trim(),
 });
-
 export type IntegrationMetadata = z.infer<typeof IntegrationMetadataSchema>;
 
 export const integrationSchema = z.object({
-	name: z.string().trim().min(1),
-	path: z.string().trim().min(1),
-	metadata: IntegrationMetadataSchema,
 	docs: z.array(integrationDocSchema),
+	metadata: IntegrationMetadataSchema,
+	name: z.string().trim().toLowerCase().min(1),
+	path: z.string().trim().min(1),
 });
-
 export type Integration = z.infer<typeof integrationSchema>;
+
+export const integrationsSchema = z.array(integrationSchema);
+export type Integrations = z.infer<typeof integrationsSchema>;

--- a/src/components/integrations/use-integrations.tsx
+++ b/src/components/integrations/use-integrations.tsx
@@ -1,16 +1,11 @@
 import { usePluginData } from "@docusaurus/useGlobalData";
-import { Integrations, integrationsSchema } from "./schema";
+import { parseIntegrations } from "./schema";
 
 const pluginKey = "ngrok-parse-integrations" as const;
 
-export function useIntegrations(): Integrations {
+export function useIntegrations() {
 	const rawData = usePluginData(pluginKey);
-	try {
-		return integrationsSchema.parse(rawData);
-	} catch (error) {
-		console.error(error);
-		return [];
-	}
+	return parseIntegrations(rawData);
 }
 
 export function useIntegration(name: string) {

--- a/src/components/integrations/use-integrations.tsx
+++ b/src/components/integrations/use-integrations.tsx
@@ -1,0 +1,23 @@
+import { usePluginData } from "@docusaurus/useGlobalData";
+import { Integrations, integrationsSchema } from "./schema";
+
+const pluginKey = "ngrok-parse-integrations" as const;
+
+export function useIntegrations(): Integrations {
+	const rawData = usePluginData(pluginKey);
+	try {
+		return integrationsSchema.parse(rawData);
+	} catch (error) {
+		console.error(error);
+		return [];
+	}
+}
+
+export function useIntegration(name: string) {
+	const integrations = useIntegrations();
+
+	// case insensitive search
+	return integrations.find(
+		(item) => item.name.toLowerCase() === name.toLowerCase(),
+	);
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /**
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to

--- a/src/plugins/tailwindcss.js
+++ b/src/plugins/tailwindcss.js
@@ -1,0 +1,11 @@
+module.exports = async function myPlugin(context, options) {
+	return {
+		name: "docusaurus-tailwindcss",
+		configurePostCss(postcssOptions) {
+			// Appends TailwindCSS and AutoPrefixer.
+			postcssOptions.plugins.push(require("tailwindcss"));
+			postcssOptions.plugins.push(require("autoprefixer"));
+			return postcssOptions;
+		},
+	};
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+	content: ["./src/**/*.{js,jsx,ts,tsx}"],
+	theme: {
+		extend: {},
+	},
+	plugins: [],
+	corePlugins: {
+		preflight: false,
+	},
+};


### PR DESCRIPTION
Make integration page data loading safer and simplify rendering logic

- adds tailwind support
- uses zod for defining the integration schemas and type safe parsing
- simplifies the rendering logic in integration pages (use css for layout, not confusing js methods with `:any` sprinkled everywhere)

shortcut: https://ngrok-docs-git-cody-fix-integration-page-list-ngrok-dev.vercel.app/docs/integrations