### PR TITLE
add ~/.ssh/id_ed25519.pub to ssh-reverse-tunnel-agent

### DIFF
--- a/docs/agent/ssh-reverse-tunnel-agent.mdx
+++ b/docs/agent/ssh-reverse-tunnel-agent.mdx
@@ -91,11 +91,23 @@ Copy your default SSH public key with:
 cat ~/.ssh/id_rsa.pub | pbcopy
 ```
 
+or:
+
+```bash
+cat ~/.ssh/id_ed25519.pub | pbcopy
+```
+
 </TabItem>
 <TabItem value="linux" label="Linux">
 
 ```bash
 cat ~/.ssh/id_rsa.pub
+```
+
+or:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
 ```
 
 </TabItem>


### PR DESCRIPTION
Mention `id_ed25519.pub` since that is the ssh default now.