### PR TITLE
s/_/- for content-type in go traffic policy example

### DIFF
--- a/examples/go-sdk/http-traffic-policy.mdx
+++ b/examples/go-sdk/http-traffic-policy.mdx
@@ -24,7 +24,7 @@ func ngrokListener(ctx context.Context) (net.Listener, error) {
                     "status_code": 400,
                     "content": "not found",
                     "headers": {
-                      "content_type": "text/plain"
+                      "content-type": "text/plain"
                     }
                   },
                 },


### PR DESCRIPTION
Botched this one. Oops.