### PR TITLE
refactor: remove mention of product tier for Contentful WRV

### DIFF
--- a/docs/integrations/contentful/webhooks.mdx
+++ b/docs/integrations/contentful/webhooks.mdx
@@ -20,10 +20,6 @@ By integrating ngrok with Contentful, you can:
 - **Modify and Replay Contentful webhook requests** with a single click and without spending time reproducing events manually in your Contentful account.
 - **Verify signed Contentful webhook requests** at the edge using ngrok's webhook verification options: `--verify-webhook=contentful --verify-webhook-secret=<webhook signing secret>`
 
-  :::info NOTE
-  [Webhook Request Verification](https://www.contentful.com/developers/docs/webhooks/request-verification/) can be enabled by Contentful customers with a Premium+ subscription.
-  :::
-
 ## **Step 1**: Start your app {#start-your-app}
 
 For this tutorial, we'll use the [sample NodeJS app available on GitHub](https://github.com/ngrok/ngrok-webhook-nodejs-sample).


### PR DESCRIPTION
Removes a note about product tiers for Contentful Webhook Request Verification. This feature will be accessible to all Contentful customers.