### PR TITLE
tcp tunnels: region is no longer required with the advent of cross-region tcp tunnels

### DIFF
--- a/docs/network-edge/gslb.mdx
+++ b/docs/network-edge/gslb.mdx
@@ -137,10 +137,6 @@ you must select the point of presence where it will accept traffic. Unlike
 ngrok's globally routed domains, traffic to TCP addresses always enters ngrok's
 network from that point of presence.
 
-Moreover, when you use a TCP address, you must [explicitly select the region of
-the ngrok agent](#explicit-region-selection). This is a temporary limitation
-that we are working to remove.
-
 ## Agents
 
 ngrok's GSLB automatically improves the performance and resiliency of your

--- a/examples/agent-cli/tcp-fixed.mdx
+++ b/examples/agent-cli/tcp-fixed.mdx
@@ -1,3 +1,3 @@
 ```bash
-ngrok tcp 3389 --region eu --remote-addr 1.tcp.eu.ngrok.io:12345
+ngrok tcp 3389 --remote-addr 1.tcp.eu.ngrok.io:12345
 ```

--- a/examples/agent-config/tcp-fixed.mdx
+++ b/examples/agent-config/tcp-fixed.mdx
@@ -1,5 +1,4 @@
 ```yaml
-region: eu
 tunnels:
   example:
     proto: tcp


### PR DESCRIPTION
Now folks don't need to care about regions for TCP tunnels!

See https://github.com/ngrok-private/ngrok/issues/23493