### PR TITLE
Fix Integrations Hub page for Spectro Cloud

### DIFF
--- a/docs/integrations/spectro-cloud/index.mdx
+++ b/docs/integrations/spectro-cloud/index.mdx
@@ -1,5 +1,5 @@
 ---
-name: Spectro Cloud Palette
+name: spectro-cloud
 title: Spectro Cloud Integration Hub
 sidebar_label: Spectro Cloud
 description: |


### PR DESCRIPTION
I mis-configured the Integrations Hub frontmatter in #575, which meant the page didn't show associated how-to guide. This PR should fix that.