### PR TITLE
Add limitation for GitHub OAuth

### DIFF
--- a/docs/http/oauth.mdx
+++ b/docs/http/oauth.mdx
@@ -376,7 +376,7 @@ a single MAU even if they connect to multiple endpoints on your account.
 
 ### Supported Providers {#supported-providers}
 
-ngrok currently supports the following OAuth providers:
+ngrok currently supports the following OAuth providers (see the Integration Guides for more details):
 
 | Provider  | Provider Identifier | Managed App Available | Integration Guide                                    |
 | --------- | ------------------- | --------------------- | ---------------------------------------------------- |

--- a/docs/integrations/github/oauth.mdx
+++ b/docs/integrations/github/oauth.mdx
@@ -56,3 +56,7 @@ ngrok authorizes against users' first 200 memberships of each constraint in chro
 1.  From any team membership, check the parent organization.
 2.  Check team membership.
 3.  Check organization membership.
+
+## Known Limitations
+
+- Users who utilize GitHub's [private email setting](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#:~:text=If%20you%27d%20like%20to%20keep%20your%20personal,to%20Keep%20my%20email%20address%20private.) are not able to sign in.


### PR DESCRIPTION
I believe this is due to ngrok requiring an email for login and requesting that scope during the OAuth handshake.