### PR TITLE
Fix the links in flask.md

### DIFF
--- a/docs/using-ngrok-with/flask.md
+++ b/docs/using-ngrok-with/flask.md
@@ -12,9 +12,9 @@ This article assumes you have Python, PIP, and Flask already installed.
 
 To share a local Flask development server with someone else, simply run: `ngrok http 5000`.
 
-You may also need to update your `SERVER_NAME` and `APPLICATION_ROOT` in your Flask app configuration to the values provided by ngrok. See the [Flask docs](https://flask.palletsprojects.com/en/3.0.x/config/#builtin-configuration-values) for more information.
+You may also need to update your [`SERVER_NAME`](https://flask.palletsprojects.com/en/3.0.x/config/#SERVER_NAME) and [`APPLICATION_ROOT`](https://flask.palletsprojects.com/en/3.0.x/config/#APPLICATION_ROOT) in your Flask app configuration to the values provided by ngrok. See the [Flask docs](https://flask.palletsprojects.com/en/3.0.x/config/#builtin-configuration-values) for more information.
 
-Note: For users on the latest MacOS, there is an issue where the default port of 5000 is used by Apple AirPlay Receiver. You can use a different port for your Flask app or see this [Stack Overflow post for disabling the AirPlay Receiver service](https://stackoverflow.com/a/6982933/7282727).
+Note: For users on the latest MacOS, there is an issue where the default port 5000 (and 7000) is used by Apple AirPlay Receiver. You can use a different port for your Flask app or disable the Apple AirPlay reciever by disabling it in `System Settings > General > AirDrop & Handoff > AirPlay Receiver`.
 
 ### Python SDK
 


### PR DESCRIPTION
This directly links to the configuration variables in the docs. The link to the stackoverflow post was changed, so I added it directly.