### PR TITLE
Update docker.md

### DIFF
--- a/docs/using-ngrok-with/docker.md
+++ b/docs/using-ngrok-with/docker.md
@@ -50,6 +50,7 @@ services:
         image: ngrok/ngrok:latest
         restart: unless-stopped
         command:
+          - "ngrok"
           - "start"
           - "--all"
           - "--config"


### PR DESCRIPTION
corrected documentation, the command should include "ngrok" before the args. Tested in kubernetes, but should apply to docker compose as well.