### PR TITLE
Updated index pages for ngrok-java SDK GA

### DIFF
--- a/docs/agent-sdks/index.mdx
+++ b/docs/agent-sdks/index.mdx
@@ -44,7 +44,7 @@ ngrok's edge just as if you opened a socket to listen on a port.
 | Rust       | [ngrok-rust docs](https://docs.rs/ngrok/latest/ngrok/)             | [ngrok-rust quickstart](/getting-started/rust/) | [github.com/ngrok/ngrok-rust](https://github.com/ngrok/ngrok-rust)             | Stable |
 | Python     | [ngrok-python docs](https://ngrok.github.io/ngrok-python/)         |                                                 | [github.com/ngrok/ngrok-python](https://github.com/ngrok/ngrok-python)         | Stable |
 | JavaScript | [ngrok-javascript docs](https://ngrok.github.io/ngrok-javascript/) |                                                 | [github.com/ngrok/ngrok-javascript](https://github.com/ngrok/ngrok-javascript) | Stable |
-| Java       |                                                                    |                                                 | [github.com/ngrok/ngrok-java](https://github.com/ngrok/ngrok-java)             | Alpha  |
+| Java       | [ngrok-java docs](https://ngrok.github.io/ngrok-java/)             |                                                 | [github.com/ngrok/ngrok-java](https://github.com/ngrok/ngrok-java)             | Stable |
 
 ## When should I use Agent SDKs?
 

--- a/docs/agent-sdks/index.mdx
+++ b/docs/agent-sdks/index.mdx
@@ -10,6 +10,7 @@ import RandomGoSdkExample from "/examples/go-sdk/http-random.mdx";
 import RandomJavascriptSdkExample from "/examples/javascript-sdk/http-random.mdx";
 import RandomPythonSdkExample from "/examples/python-sdk/http-random.mdx";
 import RandomRustSdkExample from "/examples/rust-sdk/http-random.mdx";
+import RandomJavaSdkExample from "/examples/java-sdk/http-random.mdx";
 
 # Agent SDKs
 
@@ -34,6 +35,10 @@ ngrok's edge just as if you opened a socket to listen on a port.
 	<TabItem value="rust-sdk" label="Rust SDK">
 		<RandomRustSdkExample />
 	</TabItem>
+	<TabItem value="java-sdk" label="Java SDK">
+		<RandomJavaSdkExample />
+	</TabItem>
+
 </Tabs>
 
 ## Supported Languages


### PR DESCRIPTION
Adding changes to the index page for the Agent SDKs to reflect Java SDK GA.
There is an example included that is not modified in this branch, which is why it is still in draft state. That example (and others) are being worked on in https://github.com/ngrok/ngrok-docs/pull/617