### PR TITLE
Fix formatting in recent integration how-to guides

### DIFF
--- a/docs/integrations/linkerd/k8s.md
+++ b/docs/integrations/linkerd/k8s.md
@@ -157,6 +157,12 @@ Controller](https://github.com/ngrok/kubernetes-ingress-controller) to simplify 
 
 To demonstrate how Linkerd and the ngrok Ingress Controller integrate to add additional observability, security, and reliability into your cluster, you'll deploy the [Emojivoto](https://github.com/BuoyantIO/emojivoto) demo application, which was developed by Buoyant, the company that originally developed Linkerd.
 
+1. Create a ngrok static subdomain for ingress if you don't have one already. Navigate to the [**Domains**
+   section](https://dashboard.ngrok.com/cloud-edge/domains) of the ngrok dashboard and click **Create Domain** or **New
+   Domain**. This static subdomain will be your `NGROK_DOMAIN` for the remainder of this guide.
+
+   By creating a subdomain on the ngrok network, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
+
 1. Deploy Emojivoto to the `emojivoto` namespace.
 
    ```bash
@@ -184,7 +190,7 @@ To demonstrate how Linkerd and the ngrok Ingress Controller integrate to add add
 
    :::tip
 
-   Make sure you edit line `9` of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok.app`.
+   Make sure you edit line `9` of the manifest below, which contains the `NGROK_DOMAIN` variable, with your ngrok subdomain. It should look something like `one-two-three.ngrok.app`.
 
    :::
 

--- a/docs/integrations/linkerd/k8s.md
+++ b/docs/integrations/linkerd/k8s.md
@@ -157,11 +157,11 @@ Controller](https://github.com/ngrok/kubernetes-ingress-controller) to simplify 
 
 To demonstrate how Linkerd and the ngrok Ingress Controller integrate to add additional observability, security, and reliability into your cluster, you'll deploy the [Emojivoto](https://github.com/BuoyantIO/emojivoto) demo application, which was developed by Buoyant, the company that originally developed Linkerd.
 
-1. Create a ngrok static subdomain for ingress if you don't have one already. Navigate to the [**Domains**
+1. Create an ngrok static subdomain for ingress if you don't have one already. Navigate to the [**Domains**
    section](https://dashboard.ngrok.com/cloud-edge/domains) of the ngrok dashboard and click **Create Domain** or **New
    Domain**. This static subdomain will be your `NGROK_DOMAIN` for the remainder of this guide.
 
-   By creating a subdomain on the ngrok network, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
+   By creating a subdomain on the ngrok Edge, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
 
 1. Deploy Emojivoto to the `emojivoto` namespace.
 

--- a/docs/integrations/linkerd/k8s.md
+++ b/docs/integrations/linkerd/k8s.md
@@ -231,7 +231,7 @@ To demonstrate how Linkerd and the ngrok Ingress Controller integrate to add add
 
    :::
 
-1. Access your Emojivoto application by navigating to the your ngrok domain, e.g. `https://one-two-three.ngrok-free.app`, in your browser.
+1. Access your Emojivoto application by navigating to the your ngrok domain, e.g. `https://one-two-three.ngrok.app`, in your browser.
 
    ![Viewing the Emojivoto application](img/emojivoto.png)
 

--- a/docs/integrations/rancher/k8s.md
+++ b/docs/integrations/rancher/k8s.md
@@ -126,7 +126,7 @@ docker logs [DOCKER_NAME] 2>&1 | grep "Bootstrap Password:"
 
    ```bash
    kubectl get namespaces
-   
+
    NAME                          STATUS   AGE
    calico-system                 Active   4m
    cattle-impersonation-system   Active   29s
@@ -269,18 +269,18 @@ simplifying how you route external traffic through your Rancher-managed cluster.
    spec:
      ingressClassName: ngrok
      rules:
-         # highlight-start
-         - host: NGROK_DOMAIN
+       # highlight-start
+       - host: NGROK_DOMAIN
          # highlight-end
-           http:
-             paths:
-               - path: /
-                 pathType: Prefix
-                 backend:
-                   service:
-                     name: game-2048
-                     port:
-                       number: 80
+         http:
+           paths:
+             - path: /
+               pathType: Prefix
+               backend:
+                 service:
+                   name: game-2048
+                   port:
+                     number: 80
    ```
 
 1. Apply the `2048.yaml` manifest to your RKE2 cluster.

--- a/docs/integrations/rancher/k8s.md
+++ b/docs/integrations/rancher/k8s.md
@@ -221,7 +221,7 @@ simplifying how you route external traffic through your Rancher-managed cluster.
    edge via your `NGROK_DOMAIN`.
 
    :::tip
-   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you just created. It should look something like `one-two-three.ngrok-free.app`.
+   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you just created. It should look something like `one-two-three.ngrok.app`.
    :::
 
    ```yaml showLineNumbers
@@ -294,7 +294,7 @@ simplifying how you route external traffic through your Rancher-managed cluster.
    and try again.
    :::
 
-1. Access your 2048 demo app by navigating to your ngrok subdomain, e.g. `https://one-two-three.ngrok-free.app`.
+1. Access your 2048 demo app by navigating to your ngrok subdomain, e.g. `https://one-two-three.ngrok.app`.
    ngrok's edge and your Ingress Controller will route traffic to your app from any device or external network as long
    as your Rancher server and application cluster remain operational.
 

--- a/docs/integrations/rancher/k8s.md
+++ b/docs/integrations/rancher/k8s.md
@@ -124,20 +124,20 @@ docker logs [DOCKER_NAME] 2>&1 | grep "Bootstrap Password:"
 1. Ensure your new RKE2 cluster is active by getting the namespaces for your instance. Your list of namespaces should
    look like the following:
 
-```bash
-kubectl get namespaces
-
-NAME                          STATUS   AGE
-calico-system                 Active   4m
-cattle-impersonation-system   Active   29s
-cattle-system                 Active   5m
-default                       Active   5m4s
-kube-node-lease               Active   5m6s
-kube-public                   Active   5m6s
-kube-system                   Active   5m6s
-local                         Active   23s
-tigera-operator               Active   4m10s
-```
+   ```bash
+   kubectl get namespaces
+   
+   NAME                          STATUS   AGE
+   calico-system                 Active   4m
+   cattle-impersonation-system   Active   29s
+   cattle-system                 Active   5m
+   default                       Active   5m4s
+   kube-node-lease               Active   5m6s
+   kube-public                   Active   5m6s
+   kube-system                   Active   5m6s
+   local                         Active   23s
+   tigera-operator               Active   4m10s
+   ```
 
 You have now installed Rancher in a Docker container, created a new Kubernetes cluster for your applications, and
 connected one or more Linux nodes to Rancher for handling future workloads.

--- a/docs/integrations/rancher/k8s.md
+++ b/docs/integrations/rancher/k8s.md
@@ -90,6 +90,7 @@ docker logs [DOCKER_NAME] 2>&1 | grep "Bootstrap Password:"
 
 1. Copy the terminal output into the password input and click **Log in with Local User**. Next, choose between a
    randomly-generated password or one of your choosing to initialize the **admin** user.
+
 1. The **Server URL** field will default to `https://localhost:444`, but your worker nodes won't be able to connect to
    Rancher in this configuration. Find your local IP address—try `hostname -I` for Linux or `ipconfig getifaddr en0` on macOs—which will look similar to `192.168.1.123`, and
    replace `localhost` with it, similar to the following: `https://192.168.1.107:444`.
@@ -220,66 +221,66 @@ simplifying how you route external traffic through your Rancher-managed cluster.
    edge via your `NGROK_DOMAIN`.
 
    :::tip
-   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok-free.app`.
+   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you just created. It should look something like `one-two-three.ngrok-free.app`.
    :::
 
    ```yaml showLineNumbers
    apiVersion: v1
    kind: Service
    metadata:
-   name: game-2048
-   namespace: ngrok-ingress-controller
+     name: game-2048
+     namespace: ngrok-ingress-controller
    spec:
-   ports:
-      - name: http
+     ports:
+       - name: http
          port: 80
          targetPort: 80
-   selector:
-      app: game-2048
+     selector:
+       app: game-2048
    ---
    apiVersion: apps/v1
    kind: Deployment
    metadata:
-   name: game-2048
-   namespace: ngrok-ingress-controller
+     name: game-2048
+     namespace: ngrok-ingress-controller
    spec:
-   replicas: 1
-   selector:
-      matchLabels:
+     replicas: 1
+     selector:
+       matchLabels:
          app: game-2048
-   template:
-      metadata:
+     template:
+       metadata:
          labels:
-         app: game-2048
-      spec:
+           app: game-2048
+       spec:
          containers:
-         - name: backend
-            image: alexwhen/docker-2048
-            ports:
+           - name: backend
+             image: alexwhen/docker-2048
+             ports:
                - name: http
-               containerPort: 80
+                 containerPort: 80
    ---
-   # ngrok Ingress Controller Configuration
+   # ngrok Kubernetes  Ingress Controller configuration
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
-   name: game-2048-ingress
-   namespace: ngrok-ingress-controller
+     name: game-2048-ingress
+     namespace: ngrok-ingress-controller
    spec:
-   ingressClassName: ngrok
-   rules:
-      # highlight-start
-      - host: NGROK_DOMAIN
+     ingressClassName: ngrok
+     rules:
+         # highlight-start
+         - host: NGROK_DOMAIN
          # highlight-end
-         http:
-         paths:
-            - path: /
-               pathType: Prefix
-               backend:
-               service:
-                  name: game-2048
-                  port:
-                     number: 80
+           http:
+             paths:
+               - path: /
+                 pathType: Prefix
+                 backend:
+                   service:
+                     name: game-2048
+                     port:
+                       number: 80
    ```
 
 1. Apply the `2048.yaml` manifest to your RKE2 cluster.

--- a/docs/integrations/vcluster/k8s.md
+++ b/docs/integrations/vcluster/k8s.md
@@ -251,11 +251,11 @@ Ingress Controller.
 multiple tunnels for load balancing, enabling the [Mutual TLS module](/http/mutual-tls/), adding
 compression, and more. We'll use one of these options, OAuth, in the next step.
 
-1. Access your 2048 demo app by navigating to the your domain, e.g. `https://one-two-three.ngrok-free.app`. ngrok's edge
+1. Access your 2048 demo app by navigating to the your domain, e.g. `https://one-two-three.ngrok.app`. ngrok's edge
    and your Ingress Controller will route traffic to your app from any device or external network as long as your
    vcluster remains operational.
 
-   !["Navigating directly to the https://one-two-three.ngrok-free.app domain to see the 2048 application"](img/ngrok-k8s-vcluster_2048.png)
+   !["Navigating directly to the https://one-two-three.ngrok.app domain to see the 2048 application"](img/ngrok-k8s-vcluster_2048.png)
 
 ## **Step 4**: Add OAuth protection to your demo app {#add-oauth-protection}
 
@@ -364,7 +364,7 @@ allowing ingress and access to your endpoint.
 
    ![Verifying the OAuth module configuration in the ngrok dashboard](img/ngrok-k8s-vcluster_oauth-config.png)
 
-1. Access your 2048 app at your domain (e.g. `https://one-two-three.ngrok-free.app`) to verify that it requests
+1. Access your 2048 app at your domain (e.g. `https://one-two-three.ngrok.app`) to verify that it requests
    authentication via Google OAuth before allowing you to access the 2048 app.
 
 ## What's next?

--- a/docs/integrations/vcluster/k8s.md
+++ b/docs/integrations/vcluster/k8s.md
@@ -55,51 +55,51 @@ If you don't have a cluster already, create one locally with minikube and instal
 
 1. Create a local Kubernetes cluster with minikube.
 
-```bash
-minikube start --profile dc1 --memory 4096
-```
+   ```bash
+   minikube start --profile dc1 --memory 4096
+   ```
 
 1. Use the `minikube` CLI to ensure your new local cluster is running properly.
 
-```bash
-kubectl get namespaces
+   ```bash
+   kubectl get namespaces
+   
+   NAME              STATUS   AGE
+   default           Active   5m55s
+   kube-node-lease   Active   5m55s
+   kube-public       Active   5m55s
+   kube-system       Active   5m55s
+   ```
 
-NAME              STATUS   AGE
-default           Active   5m55s
-kube-node-lease   Active   5m55s
-kube-public       Active   5m55s
-kube-system       Active   5m55s
-```
+1. Create a new vcluster with the name `my-vcluster`, which creates a new namespace called `vcluster-my-cluster` and automatically switches the active kube context to use your new vcluster.
 
-1. Create a new vcluster with the name `my-vcluster`, which creates a new namespace called `vcluster-my-cluster` and
-   automatically switches the active kube context to use your new vcluster.
+   ```bash
+   vcluster create my-vcluster --expose-local
+   ```
 
-```bash
-vcluster create my-vcluster --expose-local
-```
+1. To ensure your new local cluster is running properly get the namespaces for your instance. Your list of namespaces in the `my-vcluster` context should look something like this.
+   
+   ```bash
+   kubectl get namespaces
+   
+   NAME              STATUS   AGE
+   default           Active   19s
+   kube-system       Active   19s
+   kube-public       Active   19s
+   kube-node-lease   Active   19s
+   ```
+   
+   If you are not connected to your new vcluster and its kube context, you can run `vcluster connect my-vcluster` to try
+   again.
+   
+   You know have a vcluster installed on your local minikube cluster.
+   
+   :::note
 
-1. To ensure your new local cluster is running properly get the namespaces for your instance. Your list of namespaces in
-   the `my-vcluster` context should look something like this.
+   These steps are partially based the guide [Using the ngrok Ingress Controller to create Preview Environments with vcluster](https://loft.sh/blog/using-the-ngrok-ingress-controller-to-create-preview-environments-with-vcluster/) from [Loft](https://loft.sh/), the maintainers of vcluster.
 
-```bash
-kubectl get namespaces
-
-NAME              STATUS   AGE
-default           Active   19s
-kube-system       Active   19s
-kube-public       Active   19s
-kube-node-lease   Active   19s
-```
-
-If you are not connected to your new vcluster and its kube context, you can run `vcluster connect my-vcluster` to try
-again.
-
-You know have a vcluster installed on your local minikube cluster.
-
-:::note
-These steps are partially based the guide [Using the ngrok Ingress Controller to create Preview Environments with vcluster](https://loft.sh/blog/using-the-ngrok-ingress-controller-to-create-preview-environments-with-vcluster/) from [Loft](https://loft.sh/), the maintainers of vcluster.
-:::
-
+   :::
+   
 ## **Step 2**: Install the ngrok Ingress Controller {#install-the-ngrok-ingress-controller}
 
 Now that you have a Kubernetes cluster integrated with vcluster, you can install the [ngrok Kubernetes Ingress
@@ -108,41 +108,37 @@ on your virtual cluster.
 
 1. Add the ngrok Helm repository if you haven't already.
 
-```bash
-helm repo add ngrok https://ngrok.github.io/kubernetes-ingress-controller
-```
+   ```bash
+   helm repo add ngrok https://ngrok.github.io/kubernetes-ingress-controller
+   ```
 
-1. Set up the `AUTHTOKEN` and `API_KEY` exports, which allows Helm to install the Ingress Controller using your ngrok
-   credentials. Find your `AUTHTOKEN` under [**Your Authtoken**](https://dashboard.ngrok.com/get-started/your-authtoken)
-   in the ngrok dashboard.
+1. Set up the `AUTHTOKEN` and `API_KEY` exports, which allows Helm to install the Ingress Controller using your ngrok credentials. Find your `AUTHTOKEN` under [**Your Authtoken**](https://dashboard.ngrok.com/get-started/your-authtoken) in the ngrok dashboard.
 
-To create a new API key, navigate to the [**API** section](https://dashboard.ngrok.com/api) of the ngrok dashboard,
-click the **New API Key** button, change the description or owner, and click the **Add API Key** button. Copy the API
-key token shown in the modal window before closing it, as the ngrok dashboard will not show you the token again.
+   To create a new API key, navigate to the [**API** section](https://dashboard.ngrok.com/api) of the ngrok dashboard, click the **New API Key** button, change the description or owner, and click the **Add API Key** button. Copy the API key token shown in the modal window before closing it, as the ngrok dashboard will not show you the token again.
 
-```bash
-export NGROK_AUTHTOKEN=[YOUR-AUTHTOKEN]
-export NGROK_API_KEY=[YOUR-API-KEY]
-```
+   ```bash
+   export NGROK_AUTHTOKEN=[YOUR-AUTHTOKEN]
+   export NGROK_API_KEY=[YOUR-API-KEY]
+   ```
 
 1. Install the ngrok Ingress Controller with Helm under a new `ngrok-ingress-controller` namespace.
 
-```bash
-helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
-  --namespace ngrok-ingress-controller \
-  --create-namespace \
-  --set credentials.apiKey=$NGROK_API_KEY \
-  --set credentials.authtoken=$NGROK_AUTHTOKEN
-```
+   ```bash
+   helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
+     --namespace ngrok-ingress-controller \
+     --create-namespace \
+     --set credentials.apiKey=$NGROK_API_KEY \
+     --set credentials.authtoken=$NGROK_AUTHTOKEN
+   ```
 
 1. Verify you have installed the ngrok Ingress Controller successfully and that pods are healthy.
 
-```bash
-kubectl get pods -l 'app.kubernetes.io/name=kubernetes-ingress-controller' --namespace ngrok-ingress-controller
-
-NAME                                                              READY   STATUS    RESTARTS   AGE
-ngrok-ingress-controller-kubernetes-ingress-controller-man2fg5p   1/1     Running   0          2m23s
-```
+   ```bash
+   kubectl get pods -l 'app.kubernetes.io/name=kubernetes-ingress-controller' --namespace ngrok-ingress-controller
+   
+   NAME                                                              READY   STATUS    RESTARTS   AGE
+   ngrok-ingress-controller-kubernetes-ingress-controller-man2fg5p   1/1     Running   0          2m23s
+   ```
 
 ## **Step 3**: Install a sample application {#install-a-sample-application}
 
@@ -154,99 +150,104 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    section](https://dashboard.ngrok.com/cloud-edge/domains) of the ngrok dashboard and click **Create Domain** or **New
    Domain**. This static subdomain will be your `NGROK_DOMAIN` for the remainder of this guide.
 
-By creating a subdomain on the ngrok network, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
+   By creating a subdomain on the ngrok network, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
 
 1. Create a new Kubernetes manifest (`2048.yaml`) with the below contents. This manifest defines the 2048 application
    service and deployment, then configures the ngrok Ingress Controller to connect the `game-2048` service to the ngrok
    edge via your `NGROK_DOMAIN`.
 
-:::tip Notes: - Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok-free.app`.
-:::
+   :::tip
+   
+   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok.app`.
+   
+   :::
 
-```yaml showLineNumbers
-apiVersion: v1
-kind: Service
-metadata:
-  name: game-2048
-  namespace: ngrok-ingress-controller
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-  selector:
-    app: game-2048
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: game-2048
-  namespace: ngrok-ingress-controller
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: game-2048
-  template:
-    metadata:
-      labels:
-        app: game-2048
-    spec:
-      containers:
-        - name: backend
-          image: alexwhen/docker-2048
-          ports:
-            - name: http
-              containerPort: 80
----
-# ngrok Ingress Controller Configuration
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: game-2048-ingress
-  namespace: ngrok-ingress-controller
-spec:
-  ingressClassName: ngrok
-  rules:
-    # highlight-start
-    - host: NGROK_DOMAIN
-      # highlight-end
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: game-2048
-                port:
-                  number: 80
-```
+   ```yaml showLineNumbers
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: game-2048
+     namespace: ngrok-ingress-controller
+   spec:
+     ports:
+       - name: http
+         port: 80
+         targetPort: 80
+     selector:
+       app: game-2048
+   ---
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: game-2048
+     namespace: ngrok-ingress-controller
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         app: game-2048
+     template:
+       metadata:
+         labels:
+           app: game-2048
+       spec:
+         containers:
+           - name: backend
+             image: alexwhen/docker-2048
+             ports:
+               - name: http
+                 containerPort: 80
+   ---
+   # ngrok Ingress Controller Configuration
+   apiVersion: networking.k8s.io/v1
+   kind: Ingress
+   metadata:
+     name: game-2048-ingress
+     namespace: ngrok-ingress-controller
+   spec:
+     ingressClassName: ngrok
+     rules:
+       # highlight-start
+       - host: NGROK_DOMAIN
+         # highlight-end
+         http:
+           paths:
+             - path: /
+               pathType: Prefix
+               backend:
+                 service:
+                   name: game-2048
+                   port:
+                     number: 80
+   ```
 
 1. Apply the `2048.yaml` manifest to your vcluster.
 
-```bash
-kubectl apply -f 2048.yaml
-```
+   ```bash
+   kubectl apply -f 2048.yaml
+   ```
 
-:::tip
-**Note:** If you get an error when applying the manifest, double check that you've updated the `NGROK_DOMAIN` value
-and try again.
-:::
+   :::tip
+   
+   **Note:** If you get an error when applying the manifest, double check that you've updated the `NGROK_DOMAIN` value
+   and try again.
+   
+   :::
 
 1. Confirm your vcluster successfully deployed your 2048 application by navigating to the [**Edges**
    section](https://dashboard.ngrok.com/cloud-edge/edges) in the ngrok dashboard.
 
-An edge connects your 2048 application, running in your vcluster, to the rest of the world through the ngrok Ingress
+   An edge connects your 2048 application, running in your vcluster, to the rest of the world through the ngrok Ingress
 Controller. You should see a new edge configuration created by `kubernetes-ingress-controller` that matches the domain
 name you entered on L45 of your `2048.yaml` manifest.
 
-Under the **Backend** section of your edge configuration, you can also see cluster details as annotations, like the
+   Under the **Backend** section of your edge configuration, you can also see cluster details as annotations, like the
 namespace and connected service, to validate that your demo application is accessible to external traffic via the
 Ingress Controller.
 
-!["Looking at existing Edge configurations in the ngrok dashboard"](img/ngrok-k8s-vcluster_edges.png)
+   !["Looking at existing Edge configurations in the ngrok dashboard"](img/ngrok-k8s-vcluster_edges.png)
 
-Click on your edge configuration to see additional details and options for advanced ingress needs, like creating
+   Click on your edge configuration to see additional details and options for advanced ingress needs, like creating
 multiple tunnels for load balancing, enabling the [Mutual TLS module](/http/mutual-tls/), adding
 compression, and more. We'll use one of these options, OAuth, in the next step.
 
@@ -254,7 +255,7 @@ compression, and more. We'll use one of these options, OAuth, in the next step.
    and your Ingress Controller will route traffic to your app from any device or external network as long as your
    vcluster remains operational.
 
-!["Navigating directly to the https://one-two-three.ngrok-free.app domain to see the 2048 application"](img/ngrok-k8s-vcluster_2048.png)
+   !["Navigating directly to the https://one-two-three.ngrok-free.app domain to see the 2048 application"](img/ngrok-k8s-vcluster_2048.png)
 
 ## **Step 4**: Add OAuth protection to your demo app {#add-oauth-protection}
 
@@ -267,97 +268,101 @@ allowing ingress and access to your endpoint.
 
 1. Edit your existing `2048.yaml` manifest with the following configuration.
 
-:::tip Notes: - See L42-43 for the additional annotation that this OAuth setup requires. - See L58-69 for the newly added configuration for ngrok's OAuth module, replacing `acme.com` or `ngrok.com` with the domain name for your email address. You can also [configure the OAuth module](https://github.com/ngrok/kubernetes-ingress-controller/blob/main/docs/user-guide/route-modules.md#ngrok-managed-oauth-application) to authenticate individual email addresses.
-:::
-
-```yaml showLineNumbers
-apiVersion: v1
-kind: Service
-metadata:
-  name: game-2048
-  namespace: ngrok-ingress-controller
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-  selector:
-    app: game-2048
----
-# Configuration for the 2048 application, service, and deployment
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: game-2048
-  namespace: ngrok-ingress-controller
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: game-2048
-  template:
-    metadata:
-      labels:
-        app: game-2048
-    spec:
-      containers:
-        - name: backend
-          image: alexwhen/docker-2048
-          ports:
-            - name: http
-              containerPort: 80
----
-# Configuration for ngrok's Kubernetes Ingress Controller
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: game-2048-ingress
-  namespace: ngrok-ingress-controller
-  # highlight-start
-  annotations:
-    k8s.ngrok.com/modules: oauth
-  # highlight-end
-spec:
-  ingressClassName: ngrok
-  rules:
-    - host: NGROK_DOMAIN
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: game-2048
-                port:
-                  number: 80
----
-# highlight-start
-# Configuration for ngrok's OAuth authentication module
-kind: NgrokModuleSet
-apiVersion: ingress.k8s.ngrok.com/v1alpha1
-metadata:
-  name: oauth
-  namespace: ngrok-ingress-controller
-modules:
-  oauth:
-    google:
-      emailDomains:
-        - acme.com
-        - ngrok.com
-#highlight-end
-```
+   :::tip
+   
+   - See L42-43 for the additional annotation that this OAuth setup requires. 
+   - See L58-69 for the newly added configuration for ngrok's OAuth module, replacing `acme.com` or `ngrok.com` with the domain name for your email address. You can also [configure the OAuth module](https://github.com/ngrok/kubernetes-ingress-controller/blob/main/docs/user-guide/route-modules.md#ngrok-managed-oauth-application) to authenticate individual email addresses.
+   
+   :::
+   
+   ```yaml showLineNumbers
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: game-2048
+     namespace: ngrok-ingress-controller
+   spec:
+     ports:
+       - name: http
+         port: 80
+         targetPort: 80
+     selector:
+       app: game-2048
+   ---
+   # Configuration for the 2048 application, service, and deployment
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: game-2048
+     namespace: ngrok-ingress-controller
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         app: game-2048
+     template:
+       metadata:
+         labels:
+           app: game-2048
+       spec:
+         containers:
+           - name: backend
+             image: alexwhen/docker-2048
+             ports:
+               - name: http
+                 containerPort: 80
+   ---
+   # Configuration for ngrok's Kubernetes Ingress Controller
+   apiVersion: networking.k8s.io/v1
+   kind: Ingress
+   metadata:
+     name: game-2048-ingress
+     namespace: ngrok-ingress-controller
+     # highlight-start
+     annotations:
+       k8s.ngrok.com/modules: oauth
+     # highlight-end
+   spec:
+     ingressClassName: ngrok
+     rules:
+       - host: NGROK_DOMAIN
+         http:
+           paths:
+             - path: /
+               pathType: Prefix
+               backend:
+                 service:
+                   name: game-2048
+                   port:
+                     number: 80
+   ---
+   # highlight-start
+   # Configuration for ngrok's OAuth authentication module
+   kind: NgrokModuleSet
+   apiVersion: ingress.k8s.ngrok.com/v1alpha1
+   metadata:
+     name: oauth
+     namespace: ngrok-ingress-controller
+   modules:
+     oauth:
+       google:
+         emailDomains:
+           - acme.com
+           - ngrok.com
+   #highlight-end
+   ```
 
 1. Re-apply your `2048.yaml` configuration.
 
-```bash
-kubectl apply -f 2048.yaml
-```
+   ```bash
+   kubectl apply -f 2048.yaml
+   ```
 
 1. Visit the [**Edges** section](https://dashboard.ngrok.com/cloud-edge/edges/) of the ngrok dashboard, click on the
    edge for your deployment, then click **OAuth** to confirm the module is using the configuration you added to your
    `2048.yaml` manifest.
 
-![Verifying the OAuth module configuration in the ngrok dashboard](img/ngrok-k8s-vcluster_oauth-config.png)
+   ![Verifying the OAuth module configuration in the ngrok dashboard](img/ngrok-k8s-vcluster_oauth-config.png)
 
 1. Access your 2048 app at your domain (e.g. `https://one-two-three.ngrok-free.app`) to verify that it requests
    authentication via Google OAuth before allowing you to access the 2048 app.

--- a/docs/integrations/vcluster/k8s.md
+++ b/docs/integrations/vcluster/k8s.md
@@ -63,7 +63,7 @@ If you don't have a cluster already, create one locally with minikube and instal
 
    ```bash
    kubectl get namespaces
-   
+
    NAME              STATUS   AGE
    default           Active   5m55s
    kube-node-lease   Active   5m55s
@@ -78,28 +78,28 @@ If you don't have a cluster already, create one locally with minikube and instal
    ```
 
 1. To ensure your new local cluster is running properly get the namespaces for your instance. Your list of namespaces in the `my-vcluster` context should look something like this.
-   
+
    ```bash
    kubectl get namespaces
-   
+
    NAME              STATUS   AGE
    default           Active   19s
    kube-system       Active   19s
    kube-public       Active   19s
    kube-node-lease   Active   19s
    ```
-   
+
    If you are not connected to your new vcluster and its kube context, you can run `vcluster connect my-vcluster` to try
    again.
-   
+
    You know have a vcluster installed on your local minikube cluster.
-   
+
    :::note
 
    These steps are partially based the guide [Using the ngrok Ingress Controller to create Preview Environments with vcluster](https://loft.sh/blog/using-the-ngrok-ingress-controller-to-create-preview-environments-with-vcluster/) from [Loft](https://loft.sh/), the maintainers of vcluster.
 
    :::
-   
+
 ## **Step 2**: Install the ngrok Ingress Controller {#install-the-ngrok-ingress-controller}
 
 Now that you have a Kubernetes cluster integrated with vcluster, you can install the [ngrok Kubernetes Ingress
@@ -135,7 +135,7 @@ on your virtual cluster.
 
    ```bash
    kubectl get pods -l 'app.kubernetes.io/name=kubernetes-ingress-controller' --namespace ngrok-ingress-controller
-   
+
    NAME                                                              READY   STATUS    RESTARTS   AGE
    ngrok-ingress-controller-kubernetes-ingress-controller-man2fg5p   1/1     Running   0          2m23s
    ```
@@ -157,9 +157,9 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    edge via your `NGROK_DOMAIN`.
 
    :::tip
-   
+
    Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok.app`.
-   
+
    :::
 
    ```yaml showLineNumbers
@@ -228,28 +228,28 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    ```
 
    :::tip
-   
+
    **Note:** If you get an error when applying the manifest, double check that you've updated the `NGROK_DOMAIN` value
    and try again.
-   
+
    :::
 
 1. Confirm your vcluster successfully deployed your 2048 application by navigating to the [**Edges**
    section](https://dashboard.ngrok.com/cloud-edge/edges) in the ngrok dashboard.
 
    An edge connects your 2048 application, running in your vcluster, to the rest of the world through the ngrok Ingress
-Controller. You should see a new edge configuration created by `kubernetes-ingress-controller` that matches the domain
-name you entered on L45 of your `2048.yaml` manifest.
+   Controller. You should see a new edge configuration created by `kubernetes-ingress-controller` that matches the domain
+   name you entered on L45 of your `2048.yaml` manifest.
 
    Under the **Backend** section of your edge configuration, you can also see cluster details as annotations, like the
-namespace and connected service, to validate that your demo application is accessible to external traffic via the
-Ingress Controller.
+   namespace and connected service, to validate that your demo application is accessible to external traffic via the
+   Ingress Controller.
 
    !["Looking at existing Edge configurations in the ngrok dashboard"](img/ngrok-k8s-vcluster_edges.png)
 
    Click on your edge configuration to see additional details and options for advanced ingress needs, like creating
-multiple tunnels for load balancing, enabling the [Mutual TLS module](/http/mutual-tls/), adding
-compression, and more. We'll use one of these options, OAuth, in the next step.
+   multiple tunnels for load balancing, enabling the [Mutual TLS module](/http/mutual-tls/), adding
+   compression, and more. We'll use one of these options, OAuth, in the next step.
 
 1. Access your 2048 demo app by navigating to the your domain, e.g. `https://one-two-three.ngrok.app`. ngrok's edge
    and your Ingress Controller will route traffic to your app from any device or external network as long as your
@@ -269,12 +269,12 @@ allowing ingress and access to your endpoint.
 1. Edit your existing `2048.yaml` manifest with the following configuration.
 
    :::tip
-   
-   - See L42-43 for the additional annotation that this OAuth setup requires. 
+
+   - See L42-43 for the additional annotation that this OAuth setup requires.
    - See L58-69 for the newly added configuration for ngrok's OAuth module, replacing `acme.com` or `ngrok.com` with the domain name for your email address. You can also [configure the OAuth module](https://github.com/ngrok/kubernetes-ingress-controller/blob/main/docs/user-guide/route-modules.md#ngrok-managed-oauth-application) to authenticate individual email addresses.
-   
+
    :::
-   
+
    ```yaml showLineNumbers
    apiVersion: v1
    kind: Service


### PR DESCRIPTION
In the process of writing my latest integration how-to for AKS, I was referencing past pieces I'd written and noticed a number of formatting errors that hurt readability. The Rancher how-to also had a lengthy YAML with the indentation all messed up, which made me wonder if one could actually duplicate the step.

I also made some small QOL fixes, like changing references from `...ngrok-free.app` to `ngrok.app`.