### PR TITLE
Fix the wording on Add Headers

### DIFF
--- a/docs/http/traffic-policy/actions/index.mdx
+++ b/docs/http/traffic-policy/actions/index.mdx
@@ -11,7 +11,7 @@ Traffic Policy actions enable you to modify the behavior of traffic flowing thro
 
 | Type                                   | Description                                                                              | Supported On      |
 | -------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------- |
-| [add-headers](add-headers)             | Add headers from incoming requests or outgoing responses.                                | Inbound, Outbound |
+| [add-headers](add-headers)             | Add headers to incoming requests or outgoing responses.                                  | Inbound, Outbound |
 | [compress-response](compress-response) | Compress HTTP Response bodies as they leave your upstream server.                        | Inbound, Outbound |
 | [custom-response](custom-response)     | Send back a pre-defined custom response to the client.                                   | Inbound, Outbound |
 | [deny](deny)                           | Reject incoming traffic to an endpoint.                                                  | Inbound           |


### PR DESCRIPTION
Update to indicate we are adding headers `to` the request or response rather than `from` the request or response