### PR TITLE
update docs with renamed flags

### DIFF
--- a/docs/agent/cli.mdx
+++ b/docs/agent/cli.mdx
@@ -381,43 +381,45 @@ ngrok http https://localhost:8443           # forward to a local https server
 
 ### Flags
 
-| Flag                               | Description                                                                                                        |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `--authtoken string`               | ngrok authtoken                                                                                                    |
-| `--app-protocol string`            | specify the application protocol to be used: `http1`, `http2` (default `http1`)                                    |
-| `--basic-auth strings`             | enforce basic auth on tunnel endpoint, `user:password`                                                             |
-| `--cidr-allow strings`             | reject connections that do not match the given CIDRs                                                               |
-| `--cidr-deny strings`              | reject connections that match the given CIDRs                                                                      |
-| `--circuit-breaker float`          | reject requests when 5XX responses exceed this ratio                                                               |
-| `--compression`                    | gzip compress http responses from your web service                                                                 |
-| `--config strings`                 | path to config files; they are merged if multiple                                                                  |
-| `--domain string`                  | host tunnel on a custom domain                                                                                     |
-| `-h`, `--help`                     | help for this command                                                                                              |
-| `--host-header string`             | set Host header; if `rewrite` use local address hostname                                                           |
-| `--inspect`                        | enable/disable http introspection (default true)                                                                   |
-| `--log string`                     | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                  |
-| `--log-format string`              | log record format: `term`, `logfmt`, `json` (default `term`)                                                       |
-| `--log-level string`               | logging level: `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                           |
-| `--mutual-tls-cas string`          | path to TLS certificate authority to verify client certs in mutual TLS.                                            |
-| `--oauth string`                   | enforce authentication OAuth2 provider on tunnel endpoint, e.g. `google`                                           |
-| `--oauth-allow-domain strings`     | allow only OAuth2 users with these email domains                                                                   |
-| `--oauth-allow-email strings`      | allow only OAuth2 users with these emails                                                                          |
-| `--oauth-client-id string`         | oauth app client id, optional                                                                                      |
-| `--oauth-client-secret string`     | oauth app client id, optional                                                                                      |
-| `--oauth-scope strings`            | request these OAuth2 scopes when users authenticate                                                                |
-| `--policy-file string`             | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/http/traffic-policy/?cty=agent-cli)) |
-| `--proxy-proto string`             | version of PROXY protocol to use with this tunnel, empty if not using. Example values are 1 or 2.                  |
-| `--region string` (Deprecated)     | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (defaults to closest)                     |
-| `--request-header-add strings`     | header key:value to add to request                                                                                 |
-| `--request-header-remove strings`  | header field to remove from request if present                                                                     |
-| `--response-header-add strings`    | header key:value to add to response                                                                                |
-| `--response-header-remove strings` | header field to remove from response if present                                                                    |
-| `--scheme strings`                 | which scheme to listen on (default `https`)                                                                        |
-| `--ua-filter-allow strings`        | a list of regular expressions for user-agents to allow                                                             |
-| `--ua-filter-deny strings`         | a list of regular expressions for user-agents to deny                                                              |
-| `--verify-webhook string`          | validate webhooks are signed by this provider, e.g. `slack`                                                        |
-| `--verify-webhook-secret string`   | secret used by provider to sign webhooks, if any                                                                   |
-| `--websocket-tcp-converter`        | convert ingress websocket connections to TCP upstream                                                              |
+| Flag                                 | Description                                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `--authtoken string`                 | ngrok authtoken                                                                                                    |
+| `--app-protocol string` (Deprecated) | use '--upstream-protocol' instead                                                                                  |
+| `--basic-auth strings`               | enforce basic auth on tunnel endpoint, `user:password`                                                             |
+| `--cidr-allow strings`               | reject connections that do not match the given CIDRs                                                               |
+| `--cidr-deny strings`                | reject connections that match the given CIDRs                                                                      |
+| `--circuit-breaker float`            | reject requests when 5XX responses exceed this ratio                                                               |
+| `--compression`                      | gzip compress http responses from your web service                                                                 |
+| `--config strings`                   | path to config files; they are merged if multiple                                                                  |
+| `--domain string`                    | host tunnel on a custom domain                                                                                     |
+| `-h`, `--help`                       | help for this command                                                                                              |
+| `--host-header string`               | set Host header; if `rewrite` use local address hostname                                                           |
+| `--inspect`                          | enable/disable http introspection (default true)                                                                   |
+| `--log string`                       | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                  |
+| `--log-format string`                | log record format: `term`, `logfmt`, `json` (default `term`)                                                       |
+| `--log-level string`                 | logging level: `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                           |
+| `--mutual-tls-cas string`            | path to TLS certificate authority to verify client certs in mutual TLS.                                            |
+| `--oauth string`                     | enforce authentication OAuth2 provider on tunnel endpoint, e.g. `google`                                           |
+| `--oauth-allow-domain strings`       | allow only OAuth2 users with these email domains                                                                   |
+| `--oauth-allow-email strings`        | allow only OAuth2 users with these emails                                                                          |
+| `--oauth-client-id string`           | oauth app client id, optional                                                                                      |
+| `--oauth-client-secret string`       | oauth app client id, optional                                                                                      |
+| `--oauth-scope strings`              | request these OAuth2 scopes when users authenticate                                                                |
+| `--policy-file string` (Deprecated)  | use `--traffic-policy-file` instead                                                                                |
+| `--proxy-proto string`               | version of PROXY protocol to use with this tunnel, empty if not using. Example values are 1 or 2.                  |
+| `--region string` (Deprecated)       | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (defaults to closest)                     |
+| `--request-header-add strings`       | header key:value to add to request                                                                                 |
+| `--request-header-remove strings`    | header field to remove from request if present                                                                     |
+| `--response-header-add strings`      | header key:value to add to response                                                                                |
+| `--response-header-remove strings`   | header field to remove from response if present                                                                    |
+| `--scheme strings`                   | which scheme to listen on (default `https`)                                                                        |
+| `--traffic-policy-file string`       | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/http/traffic-policy/?cty=agent-cli)) |
+| `--ua-filter-allow strings`          | a list of regular expressions for user-agents to allow                                                             |
+| `--ua-filter-deny strings`           | a list of regular expressions for user-agents to deny                                                              |
+| `--upstream-protocol string`         | specify the upstream protocol to be used: `http1`, `http2` (default `http1`)                                       |
+| `--verify-webhook string`            | validate webhooks are signed by this provider, e.g. `slack`                                                        |
+| `--verify-webhook-secret string`     | secret used by provider to sign webhooks, if any                                                                   |
+| `--websocket-tcp-converter`          | convert ingress websocket connections to TCP upstream                                                              |
 
 ## ngrok service
 
@@ -512,20 +514,21 @@ ngrok tcp --remote-addr=1.tcp.ngrok.io:27210 3389
 
 ### Flags
 
-| Flag                   | Description                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--authtoken string`   | ngrok authtoken                                                                                                   |
-| `--cidr-allow strings` | reject connections that do not match the given CIDRs                                                              |
-| `--cidr-deny strings`  | reject connections that match the given CIDRs                                                                     |
-| `--config strings`     | path to config files; they are merged if multiple                                                                 |
-| `-h`, `--help`         | help for this command                                                                                             |
-| `--log string`         | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                 |
-| `--log-format string`  | log record format: `term`, `logfmt`, `json` (default `term`)                                                      |
-| `--log-level string`   | `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                                         |
-| `--policy-file string` | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/tcp/traffic-policy/?cty=agent-cli)) |
-| `--proxy-proto string` | version of proxy proto to use with this tunnel, empty if not using                                                |
-| `--region string`      | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (default to closest)                     |
-| `--remote-addr string` | bind remote address (requires you reserve a TCP Address)                                                          |
+| Flag                                | Description                                                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--authtoken string`                | ngrok authtoken                                                                                                   |
+| `--cidr-allow strings`              | reject connections that do not match the given CIDRs                                                              |
+| `--cidr-deny strings`               | reject connections that match the given CIDRs                                                                     |
+| `--config strings`                  | path to config files; they are merged if multiple                                                                 |
+| `-h`, `--help`                      | help for this command                                                                                             |
+| `--log string`                      | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                 |
+| `--log-format string`               | log record format: `term`, `logfmt`, `json` (default `term`)                                                      |
+| `--log-level string`                | `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                                         |
+| `--traffic-policy-file string`      | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/tcp/traffic-policy/?cty=agent-cli)) |
+| `--proxy-proto string`              | version of proxy proto to use with this tunnel, empty if not using                                                |
+| `--policy-file string` (Deprecated) | use `--traffic-policy-file` instead                                                                               |
+| `--region string`                   | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (default to closest)                     |
+| `--remote-addr string`              | bind remote address (requires you reserve a TCP Address)                                                          |
 
 ## ngrok tls
 
@@ -560,24 +563,25 @@ ngrok tls --domain=t.co --crt=/path/to/t.co.crt --key=/path/to/t.co.key 443
 
 ### Flags
 
-| Flag                      | Description                                                                                                             |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--authtoken string`      | ngrok authtoken                                                                                                         |
-| `--cidr-allow strings`    | reject connections that do not match the given CIDRs                                                                    |
-| `--cidr-deny strings`     | reject connections that match the given CIDRs                                                                           |
-| `--config strings`        | path to config files; they are merged if multiple                                                                       |
-| `--crt string`            | path to a TLS certificate for TLS termination                                                                           |
-| `--domain string`         | host tunnel on a custom domain                                                                                          |
-| `-h`, `--help`            | help for this command                                                                                                   |
-| `--key string`            | path to a TLS key for TLS termination                                                                                   |
-| `--log string`            | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                       |
-| `--log-format string`     | log record format: `term`, `logfmt`, `json` (default `term`)                                                            |
-| `--log-level string`      | `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                                               |
-| `--mutual-tls-cas string` | path to TLS certificate authority to verify client certs in mutual TLS                                                  |
-| `--policy-file string`    | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/tls/traffic-policy/?cty=agent-cli))       |
-| `--proxy-proto string`    | version of proxy proto to use with this tunnel, empty if not using                                                      |
-| `--region string`         | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (defaults to closest)                          |
-| `--terminate-at string`   | terminate at ngrok "edge", "agent" or "upstream. Defaults to no termination or "edge" if `--crt` or `--key` are present |
+| Flag                                | Description                                                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--authtoken string`                | ngrok authtoken                                                                                                         |
+| `--cidr-allow strings`              | reject connections that do not match the given CIDRs                                                                    |
+| `--cidr-deny strings`               | reject connections that match the given CIDRs                                                                           |
+| `--config strings`                  | path to config files; they are merged if multiple                                                                       |
+| `--crt string`                      | path to a TLS certificate for TLS termination                                                                           |
+| `--domain string`                   | host tunnel on a custom domain                                                                                          |
+| `-h`, `--help`                      | help for this command                                                                                                   |
+| `--key string`                      | path to a TLS key for TLS termination                                                                                   |
+| `--log string`                      | path to log file, `stdout`, `stderr` or `false` (default `false`)                                                       |
+| `--log-format string`               | log record format: `term`, `logfmt`, `json` (default `term`)                                                            |
+| `--log-level string`                | `debug`, `info`, `warn`, `error`, `crit` (default `info`)                                                               |
+| `--mutual-tls-cas string`           | path to TLS certificate authority to verify client certs in mutual TLS                                                  |
+| `--traffic-policy-file string`      | path to traffic policy configuration YAML or JSON file (See [Traffic Policy](/tls/traffic-policy/?cty=agent-cli))       |
+| `--proxy-proto string`              | version of proxy proto to use with this tunnel, empty if not using                                                      |
+| `--policy-file string` (Deprecated) | use `--traffic-policy-file` instead                                                                                     |
+| `--region string`                   | ngrok server region `us`, `us-cal-1`, `eu`, `au`, `ap`, `sa`, `jp`, `in` (defaults to closest)                          |
+| `--terminate-at string`             | terminate at ngrok "edge", "agent" or "upstream. Defaults to no termination or "edge" if `--crt` or `--key` are present |
 
 ## ngrok tunnel
 

--- a/examples/agent-cli/http-traffic-policy.mdx
+++ b/examples/agent-cli/http-traffic-policy.mdx
@@ -1,5 +1,5 @@
 ```bash
-ngrok http 80 --policy-file /path/to/policy.yml
+ngrok http 80 --traffic-policy-file /path/to/policy.yml
 ```
 
 ```yaml title="policy.yml"

--- a/examples/agent-cli/tcp-traffic-policy.mdx
+++ b/examples/agent-cli/tcp-traffic-policy.mdx
@@ -1,5 +1,5 @@
 ```bash
-ngrok tcp 22 --policy-file /path/to/policy.yml
+ngrok tcp 22 --traffic-policy-file /path/to/policy.yml
 ```
 
 ```yaml title="policy.yml"

--- a/examples/agent-cli/tls-traffic-policy.mdx
+++ b/examples/agent-cli/tls-traffic-policy.mdx
@@ -1,5 +1,5 @@
 ```bash
-ngrok tls 80 --policy-file /path/to/policy.yml
+ngrok tls 80 --traffic-policy-file /path/to/policy.yml
 ```
 
 ```yaml title="policy.yml"


### PR DESCRIPTION
Resolves ngrok-private/ngrok#31125

The docs updates to go with these changes:
- [policy](https://github.com/ngrok-private/ngrok/pull/31060)
- [agent](https://github.com/ngrok-private/ngrok/pull/31101/files)

(To be deployed **after** PRS are merged and go live with thursday's agent release)