### PR TITLE
Fixed a typo in the metadata

### DIFF
--- a/docs/integrations/linode/gslb.mdx
+++ b/docs/integrations/linode/gslb.mdx
@@ -1,5 +1,5 @@
 ---
-description: In this guide, you'll learn how to layer load balancing between three or more globbly-distributed, cloud-based virtual machines in Linode.
+description: In this guide, you'll learn how to layer load balancing between three or more globally-distributed, cloud-based virtual machines in Linode.
 ---
 
 # Use ngrok's Global Server Load Balancing with Linode


### PR DESCRIPTION
Globally was spelled incorreclty. 