### PR TITLE
Fixing all the split infinitives in Docs

### DIFF
--- a/docs/http/request-headers.mdx
+++ b/docs/http/request-headers.mdx
@@ -101,7 +101,7 @@ foo: baz
 
 :::note
 
-There is a bug which currently causes the above behavior to not be correct.
+There is a bug which currently causes the above behavior not to be correct.
 Only the last header will be used when specifying multiple headers. This behavior
 will be fixed to match what is documented above.
 

--- a/docs/http/response-headers.mdx
+++ b/docs/http/response-headers.mdx
@@ -89,7 +89,7 @@ foo: baz
 
 :::note
 
-There is a bug which currently causes the above behavior to not be correct.
+There is a bug which currently causes the above behavior not to be correct.
 Only the last header will be used when specifying multiple headers. This behavior
 will be fixed to match what is documented above.
 

--- a/docs/network-edge/index.mdx
+++ b/docs/network-edge/index.mdx
@@ -78,7 +78,7 @@ provisioning one automatically if necessary.
 | Endpoint Type        | Behavior                                                                                                                                                                                                                         |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [HTTPS](/docs/http/) | ngrok always terminates TLS on connections to HTTPS endpoints at the ngrok edge. Traffic is re-encrypted with TLS as it is transmitted to your upstream service via the [Agent](/agent/).                                        |
-| [TLS](/docs/tls/)    | TLS endpoints may be configured to terminate TLS at the ngrok edge or to not terminate TLS. When a TLS endpoint is configured to not terminate TLS at ngrok's edge, we call this [Zero-Knowledge TLS](/tls/#zero-knowledge-tls). |
+| [TLS](/docs/tls/)    | TLS endpoints may be configured to terminate TLS at the ngrok edge or not to terminate TLS. When a TLS endpoint is configured not to terminate TLS at ngrok's edge, we call this [Zero-Knowledge TLS](/tls/#zero-knowledge-tls). |
 | [TCP](/docs/tcp/)    | TCP endpoints are unaware of higher layer protocols like TLS and thus never terminate TLS.                                                                                                                                       |
 
 ## DDoS Protection


### PR DESCRIPTION
Fixed all the split infinitives in Docs