### PR TITLE
Update JS SDK links

### DIFF
--- a/docs/agent-sdks/index.mdx
+++ b/docs/agent-sdks/index.mdx
@@ -40,13 +40,13 @@ ngrok's edge just as if you opened a socket to listen on a port.
 
 ## Supported Languages
 
-| Language   | Docs                                                       | Quickstart                                      | Repository                                                             | Status |
-| ---------- | ---------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- | ------ |
-| Go         | [ngrok-go docs](https://pkg.go.dev/golang.ngrok.com/ngrok) | [ngrok-go quickstart](/getting-started/go/)     | [github.com/ngrok/ngrok-go](https://github.com/ngrok/ngrok-go)         | Stable |
-| Rust       | [ngrok-rust docs](https://docs.rs/ngrok/latest/ngrok/)     | [ngrok-rust quickstart](/getting-started/rust/) | [github.com/ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust)     | Stable |
-| Python     | [ngrok-python docs](https://ngrok.github.io/ngrok-python/) |                                                 | [github.com/ngrok/ngrok-python](https://github.com/ngrok/ngrok-python) | Beta   |
-| JavaScript | [ngrok-nodejs docs](https://ngrok.github.io/ngrok-nodejs/) |                                                 | [github.com/ngrok/ngrok-nodejs](https://github.com/ngrok/ngrok-nodejs) | Beta   |
-| Java       |                                                            |                                                 | [github.com/ngrok/ngrok-java](https://github.com/ngrok/ngrok-java)     | Alpha  |
+| Language   | Docs                                                               | Quickstart                                      | Repository                                                                     | Status |
+| ---------- | ------------------------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------ | ------ |
+| Go         | [ngrok-go docs](https://pkg.go.dev/golang.ngrok.com/ngrok)         | [ngrok-go quickstart](/getting-started/go/)     | [github.com/ngrok/ngrok-go](https://github.com/ngrok/ngrok-go)                 | Stable |
+| Rust       | [ngrok-rust docs](https://docs.rs/ngrok/latest/ngrok/)             | [ngrok-rust quickstart](/getting-started/rust/) | [github.com/ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust)             | Stable |
+| Python     | [ngrok-python docs](https://ngrok.github.io/ngrok-python/)         |                                                 | [github.com/ngrok/ngrok-python](https://github.com/ngrok/ngrok-python)         | Beta   |
+| JavaScript | [ngrok-javascript docs](https://ngrok.github.io/ngrok-javascript/) |                                                 | [github.com/ngrok/ngrok-javascript](https://github.com/ngrok/ngrok-javascript) | Beta   |
+| Java       |                                                                    |                                                 | [github.com/ngrok/ngrok-java](https://github.com/ngrok/ngrok-java)             | Alpha  |
 
 ## When should I use Agent SDKs?
 


### PR DESCRIPTION
We updated the JS SDK from ngrok-nodejs to ngrok-javascript. Updating the links since docs link did not forward and was broken.