### PR TITLE
use updated method of signing repos

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -26,8 +26,8 @@ brew install ngrok/ngrok/ngrok
 
 ```bash
 curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | \
-  sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && \
-  echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | \
+  sudo gpg --dearmor -o /etc/apt/keyrings/ngrok.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/ngrok.gpg] https://ngrok-agent.s3.amazonaws.com buster main" | \
   sudo tee /etc/apt/sources.list.d/ngrok.list && \
   sudo apt update && sudo apt install ngrok
 ```

--- a/docs/guides/getting-started.mdx
+++ b/docs/guides/getting-started.mdx
@@ -47,8 +47,8 @@ For Linux, use Apt:
 
 ```bash
 curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | \
-  sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && \
-  echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | \
+  sudo gpg --dearmor -o /etc/apt/keyrings/ngrok.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/ngrok.gpg] https://ngrok-agent.s3.amazonaws.com buster main" | \
   sudo tee /etc/apt/sources.list.d/ngrok.list && \
   sudo apt update && sudo apt install ngrok
 ```


### PR DESCRIPTION
`apt-key` and `/etc/apt/trusted.gpg.d` are deprecated due to security concerns.  the new recommended method is to directly reference the key in the repository declaration.

one possible issue users could run into is if the `/etc/apt/keyrings` directory is not already created, but it's an easy enough fix.

some references for the deprecation and changes:

- https://wiki.debian.org/DebianRepository/UseThirdParty
- https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html
- https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key?newreg=c7d51f5afac945fea79db7a504d68e76