### PR TITLE
Remove site-to-site terminology from devices guide and index

### DIFF
--- a/docs/guides/device-gateway/agent.md
+++ b/docs/guides/device-gateway/agent.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 9
-title: Configure site-to-site connectivity to APIs on devices
+title: Connect to APIs on devices
 description: Connect to APIs on devices.
 tags:
   - guides
@@ -12,7 +12,7 @@ tags:
 ---
 
 This guide provides step-by-step instructions for using ngrok as a device gateway.
-This example shows you how to securely run the ngrok agent at an external site to get access
+This example shows you how to securely run the ngrok agent to access
 to an API running on an IoT device. The connection will be end-to-end encrypted using mutual TLS (mTLS).
 
 For a deeper understanding for how mTLS is implemented within ngrok, reference the [Mutual TLS module
@@ -73,7 +73,7 @@ You should receive a `201` response similar to the following:
 {
 	"id": "agin_2esRkfoq4frGvOVUmfhytlr2zS3",
 	"uri": "/agent_ingresses/agin_2esRkfoq4frGvOVUmfhytlr2zS3",
-	"description": "Custom ingress address for site-to-site connectivity",
+	"description": "Custom ingress address",
 	"domain": "connect.configurable-domain.com",
 	"ns_targets": [
 		"ns-1329.awsdns-38.org",
@@ -128,7 +128,7 @@ create endpoints and receive traffic on any subdomain of your domain.
 
 For example, you might create `*.customer1.{YOUR_DOMAIN}`. You would then be able to create endpoints
 on `app.customer1.{YOUR_DOMAIN}` and `dev.customer1.{YOUR_DOMAIN}`. It can be helpful to create
-a separate subdomain for each customer site you wish to connect to.
+a separate subdomain for each site you wish to connect to.
 
 Run the following command, substituting your API key for `{API_KEY}` and your domain for `{YOUR_DOMAIN}`:
 

--- a/docs/guides/device-gateway/index.md
+++ b/docs/guides/device-gateway/index.md
@@ -9,10 +9,10 @@ ngrok allows you to create secure ingress to any app, IoT device, or service wit
 
 This section provides getting started guides for adding ngrok to the most popular IoT devices, ensuring the agent runs integrated to your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
 
-| Name                                                | Description                                                                                       |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [APIs on Devices with the ngrok agent](/guides/device-gateway/agent)     | Connect to APIs on devices using the ngrok agent with mTLS encryption |
-| [ Linux ](/guides/device-gateway/linux)               | Configure ssh access to remotely manage Linux devices using ngrok                                 |
-| [Raspberry Pi](/guides/device-gateway/raspberry-pi) | Configure ssh access to remotely manage Raspberry Pi devices using ngrok                          |
-| [Raspberry Pi OS](/guides/device-gateway/raspbian)  | Configure ssh access to remotely manage Raspberry Pi OS (formerly Raspbian) devices using ngrok   |
-| [Windows](/guides/device-gateway/windows)           | Configure ssh access to remotely manage Windows devices using ngrok                               |
+| Name                                                                 | Description                                                                                     |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [APIs on Devices with the ngrok agent](/guides/device-gateway/agent) | Connect to APIs on devices using the ngrok agent with mTLS encryption                           |
+| [ Linux ](/guides/device-gateway/linux)                              | Configure ssh access to remotely manage Linux devices using ngrok                               |
+| [Raspberry Pi](/guides/device-gateway/raspberry-pi)                  | Configure ssh access to remotely manage Raspberry Pi devices using ngrok                        |
+| [Raspberry Pi OS](/guides/device-gateway/raspbian)                   | Configure ssh access to remotely manage Raspberry Pi OS (formerly Raspbian) devices using ngrok |
+| [Windows](/guides/device-gateway/windows)                            | Configure ssh access to remotely manage Windows devices using ngrok                             |

--- a/docs/guides/device-gateway/index.md
+++ b/docs/guides/device-gateway/index.md
@@ -11,8 +11,8 @@ This section provides getting started guides for adding ngrok to the most popula
 
 | Name                                                | Description                                                                                       |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [APIs on Devices](/guides/device-gateway/agent)     | Configure site-to-site connectivity to APIs on devices using the ngrok agent with mTLS encryption |
-| [Linux](/guides/device-gateway/linux)               | Configure ssh access to remotely manage Linux devices using ngrok                                 |
+| [APIs on Devices with the ngrok agent](/guides/device-gateway/agent)     | Connect to APIs on devices using the ngrok agent with mTLS encryption |
+| [ Linux ](/guides/device-gateway/linux)               | Configure ssh access to remotely manage Linux devices using ngrok                                 |
 | [Raspberry Pi](/guides/device-gateway/raspberry-pi) | Configure ssh access to remotely manage Raspberry Pi devices using ngrok                          |
 | [Raspberry Pi OS](/guides/device-gateway/raspbian)  | Configure ssh access to remotely manage Raspberry Pi OS (formerly Raspbian) devices using ngrok   |
 | [Windows](/guides/device-gateway/windows)           | Configure ssh access to remotely manage Windows devices using ngrok                               |


### PR DESCRIPTION
Removed site-to-site terminology from device guide.