### PR TITLE
Arrows hotfix

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -277,11 +277,11 @@ article a:focus {
 }
 
 .pagination-nav__link--prev .pagination-nav__label::before {
-	content: "← ";
+	content: "\2190\0020";
 }
 
 .pagination-nav__link--next .pagination-nav__label::after {
-	content: " →";
+	content: "\0020\2192";
 }
 
 /* Left drawer menu */


### PR DESCRIPTION
Closes #491. Follow up question though, the page has `<meta charset="utf-8">` set, so it's odd to me that this would show up as weird characters. Hmm!