### PR TITLE
Update mentions of sdk's on using-ngrok-with pages

### DIFF
--- a/docs/using-ngrok-with/django.md
+++ b/docs/using-ngrok-with/django.md
@@ -8,13 +8,9 @@ title: Django
 This article assumes you have Python, PIP, and Django already installed.
 :::
 
-### Agent Management
+### Python SDK
 
-If you're looking to natively embed the ngrok agent into your Django application, you can leverage the [pyngrok project](https://pyngrok.readthedocs.io/en/latest/integrations.html#django) to start a tunnel anytime you start the Django Dev Server.
-
-### Python SDK (beta)
-
-You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Django server via a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) or embedding in [manage.py or asgi.py](https://github.com/ngrok/ngrok-python#frameworks).
+You can also use the [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Django server via a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) or embedding in [manage.py or asgi.py](https://github.com/ngrok/ngrok-python#frameworks).
 
 - [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
 - [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)

--- a/docs/using-ngrok-with/flask.md
+++ b/docs/using-ngrok-with/flask.md
@@ -12,13 +12,9 @@ To share a local Flask development server with someone else, simply run: `ngrok 
 
 Note: For users on the latest MacOS, there is an issue where the default port of 5000 is used by Apple AirPlay Receiver. You can use a different port for your Flask app or see this [Stack Overflow post for disabling the AirPlay Receiver service](https://stackoverflow.com/a/6982933/7282727).
 
-### Agent Management
+### Python SDK
 
-If you're looking to natively embed the ngrok agent into your Flask development flow, you can leverage the [pyngrok project](https://pyngrok.readthedocs.io/en/latest/integrations.html#flask) so that a tunnel is created each time you type `flask run`.
-
-### Python SDK (beta)
-
-You can also use the beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Flask dev server via [python code](https://github.com/ngrok/ngrok-python#frameworks), or using a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) with an [ASGI Wrapper](https://flask.palletsprojects.com/en/2.3.x/deploying/asgi/).
+You can also use the [ngrok Python SDK](https://github.com/ngrok/ngrok-python) to start a tunnel to the Flask dev server via [python code](https://github.com/ngrok/ngrok-python#frameworks), or using a [ngrok ASGI runner](https://github.com/ngrok/ngrok-python#asgi-runner---tunnels-to-uvicorn-gunicorn-django-and-more-with-no-code) with an [ASGI Wrapper](https://flask.palletsprojects.com/en/2.3.x/deploying/asgi/).
 
 - [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
 - [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)

--- a/docs/using-ngrok-with/java.md
+++ b/docs/using-ngrok-with/java.md
@@ -8,10 +8,9 @@ title: Java
 
 If you'd like to programmatically manage your ngrok account and resources (register domains, create edges, configure IP restrictions, etc.), you can use the native [ngrok Java API Client](https://github.com/ngrok/ngrok-api-java) in your project.
 
-### Agent Management
+### Java SDK
 
-If you're looking to programmatically start tunnels with the ngrok agent, check out Alex's [java-ngrok](https://github.com/alexdlaird/java-ngrok) library.
+Embed ngrok secure ingress into your Java apps with a single line of code with our [ngrok Java SDK](https://github.com/ngrok/ngrok-java).
 
-### Java SDK (alpha)
-
-Embed ngrok secure ingress into your Java apps with a single line of code with our alpha [ngrok Java SDK](https://github.com/ngrok/ngrok-java).
+- [ngrok SDK on Maven](https://mvnrepository.com/artifact/com.ngrok/ngrok-java)
+- [ngrok SDK on Github](https://github.com/ngrok/ngrok-java)

--- a/docs/using-ngrok-with/node-js.md
+++ b/docs/using-ngrok-with/node-js.md
@@ -8,21 +8,14 @@ title: Node.js or npm
 This article assumes you have node and npm already installed.
 :::
 
-### Agent Management
+### Javascript SDK
 
-If you need to manage the ngrok agent for starting tunnels, use bubenshchykov's npm package:
-
-- [ngrok module on npm](https://www.npmjs.com/package/ngrok)
-- [ngrok npm module on Github](https://github.com/bubenshchykov/ngrok)
-
-### API Client
-
-If you'd like to programmatically access the ngrok API for configuring ngrok Edges and modules, use our [ngrok Javascript/Typescript Client](https://github.com/ngrok/ngrok-api-typescript).
-
-### NodeJS SDK (beta)
-
-Embed ngrok secure ingress into your Node.js apps with a single line of code with our beta [ngrok NodeJS SDK](https://github.com/ngrok/ngrok-nodejs).
+Embed ngrok secure ingress into your Node.js apps with a single line of code with our [ngrok Javascript/Typescript SDK](https://github.com/ngrok/ngrok-nodejs).
 
 - [@ngrok/ngrok module on npm](https://www.npmjs.com/package/@ngrok/ngrok)
 - [@ngrok/ngrok npm module on Github](https://github.com/ngrok/ngrok-nodejs)
 - [Reference Documentation](https://ngrok.github.io/ngrok-nodejs/)
+
+### API Client
+
+If you'd like to programmatically access the ngrok API for configuring ngrok Edges and modules, use our [ngrok Javascript/Typescript Client](https://github.com/ngrok/ngrok-api-typescript).

--- a/docs/using-ngrok-with/python.md
+++ b/docs/using-ngrok-with/python.md
@@ -8,18 +8,14 @@ title: Python
 This article assumes you have Python and PIP already installed.
 :::
 
-### API Client
+### Python SDK
 
-If you'd like to programmatically manage your ngrok account and resources (register domains, create edges, configure IP restrictions, etc.), you can use the native [ngrok Python API Client](https://github.com/ngrok/ngrok-api-python) in your project.
-
-### Agent Management
-
-If you're looking to programmatically start tunnels with the ngrok agent, check out Alex's [pyngrok](https://github.com/alexdlaird/pyngrok) library.
-
-### Python SDK (beta)
-
-Embed ngrok secure ingress into your Python apps with a single line of code with our beta [ngrok Python SDK](https://github.com/ngrok/ngrok-python).
+Embed ngrok secure ingress into your Python apps with a single line of code with our [ngrok Python SDK](https://github.com/ngrok/ngrok-python).
 
 - [ngrok SDK on PyPi](https://pypi.org/project/ngrok/)
 - [ngrok SDK on Github](https://github.com/ngrok/ngrok-python)
 - [Reference Documentation](https://ngrok.github.io/ngrok-python/)
+
+### API Client
+
+If you'd like to programmatically manage your ngrok account and resources (register domains, create edges, configure IP restrictions, etc.), you can use the native [ngrok Python API Client](https://github.com/ngrok/ngrok-api-python) in your project.


### PR DESCRIPTION
Move the SDK's up to top position, remove outdated alpha/beta notes, add links for java.