### PR TITLE
Update typo for the usage of the CLI `ngrok http` command 

### DIFF
--- a/examples/agent-cli/http-schemes.mdx
+++ b/examples/agent-cli/http-schemes.mdx
@@ -1,3 +1,3 @@
 ```bash
-ngrok http 80 --schemes http,https
+ngrok http 80 --scheme http,https
 ```


### PR DESCRIPTION
The additional option for selecting what schemes to forward on is `--scheme` not `--schemes`

![Screenshot 2023-12-03 at 1 18 56 AM](https://github.com/ngrok/ngrok-docs/assets/26232349/d03b5286-a9f0-43d0-93d7-67a285379e11)
