### PR TITLE
Fix policy gallery for GETs only

### DIFF
--- a/docs/http/traffic-policy/gallery.mdx
+++ b/docs/http/traffic-policy/gallery.mdx
@@ -17,7 +17,7 @@ This rule denies all inbound traffic that is not a GET request.
 	config={{
 		inbound: [
 			{
-				expressions: ["req.Method != GET"],
+				expressions: ["req.Method != 'GET'"],
 				actions: [{ type: "deny" }],
 			},
 		],


### PR DESCRIPTION
This needs quoting, otherwise you get the following error:

```
ERROR:  failed to start tunnel: Invalid policy expression.
ERROR:  ERROR: <input>:1:2: undeclared reference to 'getDate' (in container '')
ERROR:   | (getDate != 1)
ERROR:   | .^.
```

Unless I did something wrong!