### PR TITLE
Fix and consolidate the intro Policy examples

### DIFF
--- a/examples/agent-cli/http-traffic-policy.mdx
+++ b/examples/agent-cli/http-traffic-policy.mdx
@@ -11,12 +11,9 @@ inbound:
       - type: "custom-response"
         config:
           status_code: 404
-          content_type: text/plain
           content: not found
-      - type: "log"
-        config:
-          metadata:
-            message: "foobar request was made"
+          headers:
+            content-type: text/plain
   - name: "BazCookieForLargeRequests"
     expressions:
       - "!hasReqCookie('baz')"

--- a/examples/agent-config/http-traffic-policy.mdx
+++ b/examples/agent-config/http-traffic-policy.mdx
@@ -12,12 +12,9 @@ tunnels:
             - type: "custom-response"
               config:
                 status_code: 404
-                content_type: text/plain
                 content: not found
-            - type: "log"
-              config:
-                metadata:
-                  message: "foobar request was made"
+                headers:
+                  content-type: text/plain
         - name: "BazCookieForLargeRequests"
           expressions:
             - "!hasReqCookie('baz')"

--- a/examples/go-sdk/http-traffic-policy.mdx
+++ b/examples/go-sdk/http-traffic-policy.mdx
@@ -22,8 +22,10 @@ func ngrokListener(ctx context.Context) (net.Listener, error) {
                   Type: "custom-response",
                   Config: map[string]any{
                     "status_code": 400,
-                    "content_type": "text/plain",
                     "content": "not found",
+                    "headers": {
+                      "content_type": "text/plain"
+                    }
                   },
                 },
               },

--- a/examples/javascript-sdk/http-traffic-policy.mdx
+++ b/examples/javascript-sdk/http-traffic-policy.mdx
@@ -27,10 +27,10 @@ const fs = require("fs");
               "config":
                 {
                   "status_code": 404,
-                  "headers": {
-                     "content-type": "text/plain",
-                  }
                   "content": "not found",
+                  "headers": {
+                     "content-type": "text/plain"
+                  }
                 },
             },
           ],

--- a/examples/javascript-sdk/http-traffic-policy.mdx
+++ b/examples/javascript-sdk/http-traffic-policy.mdx
@@ -27,7 +27,9 @@ const fs = require("fs");
               "config":
                 {
                   "status_code": 404,
-                  "content_type": "text/plain",
+                  "headers": {
+                     "content-type": "text/plain",
+                  }
                   "content": "not found",
                 },
             },

--- a/examples/k8s/http-traffic-policy.mdx
+++ b/examples/k8s/http-traffic-policy.mdx
@@ -14,8 +14,9 @@ modules:
           - type: "custom-response"
             config:
               status_code: 404
-              content_type: text/plain
               content: not found
+              headers:
+                content-type: text/plain
       - name: BazCookieForLargeRequests
         expressions:
           - "!hasReqCookie('baz')"

--- a/examples/python-sdk/http-traffic-policy.mdx
+++ b/examples/python-sdk/http-traffic-policy.mdx
@@ -18,8 +18,10 @@ with open('/path/to/policy.json') as f:
               "config":
                 {
                   "status_code": 404,
-                  "content_type": "text/plain",
                   "content": "not found",
+                  "headers": {
+                    "content-type": "text/plain"
+                  }
                 },
             },
           ],


### PR DESCRIPTION
Two things were broken in the example:
-  The `content_type` attribute seems to have been removed in favor of `headers` with `content-type`. I think I got that fixed correctly off of everything.
- The `log` example was out of order and broken. It's also not present in all examples, so I just took it out.

I confirmed the change to the agent config. I haven't and probably don't have time to test _all_ of the others.