### PR TITLE
Update policy to traffic_policy on HTTP/TLS/TCP 

### DIFF
--- a/examples/agent-config/http-traffic-policy.mdx
+++ b/examples/agent-config/http-traffic-policy.mdx
@@ -3,7 +3,7 @@ tunnels:
   example:
     proto: http
     addr: 80
-    policy:
+    traffic_policy:
       inbound:
         - name: FooBarParamNotFound
           expressions:

--- a/examples/agent-config/tcp-traffic-policy.mdx
+++ b/examples/agent-config/tcp-traffic-policy.mdx
@@ -3,20 +3,20 @@ tunnels:
   example:
     proto: tcp
     addr: 22
-    policy:
+    traffic_policy:
       inbound:
-      - name: DenyTrafficOutsideUS
-        expressions:
-          - "conn.geo.country_code != 'US'"
-        actions:
-          - type: deny
-      - name: "LogRequestsFromKnownIP"
-        expressions:
-          - "conn.client_ip == '110.0.0.1'"
-        actions:
-          - type: log
-            config:
-              metadata:
-                event: "known-ip",
-                data: "110.0.0.1"
+        - name: DenyTrafficOutsideUS
+          expressions:
+            - "conn.geo.country_code != 'US'"
+          actions:
+            - type: deny
+        - name: "LogRequestsFromKnownIP"
+          expressions:
+            - "conn.client_ip == '110.0.0.1'"
+          actions:
+            - type: log
+              config:
+                metadata:
+                  event: "known-ip",
+                  data: "110.0.0.1"
 ```

--- a/examples/agent-config/tls-traffic-policy.mdx
+++ b/examples/agent-config/tls-traffic-policy.mdx
@@ -3,7 +3,7 @@ tunnels:
   example:
     proto: tls
     addr: 443
-    policy:
+    traffic_policy:
       inbound:
         - name: EnforceTLS1.3
           expressions:


### PR DESCRIPTION
I noticed that after #862, some instances of example config files were changed from `policy` to `traffic_policy`, but that hadn't reached the Traffic Policy-specific doc ([example for HTTP](https://ngrok.com/docs/http/traffic-policy/?cty=agent-config)) for each type of endpoint.

This PR updates those three examples to update the naming. And fixes what I believe to be malformed indentation in the TCP example.