### PR TITLE
Adding links to the setup and installation pages in the dashboard

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -47,6 +47,8 @@ Run this in an Administrator Command Prompt.
 Or [download the ngrok agent from our Download
 page](https://ngrok.com/download) if you can't use one of the options above.
 
+Going to the [Setup & Installation page in the dashboard](https://dashboard.ngrok.com/get-started/setup) will also provide installation directions and commands specific to your platform.
+
 The ngrok agent is a zero-dependency CLI program that runs on all major
 operating systems. Test that you installed it correctly by running the
 following command in your terminal and confirm that ngrok prints its help text.
@@ -68,6 +70,8 @@ the ngrok agent to your account.
 ```bash
 ngrok config add-authtoken <TOKEN>
 ```
+
+Going to the [Setup & Installation page in the dashboard](https://dashboard.ngrok.com/get-started/setup) will also provide a configuration command specific to your account.
 
 ## Step 3: Put your app online
 


### PR DESCRIPTION
These pages can detect platform and have explicit directions which include the account's authtoken.