### PR TITLE
Fixing minor typo in Authtoken section

### DIFF
--- a/docs/agent/index.mdx
+++ b/docs/agent/index.mdx
@@ -125,7 +125,7 @@ API](/agent/config/#authtoken). Separate authtokens isolate the security risk
 if an authtoken is compromised. It also allows you to configure
 [ACLs](#authtoken-acls) on a per agent basis.
 
-When you provision a new authtoken, the full token is only once. As a security
+When you provision a new authtoken, the full token is only displayed once. As a security
 feature, ngrok does not store a recoverable representation of the token.
 
 ## Authtoken ACLs


### PR DESCRIPTION
The original text said "When you provision a new authtoken, the full token is only once.", which is an incomplete sentence. Updated the sentence to indicate that it is displayed once.