### PR TITLE
Add missing Linkerd integration hub copy

### DIFF
--- a/docs/integrations/linkerd/index.mdx
+++ b/docs/integrations/linkerd/index.mdx
@@ -3,9 +3,9 @@ name: linkerd
 title: Linkerd Integration Hub
 sidebar_label: Linkerd
 description: |
-  TK
+  Linkerd is an open source service mesh designed to simplify and secure microservices communicatation within Kubernetes clusters. ngrok and Linkerd integrate well together to abstract away complexity around encrypted traffic ingress while also adding more observable networking data and resiliency.
 excerpt: |
-  TK
+  Quickly add ingress traffic to any Kubernetes app running on top of a Linkerd service mesh.
 ---
 
 import IntegrationPageList from "@site/src/components/IntegrationPageList";


### PR DESCRIPTION
Fixes an issue with #543, in which I'd forgotten to change the `TK` (to come) in the integration hub copy.