### PR TITLE
Adding HTTP examples for ngrok-java

### DIFF
--- a/examples/java-sdk/http-basic-auth.mdx
+++ b/examples/java-sdk/http-basic-auth.mdx
@@ -1,0 +1,32 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    private String username1; //Username for user 1
+    private String password1; //Password for user 1
+    private String username2; //Username for user 2
+    private String password2; //Password for user 2
+
+
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .basicAuthOptions(new Http.Basic.Auth(username1,password1))
+                    .basicAuthOptions(new Http.Basic.Auth(username2,password2));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-basic-auth.mdx
+++ b/examples/java-sdk/http-basic-auth.mdx
@@ -27,6 +27,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-branded-domain.mdx
+++ b/examples/java-sdk/http-branded-domain.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-branded-domain.mdx
+++ b/examples/java-sdk/http-branded-domain.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+              .domain("example.ngrok.app");
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-circuit-breaker.mdx
+++ b/examples/java-sdk/http-circuit-breaker.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-circuit-breaker.mdx
+++ b/examples/java-sdk/http-circuit-breaker.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .circuitBreaker(0.5)
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-compression.mdx
+++ b/examples/java-sdk/http-compression.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .compression()
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-compression.mdx
+++ b/examples/java-sdk/http-compression.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-fileserver-abs-path.mdx
+++ b/examples/java-sdk/http-fileserver-abs-path.mdx
@@ -1,0 +1,5 @@
+:::info
+
+Serving directory files is not supported in the Java SDK.
+
+:::

--- a/examples/java-sdk/http-fileserver-windows.mdx
+++ b/examples/java-sdk/http-fileserver-windows.mdx
@@ -1,0 +1,5 @@
+:::info
+
+Serving directory files is not supported in the Java SDK.
+
+:::

--- a/examples/java-sdk/http-fileserver-working-dir.mdx
+++ b/examples/java-sdk/http-fileserver-working-dir.mdx
@@ -1,0 +1,5 @@
+:::info
+
+Serving directory files is not supported in the Java SDK.
+
+:::

--- a/examples/java-sdk/http-ip-restrictions.mdx
+++ b/examples/java-sdk/http-ip-restrictions.mdx
@@ -1,0 +1,42 @@
+```python
+import ngrok
+
+listener = ngrok.forward("localhost:8080", authtoken_from_env=True,
+    ip_restriction_allow_cidrs=["110.0.0.0/8", "220.12.0.0/16"],
+    ip_restriction_deny_cidrs="110.2.3.4/32")
+
+print(f"Ingress established at: {listener.url()}");
+```
+
+Python SDK Docs:
+
+- [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.allow_cidr](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.allow_cidr)
+- [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.deny_cidr](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.deny_cidr)
+- [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+              .allowCIDR("110.0.0.0/8")
+              .allowCIDR("220.12.0.0/16")
+              .denyCIDR("110.2.3.4/32");
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-ip-restrictions.mdx
+++ b/examples/java-sdk/http-ip-restrictions.mdx
@@ -13,6 +13,7 @@ Python SDK Docs:
 - [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.allow_cidr](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.allow_cidr)
 - [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.deny_cidr](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.deny_cidr)
 - [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+
 ```java
 import com.ngrok.Session;
 import com.ngrok.Http;
@@ -37,6 +38,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-oauth-authn.mdx
+++ b/examples/java-sdk/http-oauth-authn.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .oauthOptions(new Http.OAuth("google"));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-oauth-authn.mdx
+++ b/examples/java-sdk/http-oauth-authn.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-oauth-authz.mdx
+++ b/examples/java-sdk/http-oauth-authz.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-oauth-authz.mdx
+++ b/examples/java-sdk/http-oauth-authz.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .oauthOptions(new Http.OAuth("google")..allowDomain(“acme.org”).allowEmail("kate.libby@gmail.com")));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-oauth-byo-app.mdx
+++ b/examples/java-sdk/http-oauth-byo-app.mdx
@@ -13,6 +13,7 @@ Python SDK Docs:
 
 - [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.oauth](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.oauth)
 - [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+
 ```java
 import com.ngrok.Session;
 import com.ngrok.Http;
@@ -38,6 +39,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-oauth-byo-app.mdx
+++ b/examples/java-sdk/http-oauth-byo-app.mdx
@@ -1,0 +1,43 @@
+```python
+import ngrok
+
+listener = ngrok.forward("localhost:8080", authtoken_from_env=True,
+    oauth_provider="microsoft",
+    oauth_client_id="{client id}",
+    oauth_client_secret="{client secret}")
+
+print(f"Ingress established at: {listener.url()}");
+```
+
+Python SDK Docs:
+
+- [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.oauth](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.oauth)
+- [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+
+    private String clientId; // Value for Client ID
+    private String clientSecret; // Value for Client Secret
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .oauthOptions(new Http.OAuth("microsoft").client(clientId,clientSecret));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-oauth-customize-scopes.mdx
+++ b/examples/java-sdk/http-oauth-customize-scopes.mdx
@@ -1,0 +1,28 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+
+    private String clientId;
+    private String clientSecret;
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+                    .oauthOptions(new Http.OAuth("github").client(clientId,clientSecret).scope("repo").scope("user"));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-oauth-customize-scopes.mdx
+++ b/examples/java-sdk/http-oauth-customize-scopes.mdx
@@ -7,8 +7,8 @@ import java.nio.ByteBuffer;
 
 public class Quickstart {
 
-    private String clientId;
-    private String clientSecret;
+    private String clientId; // Value for Client ID
+    private String clientSecret; // Value for Client Secret
     public static void main(String[] args) throws IOException {
         var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
         try (var session = sessionBuilder.connect()) {

--- a/examples/java-sdk/http-oauth-customize-scopes.mdx
+++ b/examples/java-sdk/http-oauth-customize-scopes.mdx
@@ -23,6 +23,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-random.mdx
+++ b/examples/java-sdk/http-random.mdx
@@ -9,7 +9,7 @@ public class Quickstart {
     public static void main(String[] args) throws IOException {
         var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
         try (var session = sessionBuilder.connect()) {
-            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+            var listenerBuilder = session.httpEndpoint().metadata("my listener");
             try (var listener = listenerBuilder.listen()) {
                 System.out.println("ngrok url: " + listener.getUrl());
 

--- a/examples/java-sdk/http-random.mdx
+++ b/examples/java-sdk/http-random.mdx
@@ -1,0 +1,24 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-random.mdx
+++ b/examples/java-sdk/http-random.mdx
@@ -19,6 +19,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-schemes.mdx
+++ b/examples/java-sdk/http-schemes.mdx
@@ -1,0 +1,24 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener").scheme(Http.Scheme.HTTPS)
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-schemes.mdx
+++ b/examples/java-sdk/http-schemes.mdx
@@ -19,6 +19,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-static-domain.mdx
+++ b/examples/java-sdk/http-static-domain.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-static-domain.mdx
+++ b/examples/java-sdk/http-static-domain.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+              .domain("example.ngrok.app");
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-webhook-verification.mdx
+++ b/examples/java-sdk/http-webhook-verification.mdx
@@ -12,6 +12,7 @@ Python SDK Docs:
 
 - [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.webhook_verification](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.webhook_verification)
 - [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+
 ```java
 import com.ngrok.Session;
 import com.ngrok.Http;
@@ -36,6 +37,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-webhook-verification.mdx
+++ b/examples/java-sdk/http-webhook-verification.mdx
@@ -1,0 +1,41 @@
+```python
+import ngrok
+
+listener = ngrok.forward("localhost:8080", authtoken_from_env=True,
+    verify_webhook_provider="twilio",
+    verify_webhook_secret="{twilio signing secret}")
+
+print(f"Ingress established at: {listener.url()}");
+```
+
+Python SDK Docs:
+
+- [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.webhook_verification](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.webhook_verification)
+- [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+private static final String TWILIO_SECRET
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+              .webhookVerification(Http.WebhookVerification("twilio",TWILIO_SECRET));
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-websocket-tcp-converter.mdx
+++ b/examples/java-sdk/http-websocket-tcp-converter.mdx
@@ -1,0 +1,37 @@
+```python
+import ngrok
+
+listener = ngrok.forward("localhost:8080", authtoken_from_env=True,
+    websocket_tcp_converter=True)
+
+print(f"Ingress established at: {listener.url()}");
+```
+
+Python SDK Docs:
+
+- [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.websocket_tcp_conversion](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.websocket_tcp_conversion)
+- [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener").webSocketTcpConversion();
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+

--- a/examples/java-sdk/http-websocket-tcp-converter.mdx
+++ b/examples/java-sdk/http-websocket-tcp-converter.mdx
@@ -11,6 +11,7 @@ Python SDK Docs:
 
 - [https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.websocket_tcp_conversion](https://ngrok.github.io/ngrok-python/http_listener_builder.html#ngrok.HttpListenerBuilder.websocket_tcp_conversion)
 - [https://ngrok.github.io/ngrok-python/index.html#full-configuration](https://ngrok.github.io/ngrok-python/index.html#full-configuration)
+
 ```java
 import com.ngrok.Session;
 import com.ngrok.Http;
@@ -32,6 +33,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-wildcard-domain.mdx
+++ b/examples/java-sdk/http-wildcard-domain.mdx
@@ -20,6 +20,5 @@ public class Quickstart {
 }
 
 ```
+
 Java SDK Docs:
-
-

--- a/examples/java-sdk/http-wildcard-domain.mdx
+++ b/examples/java-sdk/http-wildcard-domain.mdx
@@ -1,0 +1,25 @@
+```java
+import com.ngrok.Session;
+import com.ngrok.Http;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Quickstart {
+    public static void main(String[] args) throws IOException {
+        var sessionBuilder = Session.withAuthtokenFromEnv().metadata("my session");
+        try (var session = sessionBuilder.connect()) {
+            var listenerBuilder = session.httpEndpoint().metadata("my listener")
+              .domain("*.example.com");
+            try (var listener = listenerBuilder.listen()) {
+                System.out.println("ngrok url: " + listener.getUrl());
+
+            }
+        }
+    }
+}
+
+```
+Java SDK Docs:
+
+


### PR DESCRIPTION
Adding HTTP examples for ngrok-java. This is only adding the examples to the `examples` folder, not including them in the docs. This PR is a blocker for https://github.com/ngrok/ngrok-docs/pull/616