### PR TITLE
Add instructions for HTTP/2 support

### DIFF
--- a/docs/agent/cli.mdx
+++ b/docs/agent/cli.mdx
@@ -331,6 +331,7 @@ The `ngrok http` command is used to start a tunnel listening for HTTP/HTTPS traf
 | Flag                               | Description                                                                                       |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `--authtoken string`               | ngrok authtoken                                                                                   |
+| `--app-protocol string`            | specify the application protocol to be used: `http1`, `http2` (default `http1`)                   |
 | `--basic-auth strings`             | enforce basic auth on tunnel endpoint, `user:password`                                            |
 | `--cidr-allow strings`             | reject connections that do not match the given CIDRs                                              |
 | `--cidr-deny strings`              | reject connections that match the given CIDRs                                                     |

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -769,7 +769,7 @@ HTTP/2.
 
 #### ngrok edge to upstream service
 
-ngrok's HTTP endpoints will conitnue using HTTP/2 if you choose by using the
+ngrok's HTTP endpoints will continue using HTTP/2 if you choose by using the
 [`ngrok http` flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
 
 At this time all requests to your upstream service will be transmitted over HTTP/2

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -772,7 +772,7 @@ HTTP/2.
 Requests to upstream services can be configured to continue using HTTP/2 with
 either the [agent cli flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
 
-At this time all requests to your upstream service will be transmitted over HTTP/2
+All requests to your upstream service will be transmitted over HTTP/2
 Cleartext since TLS was already terminated at the ngrok edge. We cannot use
 [TLS-ALPN](https://httpwg.org/specs/rfc7540.html#TLS-ALPN) at this time. We rely
 on [HTTP/2 with Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http)

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -777,7 +777,7 @@ Cleartext since TLS was already terminated at the ngrok edge. We cannot use
 [TLS-ALPN](https://httpwg.org/specs/rfc7540.html#TLS-ALPN) at this time. We rely
 on [HTTP/2 with Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http)
 currently.
- 
+
 ### HTTP/3
 
 HTTP/3 is not yet supported.

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -769,8 +769,8 @@ HTTP/2.
 
 #### ngrok edge to upstream service
 
-ngrok's HTTP endpoints will continue using HTTP/2 if you choose by using the
-[`ngrok http` flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
+Requests to upstream services can be configured to continue using HTTP/2 with
+either the [agent cli flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
 
 At this time all requests to your upstream service will be transmitted over HTTP/2
 Cleartext since TLS was already terminated at the ngrok edge. We cannot use

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -770,7 +770,7 @@ HTTP/2.
 #### ngrok edge to upstream service
 
 Requests to upstream services can be configured to continue using HTTP/2 with
-either the [agent cli flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
+either the [agent CLI flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
 
 All requests to your upstream service will be transmitted over HTTP/2
 Cleartext since TLS was already terminated at the ngrok edge. We cannot use

--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -769,9 +769,15 @@ HTTP/2.
 
 #### ngrok edge to upstream service
 
-At this time, all requests to upstream service are transmitted over
-HTTP/1.1 connections.
+ngrok's HTTP endpoints will conitnue using HTTP/2 if you choose by using the
+[`ngrok http` flags](/agent/cli/#ngrok-http) or the [agent SDKs](/agent-sdks).
 
+At this time all requests to your upstream service will be transmitted over HTTP/2
+Cleartext since TLS was already terminated at the ngrok edge. We cannot use
+[TLS-ALPN](https://httpwg.org/specs/rfc7540.html#TLS-ALPN) at this time. We rely
+on [HTTP/2 with Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http)
+currently.
+ 
 ### HTTP/3
 
 HTTP/3 is not yet supported.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docusaurus": "docusaurus",
     "fmt": "prettier --write --cache .",
     "fmt:check": "prettier --check .",
-    "start": "docusaurus start",
+    "start": "docusaurus start --host 0.0.0.0",
     "build": "NODE_OPTIONS=--max-old-space-size=5120 docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Two sections of the docs are being updated to make note of the new HTTP/2 support for upstream services.
