### PR TITLE
Clarify that only json policy configuration is currently supported

### DIFF
--- a/examples/javascript-sdk/http-traffic-policy.mdx
+++ b/examples/javascript-sdk/http-traffic-policy.mdx
@@ -12,8 +12,14 @@ const fs = require("fs");
 	console.log(`Ingress established at: ${listener.url()}`);
 })();
 ```
+:::info
 
-```yaml title="policy.json"
+Traffic Policies can be defined in `json` only when using the SDKs.
+ Support for `yaml` is coming soon! 
+
+:::
+
+```json title="policy.json"
 {
   "inbound":
     [

--- a/examples/javascript-sdk/http-traffic-policy.mdx
+++ b/examples/javascript-sdk/http-traffic-policy.mdx
@@ -12,57 +12,51 @@ const fs = require("fs");
 	console.log(`Ingress established at: ${listener.url()}`);
 })();
 ```
+
 :::info
 
 Traffic Policies can be defined in `json` only when using the SDKs.
- Support for `yaml` is coming soon! 
+Support for `yaml` is coming soon!
 
 :::
 
 ```json title="policy.json"
 {
-  "inbound":
-    [
-      {
-        "name": "FooBarParamNotFound",
-        "expressions": ["'bar' in getQueryParam('foo')"],
-        "actions":
-          [
-            {
-              "type": "custom-response",
-              "config":
-                {
-                  "status_code": 404,
-                  "content": "not found",
-                  "headers": { "content-type": "text/plain" },
-                },
-            },
-          ],
-      },
-      {
-        "name": "BazCookieForLargeRequests",
-        "expressions": ["!hasReqCookie('baz')", "req.content_length > 5000"],
-        "actions": [{ "type": "deny" }],
-      },
-    ],
-  "outbound":
-    [
-      {
-        "name": "LogUnsuccessfulRequests",
-        "expressions": ["res.status_code < 200 && res.status_code >= 300"],
-        "actions":
-          [
-            {
-              "type": "log",
-              "config":
-                {
-                  "metadata":
-                    { "hostport": "example.com:443", "success": false },
-                },
-            },
-          ],
-      },
-    ],
+	"inbound": [
+		{
+			"name": "FooBarParamNotFound",
+			"expressions": ["'bar' in getQueryParam('foo')"],
+			"actions": [
+				{
+					"type": "custom-response",
+					"config": {
+						"status_code": 404,
+						"content": "not found",
+						"headers": { "content-type": "text/plain" }
+					}
+				}
+			]
+		},
+		{
+			"name": "BazCookieForLargeRequests",
+			"expressions": ["!hasReqCookie('baz')", "req.content_length > 5000"],
+			"actions": [{ "type": "deny" }]
+		}
+	],
+	"outbound": [
+		{
+			"name": "LogUnsuccessfulRequests",
+			"expressions": ["res.status_code < 200 && res.status_code >= 300"],
+			"actions": [
+				{
+					"type": "log",
+					"config": {
+						"metadata": { "hostport": "example.com:443", "success": false }
+					}
+				}
+			]
+		}
+	]
 }
 ```
 

--- a/examples/python-sdk/http-traffic-policy.mdx
+++ b/examples/python-sdk/http-traffic-policy.mdx
@@ -7,54 +7,47 @@ with open('/path/to/policy.json') as f:
 :::info
 
 Traffic Policies can be defined in `json` only when using the SDKs.
- Support for `yaml` is coming soon! 
+Support for `yaml` is coming soon!
 
 :::
 
 ```json title="policy.json"
 {
-  "inbound":
-    [
-      {
-        "name": "FooBarParamNotFound",
-        "expressions": ["'bar' in getQueryParam('foo')"],
-        "actions":
-          [
-            {
-              "type": "custom-response",
-              "config":
-                {
-                  "status_code": 404,
-                  "content": "not found",
-                  "headers": { "content-type": "text/plain" },
-                },
-            },
-          ],
-      },
-      {
-        "name": "BazCookieForLargeRequests",
-        "expressions": ["!hasReqCookie('baz')", "req.content_length > 5000"],
-        "actions": [{ "type": "deny" }],
-      },
-    ],
-  "outbound":
-    [
-      {
-        "name": "LogUnsuccessfulRequests",
-        "expressions": ["res.status_code < 200 && res.status_code >= 300"],
-        "actions":
-          [
-            {
-              "type": "log",
-              "config":
-                {
-                  "metadata":
-                    { "hostport": "example.com:443", "success": false },
-                },
-            },
-          ],
-      },
-    ],
+	"inbound": [
+		{
+			"name": "FooBarParamNotFound",
+			"expressions": ["'bar' in getQueryParam('foo')"],
+			"actions": [
+				{
+					"type": "custom-response",
+					"config": {
+						"status_code": 404,
+						"content": "not found",
+						"headers": { "content-type": "text/plain" }
+					}
+				}
+			]
+		},
+		{
+			"name": "BazCookieForLargeRequests",
+			"expressions": ["!hasReqCookie('baz')", "req.content_length > 5000"],
+			"actions": [{ "type": "deny" }]
+		}
+	],
+	"outbound": [
+		{
+			"name": "LogUnsuccessfulRequests",
+			"expressions": ["res.status_code < 200 && res.status_code >= 300"],
+			"actions": [
+				{
+					"type": "log",
+					"config": {
+						"metadata": { "hostport": "example.com:443", "success": false }
+					}
+				}
+			]
+		}
+	]
 }
 ```
 

--- a/examples/python-sdk/http-traffic-policy.mdx
+++ b/examples/python-sdk/http-traffic-policy.mdx
@@ -4,7 +4,14 @@ with open('/path/to/policy.json') as f:
 		listener = await session.http_endpoint().policy(policy).listen()
 ```
 
-```yaml title="policy.json"
+:::info
+
+Traffic Policies can be defined in `json` only when using the SDKs.
+ Support for `yaml` is coming soon! 
+
+:::
+
+```json title="policy.json"
 {
   "inbound":
     [


### PR DESCRIPTION
After spending too much time debugging my `yaml` config and then learning we don't support it yet for the SKDs, I'm adding a note so no one else repeats this.