### PR TITLE
batch of formatting fixes (missed in docusaurus v3 upgrade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See our [Contribution Guidelines](CONTRIBUTING.md) for detailed instructions on 
 
 ## Setup
 
-ngrok is built using [Docusaurus 2](https://docusaurus.io/).
+ngrok is built using [Docusaurus 3](https://docusaurus.io/).
 
 Prerequisites required:
 

--- a/docs/agent/api.md
+++ b/docs/agent/api.md
@@ -31,7 +31,7 @@ The ngrok agent API is exposed as part of ngrok's local web inspection interface
 
 ### Access the root API resource of a running ngrok agent
 
-```
+```sh
 curl http://localhost:4040/api/
 ```
 
@@ -67,45 +67,45 @@ GET/api/tunnels
 ### Example Response
 
 ```
-    {
-      "tunnels": [
-          {
-              "name": "command_line",
-              "uri": "/api/tunnels/command_line",
-              "public_url": "https://d95211d2.ngrok.io",
-              "proto": "https",
-              "config": {
-                  "addr": "localhost:80",
-                  "inspect": true,
-              },
-              "metrics": {
-                  "conns": {
-                      "count": 0,
-                      "gauge": 0,
-                      "rate1": 0,
-                      "rate5": 0,
-                      "rate15": 0,
-                      "p50": 0,
-                      "p90": 0,
-                      "p95": 0,
-                      "p99": 0
-                  },
-                  "http": {
-                      "count": 0,
-                      "rate1": 0,
-                      "rate5": 0,
-                      "rate15": 0,
-                      "p50": 0,
-                      "p90": 0,
-                      "p95": 0,
-                      "p99": 0
-                  }
-              }
-          },
-          ...
-      ],
-      "uri": "/api/tunnels"
-    }
+{
+    "tunnels": [
+        {
+            "name": "command_line",
+            "uri": "/api/tunnels/command_line",
+            "public_url": "https://d95211d2.ngrok.io",
+            "proto": "https",
+            "config": {
+                "addr": "localhost:80",
+                "inspect": true,
+            },
+            "metrics": {
+                "conns": {
+                    "count": 0,
+                    "gauge": 0,
+                    "rate1": 0,
+                    "rate5": 0,
+                    "rate15": 0,
+                    "p50": 0,
+                    "p90": 0,
+                    "p95": 0,
+                    "p99": 0
+                },
+                "http": {
+                    "count": 0,
+                    "rate1": 0,
+                    "rate5": 0,
+                    "rate15": 0,
+                    "p50": 0,
+                    "p90": 0,
+                    "p95": 0,
+                    "p99": 0
+                }
+            }
+        },
+        ...
+    ],
+    "uri": "/api/tunnels"
+}
 ```
 
 ## Start tunnel
@@ -249,7 +249,9 @@ GET/api/requests/http
 
 ### Example Request
 
-    curl http://localhost:4040/api/requests/http?limit=50
+```sh
+curl http://localhost:4040/api/requests/http?limit=50
+```
 
 ### Response
 
@@ -330,7 +332,7 @@ POST/api/requests/http
 
 ### Example Request
 
-```
+```sh
 curl -H "Content-Type: application/json" -d '{"id": "548fb5c700000002"}' http://localhost:4040/api/requests/http
 ```
 

--- a/docs/agent/changelog.md
+++ b/docs/agent/changelog.md
@@ -148,10 +148,12 @@ This change was made to help protect against maliciously crafted web pages that 
 
 Behavior changes for `http` and `tls` tunnels defined in the configuration file or started via the API that do not have a `subdomain` or `hostname` property.
 
-    tunnels:
-      webapp:
-        proto: http
-        addr: 80
+```yaml
+tunnels:
+  webapp:
+    proto: http
+    addr: 80
+```
 
 Given this example tunnel configuration, behavior will change in the following ways.
 
@@ -167,8 +169,10 @@ Starts a tunnel with a random subdomain, for example a URL like `http://d95211d2
 
 Add a `domain` property with the same name as the tunnel:
 
-    tunnels:
-      webapp:
-        proto: http
-        addr: 80
-        domain: webapp.ngrok.io
+```yaml
+tunnels:
+  webapp:
+    proto: http
+    addr: 80
+    domain: webapp.ngrok.io
+```

--- a/docs/agent/cli.mdx
+++ b/docs/agent/cli.mdx
@@ -11,7 +11,7 @@ The root command of the ngrok agent.
 
 ### Usage
 
-```
+```sh
 ngrok [flags]
 ngrok [command]
 ```
@@ -54,7 +54,7 @@ These commands mirror our standard [ngrok HTTP API](/api). If you have [shell co
 
 ### Usage
 
-```
+```sh
 ngrok api [flags]
 ```
 
@@ -104,21 +104,25 @@ The `ngrok completion` command generates shell tab completion code for Bash or Z
 
 You can add it to your current session with the command
 
-```
+```sh
 . <(ngrok completion)
 ```
 
 To enable them each time you start a new session, add the following to your `.bashrc` or `.zshrc` files:
 
-    if command -v ngrok &>/dev/null; then
-      eval "$(ngrok completion)"
-    fi
+```bash
+if command -v ngrok &>/dev/null; then
+    eval "$(ngrok completion)"
+fi
+```
 
 Once you add this to your profile, you'll need to `source ~/.bashrc` or `source ~/.zshrc` to enable it for your current session.
 
 ### Usage
 
-    ngrok completion [flags]
+```sh
+ngrok completion [flags]
+```
 
 ### Flags
 
@@ -136,7 +140,9 @@ Use `check` to test a configuration file for validity. If you have an old config
 
 ### Usage
 
-    ngrok config [flags]
+```sh
+ngrok config [flags]
+```
 
 ### Commands
 
@@ -160,11 +166,15 @@ The `ngrok config add-api-key` command saves the ngrok API key to the configurat
 
 ### Usage
 
-    ngrok config add-api-key TOKEN [flags]
+```sh
+ngrok config add-api-key TOKEN [flags]
+```
 
 ### Examples
 
-    ngrok config add-api-key 1roPsn7AascHeO18mHcxRD3xT76_3ww7C9CDLYNgcdSYsscCB
+```sh
+ngrok config add-api-key 1roPsn7AascHeO18mHcxRD3xT76_3ww7C9CDLYNgcdSYsscCB
+```
 
 ### Flags
 
@@ -184,11 +194,15 @@ The ngrok service requires that you [sign up for an account](https://dashboard.n
 
 ### Usage
 
-    ngrok config add-authtoken TOKEN [flags]
+```sh
+ngrok config add-authtoken TOKEN [flags]
+```
 
 ### Examples
 
-    ngrok config add-authtoken 1rlHSX3HqrqmOWZdeJ6bIv8rfuo_4cmS1QswRGyxcQD8NOukF
+```sh
+ngrok config add-authtoken 1rlHSX3HqrqmOWZdeJ6bIv8rfuo_4cmS1QswRGyxcQD8NOukF
+```
 
 ### Flags
 
@@ -206,7 +220,9 @@ The `ngrok config check` command checks a configuration file for validity/correc
 
 ### Usage
 
-    ngrok config check [flags]
+```sh
+ngrok config check [flags]
+```
 
 ### Flags
 
@@ -224,7 +240,9 @@ The `ngrok config edit` command opens the configuration file in an editor define
 
 ### Usage
 
-    ngrok config edit [flags]
+```sh
+ngrok config edit [flags]
+```
 
 ### Flags
 
@@ -248,7 +266,9 @@ By default this command will not move any configuration files to their new defau
 
 ### Usage
 
-    ngrok config upgrade [version] [flags]
+```sh
+ngrok config upgrade [version] [flags]
+```
 
 ### Flags
 
@@ -268,7 +288,9 @@ The `ngrok credits` command displays the software credits and license informatio
 
 ### Usage
 
-    ngrok credits [flags]
+```sh
+ngrok credits [flags]
+```
 
 ### Flags
 
@@ -282,7 +304,9 @@ The `ngrok diagnose` command runs a series of tests to diagnose potential connec
 
 ### Usage
 
-    ngrok diagnose [flags]
+```sh
+ngrok diagnose [flags]
+```
 
 ### Flags
 
@@ -299,7 +323,9 @@ The `ngrok help` command provides help for any command in the application. Simpl
 
 ### Usage
 
-    ngrok help [command] [flags]
+```sh
+ngrok help [command] [flags]
+```
 
 ### Flags
 
@@ -313,18 +339,22 @@ The `ngrok http` command is used to start a tunnel listening for HTTP/HTTPS traf
 
 ### Usage
 
-    ngrok http [address:port | port] [flags]
+```sh
+ngrok http [address:port | port] [flags]
+```
 
 ### Examples
 
-    ngrok http 8080                             # forwards provided ngrok URL to port 80
-    ngrok http example.com:9000                 # forward traffic to example.com:9000
-    ngrok http --domain=bar.ngrok.dev 80        # request subdomain name: 'bar.ngrok.dev'
-    ngrok http --domain=www.ex.com 1234         # request tunnel 'www.ex.com' (DNS CNAME)
-    ngrok http --basic-auth='falken:joshua' 80  # enforce basic auth on tunnel endpoint
-    ngrok http --host-header=ex.com 80          # rewrite the Host header to 'ex.com'
-    ngrok http file:///var/log                  # serve local files in /var/log
-    ngrok http https://localhost:8443           # forward to a local https server
+```sh
+ngrok http 8080                             # forwards provided ngrok URL to port 80
+ngrok http example.com:9000                 # forward traffic to example.com:9000
+ngrok http --domain=bar.ngrok.dev 80        # request subdomain name: 'bar.ngrok.dev'
+ngrok http --domain=www.ex.com 1234         # request tunnel 'www.ex.com' (DNS CNAME)
+ngrok http --basic-auth='falken:joshua' 80  # enforce basic auth on tunnel endpoint
+ngrok http --host-header=ex.com 80          # rewrite the Host header to 'ex.com'
+ngrok http file:///var/log                  # serve local files in /var/log
+ngrok http https://localhost:8443           # forward to a local https server
+```
 
 ### Flags
 
@@ -376,13 +406,17 @@ When the ngrok service runs, it has the same behavior as if it were invoked from
 
 ### Usage
 
-    ngrok service [flags]
+```sh
+ngrok service [flags]
+```
 
 ### Examples
 
-    ngrok service install --config=C:\ngrok.yml
-    ngrok service start
-    ngrok service stop
+```sh
+ngrok service install --config=C:\ngrok.yml
+ngrok service start
+ngrok service stop
+```
 
 ### Flags
 
@@ -397,13 +431,17 @@ The `ngrok start` command starts tunnels by name from the configuration file. Yo
 
 ### Usage
 
-    ngrok start [flags]
+```sh
+ngrok start [flags]
+```
 
 ### Examples
 
-    ngrok start dev        # start tunnel named 'dev' in the configuration file
-    ngrok start web blog   # start tunnels named 'web' and 'blog'
-    ngrok start --all      # start all tunnels defined in the config file
+```sh
+ngrok start dev        # start tunnel named 'dev' in the configuration file
+ngrok start web blog   # start tunnels named 'web' and 'blog'
+ngrok start --all      # start all tunnels defined in the config file
+```
 
 ### Flags
 
@@ -427,15 +465,21 @@ A TCP tunnel binds a public address on the remote ngrok server. Any services whi
 
 ### Usage
 
-    ngrok tcp [address:port | port] [flags]
+```sh
+ngrok tcp [address:port | port] [flags]
+```
 
 ### Examples
 
-    # forward a port to your local ssh server
-    ngrok tcp 22
+```sh
+# forward a port to your local ssh server
+ngrok tcp 22
+```
 
-    # expose an RDP server on a specific public address that you reserved
-    ngrok tcp --remote-addr=1.tcp.ngrok.io:27210 3389
+```sh
+# expose an RDP server on a specific public address that you reserved
+ngrok tcp --remote-addr=1.tcp.ngrok.io:27210 3389
+```
 
 ### Flags
 
@@ -463,18 +507,26 @@ Using this command is only recommended with the `--domain` option. Other uses wi
 
 ### Usage
 
-    ngrok tls [address:port | port] [flags]
+```sh
+ngrok tls [address:port | port] [flags]
+```
 
 ### Examples
 
-    # forward TLS traffic for www.example.com to port 443 (requires CNAME)
-    ngrok tls --domain=www.example.com 443
+```sh
+# forward TLS traffic for www.example.com to port 443 (requires CNAME)
+ngrok tls --domain=www.example.com 443
+```
 
-    # forward TLS traffic on subdomain (mismatch certificate warning)
-    ngrok tls 1234
+```sh
+# forward TLS traffic on subdomain (mismatch certificate warning)
+ngrok tls 1234
+```
 
-    # terminate TLS traffic for t.co before forwarding
-    ngrok tls --domain=t.co --crt=/path/to/t.co.crt --key=/path/to/t.co.key 443
+```sh
+# terminate TLS traffic for t.co before forwarding
+ngrok tls --domain=t.co --crt=/path/to/t.co.crt --key=/path/to/t.co.key 443
+```
 
 ### Flags
 
@@ -504,15 +556,21 @@ Starts a tunnel with labels so that it can be part of a tunnel group. The tunnel
 
 ### Examples
 
-    # tunnel-group traffic for app=foo may be forwarded to port 80
-    ngrok tunnel --label app=foo 80
+```sh
+# tunnel-group traffic for app=foo may be forwarded to port 80
+ngrok tunnel --label app=foo 80
+```
 
-    # match tunnel-group with multiple labels
-    ngrok tunnel --label app=foo --label dc=bar 80
+```sh
+# match tunnel-group with multiple labels
+ngrok tunnel --label app=foo --label dc=bar 80
+```
 
 ### Usage
 
-    ngrok tunnel [--label key:value] ... [address:port | port] [flags]
+```sh
+ngrok tunnel [--label key:value] ... [address:port | port] [flags]
+```
 
 ### Flags
 
@@ -541,12 +599,16 @@ In order to update successfully, the ngrok binary must be in a directory that is
 
 ### Examples
 
-    ngrok update                     - update ngrok to the latest stable version
-    ngrok update --channel=beta      - update ngrok to the latest beta version
+```sh
+ngrok update                     - update ngrok to the latest stable version
+ngrok update --channel=beta      - update ngrok to the latest beta version
+```
 
 ### Usage
 
-    ngrok update [flags]
+```sh
+ngrok update [flags]
+```
 
 ### Flags
 
@@ -562,7 +624,9 @@ In order to update successfully, the ngrok binary must be in a directory that is
 
 ### Usage
 
-    ngrok version [flags]
+```sh
+ngrok version [flags]
+```
 
 ### Flags
 

--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -14,7 +14,9 @@ some of its more advanced settings.
 
 The default location of the ngrok agent's configuration file varies based on your operating system. The easiest way to find the configuration file location is to run:
 
-    ngrok config check
+```sh
+ngrok config check
+```
 
 which will validate and print the location of the configuration file.
 
@@ -38,7 +40,7 @@ merging are as follows:
 
 Below is an example configuration file with all the options filled in.
 
-```
+```yaml
 authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
 api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
 connect_timeout: 30s
@@ -114,20 +116,24 @@ property in your configuration file.
 
 ##### Define two tunnels named 'httpbin' and 'demo'
 
-    tunnels:
-      httpbin:
-        proto: http
-        addr: 8000
-        domain: alan-httpbin.ngrok.dev
-      demo:
-        proto: http
-        addr: 9090
-        domain: demo.inconshreveable.com
-        inspect: false
+```yaml
+tunnels:
+  httpbin:
+    proto: http
+    addr: 8000
+    domain: alan-httpbin.ngrok.dev
+  demo:
+    proto: http
+    addr: 9090
+    domain: demo.inconshreveable.com
+    inspect: false
+```
 
 ##### Start the tunnel named 'httpbin'
 
-    ngrok start httpbin
+```sh
+ngrok start httpbin
+```
 
 Each tunnel you define is a map of configuration option names to values. The name of a configuration option is usually the same as its corresponding command line switch with hyphens (`--host-header` becomes `host_header:` in the configuration file and `--scheme` becomes `schemes`. Tunnels can define a specific `proto` or use labels to dynamically connect to one or more matching ngrok Edges. All tunnels must define a specific `addr` that tells the agent where to send the traffic. Other properties are available and many are protocol-specific.
 
@@ -205,19 +211,21 @@ Each tunnel you define is a map of configuration option names to values. The nam
 
 ##### Define two labeled tunnels
 
-    tunnels:
-      my-cool-website:
-        labels:
-          - env=prod
-          - team=infra
-        addr: 8000
-        inspect: false
-      ssh-tunnel:
-        labels:
-          - hostname=my-hostname
-          - service=ssh
-          - team=development
-        addr: 22
+```yaml
+tunnels:
+  my-cool-website:
+    labels:
+      - env=prod
+      - team=infra
+    addr: 8000
+    inspect: false
+  ssh-tunnel:
+    labels:
+      - hostname=my-hostname
+      - service=ssh
+      - team=development
+    addr: 22
+```
 
 :::tip
 
@@ -262,7 +270,9 @@ This option specifies the API key used to access the ngrok API through the [`ngr
 
 ##### ngrok.yml specifying an API key
 
-    api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
+```yaml
+api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
+```
 
 ### `authtoken`
 
@@ -272,7 +282,9 @@ Your authtoken will work on multiple machines if you are just developing. When y
 
 ##### ngrok.yml specifying an authtoken
 
-    authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
+```yaml
+authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
+```
 
 ### `connect_timeout`
 
@@ -344,13 +356,17 @@ This is the destination where ngrok should write the logs.
 | `false`      | default | disable logging                        |
 | other values |         | write log records to file path on disk |
 
-    log: /var/log/ngrok.log
+```yaml
+log: /var/log/ngrok.log
+```
 
 ### `metadata`
 
 This is a user-supplied custom string that will be returned as part of the ngrok API response to the [list online sessions resource](/api/resources/tunnel-sessions) for all tunnels started by this agent. This is a useful mechanism to identify tunnels by your own device or customer identifier. Maximum 4096 characters.
 
-    metadata: bad8c1c0-8fce-11e4-b4a9-0800200c9a66
+```yaml
+metadata: bad8c1c0-8fce-11e4-b4a9-0800200c9a66
+```
 
 ### `proxy_url`
 
@@ -436,6 +452,8 @@ These are a list of specifiers for what Host headers will be allowed to make req
 
 ##### Allow an IP address and a Domain as Host headers
 
-    web_allow_hosts:
-      - 8.8.8.8
-      - example.com
+```yaml
+web_allow_hosts:
+  - 8.8.8.8
+  - example.com
+```

--- a/docs/agent/index.mdx
+++ b/docs/agent/index.mdx
@@ -32,9 +32,7 @@ CLI for calling the [ngrok API](/api/).
 
 ## Install
 
-Follow the [getting started
-guide](/getting-started/#step-2-install-the-ngrok-agent) or visit the [download
-page](https://ngrok.com/download) to install and set up the ngrok agent.
+Follow the [getting started guide](/getting-started/#step-2-install-the-ngrok-agent) or visit the [download page](https://ngrok.com/download) to install and set up the ngrok agent.
 
 ## Example Usage
 
@@ -99,27 +97,21 @@ shell. Add tab-completion to your shell session with:
 . <(ngrok completion>
 ```
 
-Install it permanently by following the documentation for the [`ngrok completion`
-command](/agent/cli/#ngrok-completion).
+Install it permanently by following the documentation for the [`ngrok completion` command](/agent/cli/#ngrok-completion).
 
 ## Authtokens
 
-The ngrok agent authenticates with an authtoken. [Your authtoken is available
-on the ngrok
-dashboard](https://dashboard.ngrok.com/get-started/your-authtoken). Add your
-authtoken to the ngrok agent with the following command:
+The ngrok agent authenticates with an authtoken.
+[Your authtoken is available on the ngrok dashboard](https://dashboard.ngrok.com/get-started/your-authtoken).
+Add your authtoken to the ngrok agent with the following command:
 
 ```bash
 ngrok config add-authtoken <TOKEN>
 ```
 
-This command updates the `authtoken` property in your [ngrok configuration
-file](/agent/config).
+This command updates the `authtoken` property in your [ngrok configurationfile](/agent/config).
 
-Use a separate authtoken for each agent you configure. You can [provision
-additional authtokens on your ngrok
-dashboard](https://dashboard.ngrok.com/tunnels/authtokens) or [via
-API](/agent/config/#authtoken). Separate authtokens isolate the security risk
+Use a separate authtoken for each agent you configure. You can [provision additional authtokens on your ngrok dashboard](https://dashboard.ngrok.com/tunnels/authtokens) or [via API](/agent/config/#authtoken). Separate authtokens isolate the security risk
 if an authtoken is compromised. It also allows you to configure
 [ACLs](#authtoken-acls) on a per agent basis.
 
@@ -142,11 +134,9 @@ ACLs may take all actions. The following ACLs are supported:
 
 ## API Keys
 
-The ngrok agent contains a [complete CLI for the ngrok
-API](/agent/cli/#ngrok-api).
+The ngrok agent contains a [complete CLI for the ngrok API](/agent/cli/#ngrok-api).
 
-To use it, [create an API Key on your ngrok
-dashboard](https://dashboard.ngrok.com/api) and then run:
+To use it, [create an API Key on your ngrok dashboard](https://dashboard.ngrok.com/api) and then run:
 
 ```bash
 ngrok config add-api-key <API KEY>
@@ -250,8 +240,7 @@ services.
 ### Address {#connectivity-address}
 
 By default, the ngrok agent dials the following "agent ingress address" when it
-connects to the ngrok service. This address resolves to a [dyanmic set of IP
-Addresses](/network-edge/#ip-addresses).
+connects to the ngrok service. This address resolves to a [dyanmic set of IP Addresses](/network-edge/#ip-addresses).
 
 ```
 connect.ngrok-agent.com:443
@@ -329,21 +318,21 @@ to diagnose potential issues when connecting to the ngrok service. Consult the
 [`ngrok diagnose` documentation](/agent/cli/#ngrok-diagnose) for additional
 details.
 
-```
-    $ ngrok diagnose
-    Testing ngrok connectivity...
+```sh
+$ ngrok diagnose
+  Testing ngrok connectivity...
 
-    Internet Connectivity
-      Name Resolution                           [ OK ]
-      TCP                                       [ OK ]
-      TLS                                       [ OK ]
-    Ngrok Connectivity
-      Name Resolution                           [ OK ]
-      TCP                                       [ OK ]
-      TLS                                       [ OK ]
-      Tunnel Protocol                           [ OK ]
+  Internet Connectivity
+    Name Resolution                           [ OK ]
+    TCP                                       [ OK ]
+    TLS                                       [ OK ]
+  Ngrok Connectivity
+    Name Resolution                           [ OK ]
+    TCP                                       [ OK ]
+    TLS                                       [ OK ]
+    Tunnel Protocol                           [ OK ]
 
-    Successfully established ngrok connection! (region: 'us', latency: 112.461875ms)
+  Successfully established ngrok connection! (region: 'us', latency: 112.461875ms)
 ```
 
 ## System Requirements
@@ -351,8 +340,7 @@ details.
 #### Supported Platforms
 
 The ngrok agent runs on all major platforms including Linux, MacOS, Windows and
-most CPU architectures. See the [ngrok agent
-download](https://ngrok.com/download) page. It is also distributed as a Docker
+most CPU architectures. See the [ngrok agent download](https://ngrok.com/download) page. It is also distributed as a Docker
 container.
 
 | OS      | Supported Architectures                                                                              |
@@ -363,17 +351,14 @@ container.
 | FreeBSD | `x86-64`, `x86`, `arm`, `arm64`                                                                      |
 
 If the agent does not run on your target platfom, you can still use ngrok via
-the [Agent SDKs](/agent-sdks/) or the [SSH Reverse Tunnel
-Agent](/agent/ssh-reverse-tunnel-agent).
+the [Agent SDKs](/agent-sdks/) or the [SSH Reverse Tunnel Agent](/agent/ssh-reverse-tunnel-agent).
 
 #### Resource Requirements
 
 The ngrok agent is lightweight enough to run most everywhere, even on many
 embedded platforms. Keep in mind that the ngrok agent's resource usage depends
 on how much concurrent traffic you drive through it. If your resource
-requirements are more stringent, you can still use ngrok via the [Agent
-SDKs](/agent-sdks) or the [SSH Reverse Tunnel
-Agent](/agent/ssh-reverse-tunnel-agent).
+requirements are more stringent, you can still use ngrok via the [Agent SDKs](/agent-sdks) or the [SSH Reverse Tunnel Agent](/agent/ssh-reverse-tunnel-agent).
 
 | Resource | Value                           |
 | -------- | ------------------------------- |
@@ -391,8 +376,7 @@ You can reduce memory usage in the ngrok agent by disabling
 ## Updates
 
 The ngrok agent can update itself even if you didn't install it with a package
-manager. Update the ngrok agent with the [`ngrok
-update`](/agent/cli/#ngrok-update) command.
+manager. Update the ngrok agent with the [`ngrok update`](/agent/cli/#ngrok-update) command.
 
 ```bash
 ngrok update
@@ -404,8 +388,7 @@ runs. If an update is available, it will prompt you to update by pressing
 [`update_check` config parameter](/agent/config/#update_check).
 
 You can configure which release channel (e.g. `stable`, `beta`) the agent uses
-for updates via the [`update_channel` config
-parameter](/agent/config/#update_channel).
+for updates via the [`update_channel` config parameter](/agent/config/#update_channel).
 
 ## IP Restrictions
 
@@ -424,8 +407,7 @@ start and stop tunnels on the agent while it is running. Consult the
 
 :::tip
 
-If you want to programmatically control the ngrok agent, the [Agent
-SDKs](/agent-sdks/) are usually a more flexible and powerful choice.
+If you want to programmatically control the ngrok agent, the [Agent SDKs](/agent-sdks/) are usually a more flexible and powerful choice.
 
 :::
 
@@ -447,8 +429,7 @@ You may want to use ngrok with one of the alternatives above if:
 
 ## Changelog
 
-We publish the [ngrok agent
-changelog](/agent/changelog) with details on
+We publish the [ngrok agent changelog](/agent/changelog) with details on
 each release of the ngrok agent.
 
 ## Pricing

--- a/docs/errors/details/_err_ngrok_8012.md
+++ b/docs/errors/details/_err_ngrok_8012.md
@@ -1,14 +1,14 @@
 ### Troubleshooting
 
-```mdx-code-block
-import ReactPlayer from 'react-player/lazy'
+```tsx
+import ReactPlayer from "react-player/lazy";
 
-<div className='player-wrapper'>
-  <ReactPlayer
-    className='react-player'
-    url='https://www.youtube.com/watch?v=OPPBz5QeMp4'
-    width='100%'
-    height='100%'
-  />
-</div>
+<div className="player-wrapper">
+	<ReactPlayer
+		className="react-player"
+		url="https://www.youtube.com/watch?v=OPPBz5QeMp4"
+		width="100%"
+		height="100%"
+	/>
+</div>;
 ```

--- a/docs/guides/getting-started.mdx
+++ b/docs/guides/getting-started.mdx
@@ -65,55 +65,55 @@ If you don't have one of these package managers installed or prefer to install t
 
 You can test everything is working by running `ngrok -h` which should print the help text for the ngrok agent.
 
-```
-    $ ngrok -h
-    NAME:
-      ngrok - tunnel local ports to public URLs and inspect traffic
+```sh
+$ ngrok -h
+  NAME:
+    ngrok - tunnel local ports to public URLs and inspect traffic
 
-    USAGE:
-      ngrok [command] [flags]
+  USAGE:
+    ngrok [command] [flags]
 
-    DESCRIPTION:
-      ngrok exposes local networked services behinds NATs and firewalls to the
-      public internet over a secure tunnel. Share local websites, build/test
-      webhook consumers and self-host personal services.
-      Detailed help for each command is available with 'ngrok help <command>'.
-      Open http://localhost:4040 for ngrok's web interface to inspect traffic.
+  DESCRIPTION:
+    ngrok exposes local networked services behinds NATs and firewalls to the
+    public internet over a secure tunnel. Share local websites, build/test
+    webhook consumers and self-host personal services.
+    Detailed help for each command is available with 'ngrok help <command>'.
+    Open http://localhost:4040 for ngrok's web interface to inspect traffic.
 
-    Author:
-      ngrok - <support@ngrok.com>
+  Author:
+    ngrok - <support@ngrok.com>
 
-    TERMS OF SERVICE: https://ngrok.com/tos
+  TERMS OF SERVICE: https://ngrok.com/tos
 
-    EXAMPLES:
-      ngrok http 80                           # secure public URL for port 80 web server
-      ngrok http --domain baz.ngrok.dev 8080  # port 8080 available at baz.ngrok.dev
-      ngrok http foo.dev:80                   # tunnel to host:port instead of localhost
-      ngrok http https://localhost            # expose a local https server
-      ngrok tcp 22                            # tunnel arbitrary TCP traffic to port 22
-      ngrok tls --domain=foo.com 443          # TLS traffic for foo.com to port 443
-      ngrok start foo bar baz                 # start tunnels from the configuration file
+  EXAMPLES:
+    ngrok http 80                           # secure public URL for port 80 web server
+    ngrok http --domain baz.ngrok.dev 8080  # port 8080 available at baz.ngrok.dev
+    ngrok http foo.dev:80                   # tunnel to host:port instead of localhost
+    ngrok http https://localhost            # expose a local https server
+    ngrok tcp 22                            # tunnel arbitrary TCP traffic to port 22
+    ngrok tls --domain=foo.com 443          # TLS traffic for foo.com to port 443
+    ngrok start foo bar baz                 # start tunnels from the configuration file
 
-    COMMANDS:
-      api                            use ngrok agent as an api client
-      completion                     generates shell completion code for bash or zsh
-      config                         update or migrate ngrok's configuration file
-      credits                        prints author and licensing information
-      diagnose                       diagnose connection issues
-      help                           Help about any command
-      http                           start an HTTP tunnel
-      service                        run and control an ngrok service on a target operating system
-      start                          start tunnels by name from the configuration file
-      tcp                            start a TCP tunnel
-      tls                            start a TLS tunnel
-      tunnel                         start a tunnel for use with a tunnel-group backend
-      update                         update ngrok to the latest version
-      version                        print the version string
+  COMMANDS:
+    api                            use ngrok agent as an api client
+    completion                     generates shell completion code for bash or zsh
+    config                         update or migrate ngrok's configuration file
+    credits                        prints author and licensing information
+    diagnose                       diagnose connection issues
+    help                           Help about any command
+    http                           start an HTTP tunnel
+    service                        run and control an ngrok service on a target operating system
+    start                          start tunnels by name from the configuration file
+    tcp                            start a TCP tunnel
+    tls                            start a TLS tunnel
+    tunnel                         start a tunnel for use with a tunnel-group backend
+    update                         update ngrok to the latest version
+    version                        print the version string
 
-    OPTIONS:
-          --config strings   path to config files; they are merged if multiple
-      -h, --help             help for ngrok
-      -v, --version          version for ngrok
+  OPTIONS:
+        --config strings   path to config files; they are merged if multiple
+    -h, --help             help for ngrok
+    -v, --version          version for ngrok
 ```
 
 ### Step 3: Connect your agent to your ngrok account

--- a/docs/guides/running-behind-firewalls.md
+++ b/docs/guides/running-behind-firewalls.md
@@ -12,21 +12,21 @@ However, certain corporate firewalls have more restrictions around outbound conn
 
 If you're having trouble using the ngrok agent to start a tunnel, the first step is to run `ngrok diagnose` which will produce a report that will help you identify connection issues.
 
-```
-    $ ngrok diagnose
-    Testing ngrok connectivity...
+```sh
+$ ngrok diagnose
+  Testing ngrok connectivity...
 
-    Internet Connectivity
-      Name Resolution                           [ OK ]
-      TCP                                       [ OK ]
-      TLS                                       [ OK ]
-    Ngrok Connectivity
-      Name Resolution                           [ OK ]
-      TCP                                       [ OK ]
-      TLS                                       [ OK ]
-    Tunnel Protocol                           [ OK ]
+  Internet Connectivity
+    Name Resolution                           [ OK ]
+    TCP                                       [ OK ]
+    TLS                                       [ OK ]
+  Ngrok Connectivity
+    Name Resolution                           [ OK ]
+    TCP                                       [ OK ]
+    TLS                                       [ OK ]
+  Tunnel Protocol                           [ OK ]
 
-  Successfully established ngrok connection! (region: 'us', latency: 54.895145ms)
+Successfully established ngrok connection! (region: 'us', latency: 54.895145ms)
 ```
 
 To resolve these issues, you have a couple options:

--- a/docs/guides/upgrade-v2-v3.mdx
+++ b/docs/guides/upgrade-v2-v3.mdx
@@ -43,37 +43,37 @@ If you configure ngrok to start with a configuration file, the ngrok agent v3 ma
 - It adds a `version` field which is now required and identifies the configuration version to use. The latest is `version: 2`
 - It converts configuration parameters that have been renamed, such as `bind_tls` and `auth`, to their updated names
 
-```
-    $ ngrok config upgrade -h
-    NAME:
-      upgrade - auto-upgrade configuration file
+```sh
+$ ngrok config upgrade -h
+  NAME:
+    upgrade - auto-upgrade configuration file
 
-    USAGE:
-      ngrok config upgrade [version] [flags]
+  USAGE:
+    ngrok config upgrade [version] [flags]
 
-    DESCRIPTION:
-      Upgrade a configuration file to a version. The default configuration
-      file is located at /home/ubuntu/.config/ngrok/ngrok.yml
+  DESCRIPTION:
+    Upgrade a configuration file to a version. The default configuration
+    file is located at /home/ubuntu/.config/ngrok/ngrok.yml
 
-      A backup file will be created with your original configuration file in
-      the same directory.
+    A backup file will be created with your original configuration file in
+    the same directory.
 
-      You can optionally pass a version to upgrade to. If the configuration file
-      version is missing, the upgrade command will add it. It also applies all
-      automatic transformations when upgrading versions. Attempting to downgrade
-      will result in an error.
+    You can optionally pass a version to upgrade to. If the configuration file
+    version is missing, the upgrade command will add it. It also applies all
+    automatic transformations when upgrading versions. Attempting to downgrade
+    will result in an error.
 
-      By default this command will apply the transformations and display the
-      final file. Use --dry-run to preview changes before applying
+    By default this command will apply the transformations and display the
+    final file. Use --dry-run to preview changes before applying
 
-    OPTIONS:
-          --config string       upgrade this config file (default /home/ubuntu/.config/ngrok/ngrok.yml)
-          --dry-run             preview the proposed changes
-      -h, --help                help for upgrade
-          --log string          path to log file, 'stdout', 'stderr' or 'false' (default "false")
-          --log-format string   log record format: 'term', 'logfmt', 'json' (default "term")
-          --log-level string    logging level: 'debug', 'info', 'warn', 'error', 'crit' (default "info")
-          --relocate            relocates the config file to the default location
+  OPTIONS:
+        --config string       upgrade this config file (default /home/ubuntu/.config/ngrok/ngrok.yml)
+        --dry-run             preview the proposed changes
+    -h, --help                help for upgrade
+        --log string          path to log file, 'stdout', 'stderr' or 'false' (default "false")
+        --log-format string   log record format: 'term', 'logfmt', 'json' (default "term")
+        --log-level string    logging level: 'debug', 'info', 'warn', 'error', 'crit' (default "info")
+        --relocate            relocates the config file to the default location
 ```
 
 The `ngrok config upgrade` command also includes a flag `--relocate` which will move your configuration file to the updated default location for ngrok agent v3. We follow the [XDG specification](https://wiki.archlinux.org/title/XDG_Base_Directory) for storing configuration files.

--- a/docs/integrations/tiktok/webhooks.mdx
+++ b/docs/integrations/tiktok/webhooks.mdx
@@ -104,7 +104,9 @@ After your app is approved, associate a user with your app.
 
 The TikTok app will send a notification to your localhost application when a user's account is deauthorized from your application, a user video fails to upload in TikTok, or a user video has been published in TikTok.
 
-    Confirm your localhost app receives one of these event notifications and logs both headers and body in the terminal.
+```sh
+Confirm your localhost app receives one of these event notifications and logs both headers and body in the terminal.
+```
 
 ### Inspecting requests
 

--- a/docs/obs/index.mdx
+++ b/docs/obs/index.mdx
@@ -130,17 +130,23 @@ Filter expressions have the following limitations:
 
 ###### Filter for connections from a particular hostname
 
-    ev.conn.server_name.matches("ngrok-docs-examples\\.ngrok\\.dev")
+```cel
+ev.conn.server_name.matches("ngrok-docs-examples\\.ngrok\\.dev")
+```
 
 ###### Filter for connections to an endpoint that didn't use HTTPS
 
-    ev.conn.server_name.matches(".*-your-org\\.ngrok\\.dev") &&
-    ev.conn.server_port == 80
+```cel
+ev.conn.server_name.matches(".*-your-org\\.ngrok\\.dev") &&
+ev.conn.server_port == 80
+```
 
 ###### Filter for connections to a hostname that exclude traffic from a client IP
 
-    ev.conn.client_ip != "2601:0:8200:0:4cd7:fd52:0:7823" &&
-    ev.conn.server_name == "ngrok-docs-examples.ngrok.dev"
+```cel
+ev.conn.client_ip != "2601:0:8200:0:4cd7:fd52:0:7823" &&
+ev.conn.server_name == "ngrok-docs-examples.ngrok.dev"
+```
 
 ## Event Destinations {#destinations}
 
@@ -209,86 +215,86 @@ and it is `null` for Traffic Events.
 
 #### ip_policy_created.v0 event
 
-```
+```json
 {
-    "event_id": "ev_25X2AsJ5xpvuOParTYUQWe12XKo",
-    "event_type": "ip_policy_created.v0",
-    "event_timestamp": "2022-02-23T23:29:29Z",
-    "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
-    "principal": {
-        "id": "usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H",
-        "subject": "foo@example.com",
-        "source": "API",
-        "credential": {
-            "id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub",
-            "uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"
-        }
-    },
-    "object": {
-        "id": "ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
-        "uri": "https://api.ngrok.com/ip_policies/ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
-        "created_at": "2022-02-23T23:29:29Z",
-        "description": "Home network IP",
-        "metadata": "",
-        "action": "allow"
-    }
+	"event_id": "ev_25X2AsJ5xpvuOParTYUQWe12XKo",
+	"event_type": "ip_policy_created.v0",
+	"event_timestamp": "2022-02-23T23:29:29Z",
+	"account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
+	"principal": {
+		"id": "usr_2OtNv9qH5Nk4NuNeszZ39gBxZ4H",
+		"subject": "foo@example.com",
+		"source": "API",
+		"credential": {
+			"id": "ak_2Oxt94wYsBTLwFUoMZcJRvJTaub",
+			"uri": "https://api.ngrok.com/api_keys/ak_2Oxt94wYsBTLwFUoMZcJRvJTaub"
+		}
+	},
+	"object": {
+		"id": "ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
+		"uri": "https://api.ngrok.com/ip_policies/ipp_25X2Ao39z73FlVQKZ1iReMPe6Qv",
+		"created_at": "2022-02-23T23:29:29Z",
+		"description": "Home network IP",
+		"metadata": "",
+		"action": "allow"
+	}
 }
 ```
 
 #### [http_request_complete.v0](/obs/reference/#http-request-complete) event
 
-```
+```json
 {
-    "event_id": "ev_25X3yFS6TDkig1KDJWIc4nnJO0c",
-    "event_type": "http_request_complete.v0",
-    "event_timestamp": "2022-02-23T23:44:16Z",
-    "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
-    "object": {
-        "conn": {
-            "client_ip": "2601:0:8200:9e:4cd7:0:c97f:7823",
-            "server_name": "ngrok-docs-example.ngrok.app",
-            "server_port": ""
-        },
-        "http": {
-            "request": {
-                "first_byte_ts": null,
-                "last_byte_ts": null,
-                "method": "GET",
-                "url": {
-                    "path": "/docs/obs"
-                },
-                "version": "HTTP/2.0"
-            },
-            "response": {
-                "body_length": 13079,
-                "first_byte_ts": "2022-02-23T23:44:16.732791273Z",
-                "last_byte_ts": "2022-02-23T23:44:16.737257209Z",
-                "status_code": 200
-            }
-        }
-    }
+	"event_id": "ev_25X3yFS6TDkig1KDJWIc4nnJO0c",
+	"event_type": "http_request_complete.v0",
+	"event_timestamp": "2022-02-23T23:44:16Z",
+	"account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
+	"object": {
+		"conn": {
+			"client_ip": "2601:0:8200:9e:4cd7:0:c97f:7823",
+			"server_name": "ngrok-docs-example.ngrok.app",
+			"server_port": ""
+		},
+		"http": {
+			"request": {
+				"first_byte_ts": null,
+				"last_byte_ts": null,
+				"method": "GET",
+				"url": {
+					"path": "/docs/obs"
+				},
+				"version": "HTTP/2.0"
+			},
+			"response": {
+				"body_length": 13079,
+				"first_byte_ts": "2022-02-23T23:44:16.732791273Z",
+				"last_byte_ts": "2022-02-23T23:44:16.737257209Z",
+				"status_code": 200
+			}
+		}
+	}
 }
 ```
 
 #### [tcp_connection_closed.v0](/obs/reference/#tcp-connection-closed) event
 
-```
+```json
 {
-    "event_id": "ev_25X4osod1q306srserDeFyghTC4",
-    "event_type": "tcp_connection_closed.v0",
-    "event_timestamp": "2022-02-23T23:51:14Z",
-    "account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
-    "object": {
-        "conn": {
-            "bytes_in": 3437,
-            "bytes_out": 90256,
-            "client_ip": "2601:0:8200:9e:4cd7:0:c97f:7823",
-            "end_ts": "2022-02-23T23:51:14.005372199Z",
-            "server_name": "ngrok-docs-example.ngrok.app",
-            "server_port": "",
-            "start_ts": "2022-02-23T23:44:16.528374173Z"
-        }
-    }
+	"event_id": "ev_25X4osod1q306srserDeFyghTC4",
+	"event_type": "tcp_connection_closed.v0",
+	"event_timestamp": "2022-02-23T23:51:14Z",
+	"account_id": "ac_2OtNvAlhso10Gx6s7eupzX3F98q",
+	"object": {
+		"conn": {
+			"bytes_in": 3437,
+			"bytes_out": 90256,
+			"client_ip": "2601:0:8200:9e:4cd7:0:c97f:7823",
+			"end_ts": "2022-02-23T23:51:14.005372199Z",
+			"server_name": "ngrok-docs-example.ngrok.app",
+			"server_port": "",
+			"start_ts": "2022-02-23T23:44:16.528374173Z"
+		}
+	}
 }
 ```
 

--- a/docs/using-ngrok-with/rdp.md
+++ b/docs/using-ngrok-with/rdp.md
@@ -6,6 +6,8 @@ title: RDP
 
 ngrok's TCP tunnels can be used for RDP traffic but we recommend they only be used in conjunction with restricting access to a specific set of IP addresses using IP restrictions. Start a TCP tunnel to port 3389 and add the `--cidr-allow` flag with the IP addresses you'll be connecting from.
 
-    ngrok tcp 3389 --cidr-allow 0.0.0.0/32
+```sh
+ngrok tcp 3389 --cidr-allow 0.0.0.0/32
+```
 
 To learn more about the RDP protocol and security best practices, see the [Understanding the Remote Desktop Protocol (RDP) documentation](https://docs.microsoft.com/en-us/troubleshoot/windows-server/remote/understanding-remote-desktop-protocol) from Microsoft.

--- a/docs/using-ngrok-with/ssh.md
+++ b/docs/using-ngrok-with/ssh.md
@@ -6,8 +6,12 @@ title: SSH
 
 ngrok's TCP tunnels are perfect for SSH traffic. Simply start a TCP tunnel to port 22 and you should be all set.
 
-    ngrok tcp 22
+```sh
+ngrok tcp 22
+```
 
 When connecting through the ngrok TCP address, make sure you specify the port separately.
 
-    ssh -p PORT user@NGROK_TCP_ADDRESS
+```sh
+ssh -p PORT user@NGROK_TCP_ADDRESS
+```


### PR DESCRIPTION
indented code blocks don't render correctly now (since all `.md` and `.mdx` are parsed w/ mdx)

<img width="966" alt="image" src="https://github.com/ngrok/ngrok-docs/assets/34115417/5dde83aa-3a59-49d8-9046-0b761add0974">

https://mdxjs.com/docs/what-is-mdx/#markdown