### PR TITLE
Redirect User Management to new IAM pages

### DIFF
--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -106,6 +106,11 @@ const redirects = [
     [ fromIncludes(`/docs/tls/traffic-policy/expressions/#macros`), `/docs/tls/traffic-policy/expressions/macros` ],
     [ fromIncludes(`/docs/tcp/traffic-policy/expressions/#connection-variables`), `/docs/tcp/traffic-policy/expressions/variables#connection-variables` ],
     [ fromIncludes(`/docs/tcp/traffic-policy/expressions/#macros`), `/docs/tcp/traffic-policy/expressions/macros` ],
+
+    // /docs/user-management/* -> /docs/iam/*
+    [ fromIncludes(`/docs/user-management/#bot-users`), `/docs/iam/bot-users/` ],
+    [ fromIncludes(`/docs/user-management/#sso`), `/docs/iam/users/#dashboard-access` ],
+    [ fromIncludes(`/docs/user-management/#rbac`), `/docs/iam/rbac/` ],
 ]
 
 // get current href from window

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -111,6 +111,7 @@ const redirects = [
     [ fromIncludes(`/docs/user-management/#bot-users`), `/docs/iam/bot-users/` ],
     [ fromIncludes(`/docs/user-management/#sso`), `/docs/iam/users/#dashboard-access` ],
     [ fromIncludes(`/docs/user-management/#rbac`), `/docs/iam/rbac/` ],
+    [ fromIncludes(`/docs/user-management`), `/docs/iam/` ],
 ]
 
 // get current href from window


### PR DESCRIPTION
This fixes issues like our blog post that redirects to an old page with no sidebar and out-dated information to a newer page with the correct information. This also covers the other parts of the page.