### PR TITLE
Kc/update redirect to include format

### DIFF
--- a/docs/http/traffic-policy/actions/redirect.mdx
+++ b/docs/http/traffic-policy/actions/redirect.mdx
@@ -1,7 +1,9 @@
-import { ExampleHTTP } from "/examples/actions/redirect.mdx";
-import VariableInterpolation from "/src/components/VariableInterpolation";
-import HttpHeaderTemplates from "./../../_http_header_templates.mdx";
-import NamedVariblesTemplates from "./_named-variables.mdx";
+import {
+	ExampleHTTP,
+	CelSingleVariable,
+	CelWithCastingExample,
+	CelWithCaptureGroups,
+} from "/examples/actions/redirect.mdx";
 
 # Redirect
 
@@ -17,7 +19,7 @@ Use this action config in your [Traffic Policy](/docs/http/traffic-policy/index.
 
 ## Behavior
 
-When executed this action will abort the request and replace all matches on the inbound URL with the configured replacements. Before regular expression replacement occurs, all named variables will be replaced with their corresponding values.
+When executed this action will abort the request and replace all matches on the inbound URL with the configured replacements. Before regex replacement, all variables or expressions will be replaced with their corresponding values. [Cel expressions](https://ngrok.com/docs/http/traffic-policy/expressions) are used for `ngrok`, and [named variables](#named-variables) for `nginx`.
 
 ## Reference
 
@@ -31,14 +33,18 @@ When executed this action will abort the request and replace all matches on the 
 | ---------- |
 | `redirect` |
 
-| Parameter     | &nbsp;                    | Description                                                                                                                                       |
-| ------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`        | string                    | A regular expression string to match inside of the URL.                                                                                           |
-| `to`          | string                    | A regular expression string to replace the `from` match with. Also contains special [named variables](#named-variables) outside of regular regex. |
-| `status_code` | int                       | 3xx status code used for redirecting, 302 by default.                                                                                             |
-| `headers`     | Map&lt;string, string&gt; | Headers to be added to the request.                                                                                                               |
+| Parameter     | &nbsp;                    | Description                                                                                                                                                     |
+| ------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`        | string                    | A regular expression string to match inside of the URL. Also contains [cel expressions](/docs/http/traffic-policy/expressions/) outside of regular regex.       |
+| `to`          | string                    | A regular expression string to replace the `from` match with. Also contains [cel expressions](/docs/http/traffic-policy/expressions/) outside of regular regex. |
+| `status_code` | int                       | 3xx status code used for redirecting, 302 by default.                                                                                                           |
+| `headers`     | Map&lt;string, string&gt; | Headers to be added to the request.                                                                                                                             |
+| `format`      | string                    | (default: `ngrok`). Determines interpolation format in `to`/`from` fields.                                                                                      |
 
-<NamedVariblesTemplates />
-<VariableInterpolation type="redirect" />
-### Variables
-<HttpHeaderTemplates />
+## Examples
+
+_For an exhaustive list of variables, macros, and expressions, checkout [cel expressions](https://ngrok.com/docs/http/traffic-policy/expressions/)_.
+
+<CelSingleVariable />
+<CelWithCastingExample />
+<CelWithCaptureGroups />

--- a/examples/actions/redirect.mdx
+++ b/examples/actions/redirect.mdx
@@ -2,6 +2,7 @@ import ConfigExample from "../../src/components/ConfigExample.tsx";
 
 export const type = "redirect";
 export const config = {
+	format: "ngrok",
 	from: "v0/user/([0-9]+).*",
 	to: "v1/user?id=$1&$args",
 	status_code: 301,
@@ -11,6 +12,44 @@ export const config = {
 };
 
 export const ExampleHTTP = () => (
-  <ConfigExample config={{ actions: [{ type, config }] }} />
+	<ConfigExample config={{ actions: [{ type, config }] }} />
+);
 
-)
+export const CelSingleVariable = () => (
+	<ConfigExample
+		config={{
+			format: "ngrok",
+			from: "/v1/api/carmen/sandiego?found=${conn.geo.city}",
+			status_code: 301,
+			headers: {
+				rewrite: "true",
+			},
+		}}
+	/>
+);
+
+export const CelWithCastingExample = () => (
+	<ConfigExample
+		config={{
+			format: "ngrok",
+			to: "/v1/api/soon?time=${string(conn.start_ts)}",
+			status_code: 301,
+			headers: {
+				rewrite: "true",
+			},
+		}}
+	/>
+);
+
+export const CelWithCaptureGroups = () => (
+	<ConfigExample
+		config={{
+			format: "ngrok",
+			to: "/v1/api?lat=$1&long=${conn.geo.longitude}",
+			status_code: 301,
+			headers: {
+				rewrite: "true",
+			},
+		}}
+	/>
+);


### PR DESCRIPTION
Adding documentation for `redirect` templating updates. These current changes are just a stopgap; I'll be simplifying the documentation during my `custom-response` essay after conversations with product.