### PR TITLE
Update config.mdx with tip about labels and domains

### DIFF
--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -219,6 +219,12 @@ Each tunnel you define is a map of configuration option names to values. The nam
           - team=development
         addr: 22
 
+:::tip
+
+When you used labeled tunnels, the `protocol` and `domain` are configured by the matching edge.
+
+:::
+
 ## Global Configuration
 
 The following is a list of options that can be configured at the root of your configuration file and specify the behavior of the agent.


### PR DESCRIPTION
The `domain` and `protocol` don't go along with the `labels`, so the doc better reflect that

See discussion in https://github.com/ngrok/ngrok-docs/issues/481 