### PR TITLE
Indicate 'traffic policy' is in preview and may have breaking changes

### DIFF
--- a/docs/api/resources/edge-route-policy-module.mdx
+++ b/docs/api/resources/edge-route-policy-module.mdx
@@ -1,3 +1,4 @@
+import TrafficPolicyWarning from "/shared/warnings/traffic-policy-preview.mdx";
 import EdgeRoutePolicyModuleDeleteRequest from "./examples/_edge_route_policy_module_delete_request.md";
 import EdgeRoutePolicyModuleDeleteResponse from "./examples/_edge_route_policy_module_delete_response.md";
 import EdgeRoutePolicyModuleGetRequest from "./examples/_edge_route_policy_module_get_request.md";
@@ -6,6 +7,8 @@ import EdgeRoutePolicyModuleReplaceRequest from "./examples/_edge_route_policy_m
 import EdgeRoutePolicyModuleReplaceResponse from "./examples/_edge_route_policy_module_replace_response.md";
 
 # Edge Route Policy Module
+
+<TrafficPolicyWarning />
 
 ## Replace HTTPS Edge Route Policies Module
 

--- a/docs/http/traffic-policy/index.mdx
+++ b/docs/http/traffic-policy/index.mdx
@@ -14,8 +14,11 @@ import KubernetesExample from "/examples/k8s/http-traffic-policy.mdx";
 import PythonSdkExample from "/examples/python-sdk/http-traffic-policy.mdx";
 import RustSdkExample from "/examples/rust-sdk/http-traffic-policy.mdx";
 import SshExample from "/examples/ssh/http-traffic-policy.mdx";
+import TrafficPolicyWarning from "/shared/warnings/traffic-policy-preview.mdx";
 
 # Traffic Policy
+
+<TrafficPolicyWarning />
 
 ## Overview
 

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -2,6 +2,8 @@
 title: User Guide
 ---
 
+import TrafficPolicyWarning from "/shared/warnings/traffic-policy-preview.mdx";
+
 # User Guide
 
 The guide contains information on how to use the ngrok Kubernetes Operator. This is the place to start if you have the operator installed and want to use it to add ingress, gateways, routes, and other ngrok features to your clusters' apps and services.
@@ -484,6 +486,8 @@ spec:
 ## Traffic Policy
 
 Traffic policies for inbound and outbound traffic can simplifify edge management.
+
+<TrafficPolicyWarning />
 
 ### Design
 

--- a/docs/tcp/traffic-policy/index.mdx
+++ b/docs/tcp/traffic-policy/index.mdx
@@ -14,8 +14,11 @@ import KubernetesExample from "/examples/k8s/tcp-traffic-policy.mdx";
 import PythonSdkExample from "/examples/python-sdk/tcp-traffic-policy.mdx";
 import RustSdkExample from "/examples/rust-sdk/tcp-traffic-policy.mdx";
 import SshExample from "/examples/ssh/tcp-traffic-policy.mdx";
+import TrafficPolicyWarning from "/shared/warnings/traffic-policy-preview.mdx";
 
 # Traffic Policy
+
+<TrafficPolicyWarning />
 
 ## Overview
 

--- a/docs/tls/traffic-policy/index.mdx
+++ b/docs/tls/traffic-policy/index.mdx
@@ -14,8 +14,11 @@ import KubernetesExample from "/examples/k8s/tls-traffic-policy.mdx";
 import PythonSdkExample from "/examples/python-sdk/tls-traffic-policy.mdx";
 import RustSdkExample from "/examples/rust-sdk/tls-traffic-policy.mdx";
 import SshExample from "/examples/ssh/tls-traffic-policy.mdx";
+import TrafficPolicyWarning from "/shared/warnings/traffic-policy-preview.mdx";
 
 # Traffic Policy
+
+<TrafficPolicyWarning />
 
 ## Overview
 

--- a/shared/warnings/traffic-policy-preview.mdx
+++ b/shared/warnings/traffic-policy-preview.mdx
@@ -1,0 +1,6 @@
+:::warning
+
+Traffic Policy is currently in preview.
+Breaking changes may occur at any time with no notice, including changes to the structure of policy documents, the behaviors of policies, and the pricing of this feature.
+
+:::


### PR DESCRIPTION
We've already pushed a number of breaking changes to how we parse policy documents, and it wasn't clear to me from the existing docs that we don't intend backwards compatibility yet, so add notes to that effect.