### PR TITLE
docs(agent): changelog for 3.6.0

### DIFF
--- a/docs/agent/changelog.md
+++ b/docs/agent/changelog.md
@@ -10,6 +10,7 @@ title: Changelog
 
 - Added `--policy-file` flag that accepts Traffic Policy configuration for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
 - Added support for `policy` field in [agent config](/http/traffic-policy/?cty=agent-config) for Traffic Policy configuration.
+- Added concise help text when `ngrok` is run without any args
 
 ### ngrok Agent 3.5.0 - \[2023-12-01\]
 

--- a/docs/agent/changelog.md
+++ b/docs/agent/changelog.md
@@ -8,8 +8,8 @@ title: Changelog
 
 ### ngrok Agent 3.6.0 - \[2024-02-06\]
 
-- Added `--policy-file` flag that accepts Traffic Policy configuration for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
-- Added support for `policy` field in [agent config](/http/traffic-policy/?cty=agent-config) for Traffic Policy configuration.
+- Added `--policy-file` flag that accepts Traffic Policy configuration for HTTP, TCP, or TLS traffic.
+- Added support for `policy` field in agent config for Traffic Policy configuration.
 - Added concise help text when `ngrok` is run without any args
 
 ### ngrok Agent 3.5.0 - \[2023-12-01\]

--- a/docs/agent/changelog.md
+++ b/docs/agent/changelog.md
@@ -6,6 +6,11 @@ title: Changelog
 
 ## v3
 
+### ngrok Agent 3.6.0 - \[2024-02-06\]
+
+- Added `--policy-file` flag that accepts a Traffic Policy configuration file for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
+- Added support for `policy` field in [agent config](/http/traffic-policy/?cty=agent-config) for Traffic Policy configuration.
+
 ### ngrok Agent 3.5.0 - \[2023-12-01\]
 
 - The `--region` flag has been deprecated, ngrok automatically chooses the region with lowest latency

--- a/docs/agent/changelog.md
+++ b/docs/agent/changelog.md
@@ -8,7 +8,7 @@ title: Changelog
 
 ### ngrok Agent 3.6.0 - \[2024-02-06\]
 
-- Added `--policy-file` flag that accepts a Traffic Policy configuration file for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
+- Added `--policy-file` flag that accepts Traffic Policy configuration for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
 - Added support for `policy` field in [agent config](/http/traffic-policy/?cty=agent-config) for Traffic Policy configuration.
 
 ### ngrok Agent 3.5.0 - \[2023-12-01\]


### PR DESCRIPTION
### ngrok Agent 3.6.0 - \[2024-02-06\]

- Added `--policy-file` flag that accepts Traffic Policy configuration for [HTTP](/http/traffic-policy/), [TCP](/tcp/traffic-policy/), or [TLS](/tls/traffic-policy/) traffic.
- Added support for `policy` field in [agent config](/http/traffic-policy/?cty=agent-config) for Traffic Policy configuration.