### PR TITLE
Turn Full Example Config into a Fully Documented Default Configuration File

### DIFF
--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -409,7 +409,7 @@ tunnels:
   # | Tunnel with Traffic Policy                                       |
   # --------------------------------------------------------------------
 
-  # Tunnel enforcing traffic policies.
+  # Tunnel with a Traffic Policy.
   #
   # Start with after uncommenting:
   #   ngrok start example-traffic-policy

--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -38,7 +38,9 @@ merging are as follows:
 
 ## Full Example
 
-Below is an example configuration file with all the options filled in.
+Below is a comprehensive configuration file for ngrok with detailed documentation for each option.
+
+To activate a specific option or tunnel, simply uncomment the relevant lines by removing the `#` at the beginning of the line.
 
 ```yaml
 # ngrok Configuration File v2

--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -52,9 +52,9 @@ Below is an example configuration file with all the options filled in.
 # | Authtoken (required)                                               |
 # ----------------------------------------------------------------------
 
-# Specifies the authentication token (authtoken) used to connect to the 
-# ngrok service. 
-# 
+# Specifies the authentication token (authtoken) used to connect to the
+# ngrok service.
+#
 #  (1) You can get your default authtoken through the dashboard:
 #      https://dashboard.ngrok.com/get-started/your-authtoken
 #
@@ -69,7 +69,7 @@ Below is an example configuration file with all the options filled in.
 
 # The ngrok API key used to connect to the ngrok API.
 #
-#  (!) This is only needed when using the ngrok api command and should 
+#  (!) This is only needed when using the ngrok api command and should
 #      not be confused with the authtoken.
 #
 #  (1) You can obtain and manage your API Keys through the dashboard:
@@ -81,8 +81,8 @@ Below is an example configuration file with all the options filled in.
 # | Connect Timeout                                                    |
 # ----------------------------------------------------------------------
 
-# How long to wait when establishing an agent session connection to the 
-# ngrok service. 
+# How long to wait when establishing an agent session connection to the
+# ngrok service.
 #
 # Accepts duration, the default is 10s
 
@@ -106,8 +106,8 @@ Below is an example configuration file with all the options filled in.
 # ----------------------------------------------------------------------
 
 # Sets the console UI background color in the terminal.
-# 
-# To use a color other than black, set to `transparent` and adjust your 
+#
+# To use a color other than black, set to `transparent` and adjust your
 # terminal's background.
 
 #console_ui_color: transparent
@@ -138,8 +138,8 @@ Below is an example configuration file with all the options filled in.
 # | Heartbeat Interval                                                 |
 # ----------------------------------------------------------------------
 
-# How often the ngrok agent should heartbeat to the ngrok servers defined 
-# as a duration. 
+# How often the ngrok agent should heartbeat to the ngrok servers defined
+# as a duration.
 #
 # Accepts a duration (e.g., 10s, 1m). The default value is `10s`.
 
@@ -149,9 +149,9 @@ Below is an example configuration file with all the options filled in.
 # | Heartbeat Tolerance                                                |
 # ----------------------------------------------------------------------
 
-# This setting defines the maximum duration to wait for a heartbeat 
-# response from the server before reconnecting the agent tunnel session. 
-# 
+# This setting defines the maximum duration to wait for a heartbeat
+# response from the server before reconnecting the agent tunnel session.
+#
 # Accepts a duration (e.g., 10s, 1m). The default value is `15s`.
 
 #heartbeat_tolerance: 5s
@@ -160,9 +160,9 @@ Below is an example configuration file with all the options filled in.
 # | Inspect DB Size                                                    |
 # ----------------------------------------------------------------------
 
-# This is the upper limit in bytes on memory to allocate when saving 
-# requests over HTTP tunnels for inspection and reply. 
-# 
+# This is the upper limit in bytes on memory to allocate when saving
+# requests over HTTP tunnels for inspection and reply.
+#
 # Accepts a numeric value. The default is `0`, equivalent to 50MB.
 #
 #   (!) To disable inspection for all tunnels, set the value to `-1`.
@@ -227,7 +227,7 @@ Below is an example configuration file with all the options filled in.
 
 # URL of an HTTP or SOCKS5 proxy for tunnel connections.
 #
-#   (!) ngrok will also respect the `http_proxy` and `http_proxy_env` 
+#   (!) ngrok will also respect the `http_proxy` and `http_proxy_env`
 #       environment variables.
 
 #proxy_url: socks5://localhost:9150
@@ -236,8 +236,8 @@ Below is an example configuration file with all the options filled in.
 # | Remote Management                                                  |
 # ----------------------------------------------------------------------
 
-# Allows remote management of the ngrok agent (stop, restart, update) via 
-# the ngrok API or Dashboard. 
+# Allows remote management of the ngrok agent (stop, restart, update) via
+# the ngrok API or Dashboard.
 #
 # Defaults to `true`.
 
@@ -247,7 +247,7 @@ Below is an example configuration file with all the options filled in.
 # | Root CAs                                                           |
 # ----------------------------------------------------------------------
 
-# Root certificate authorities used to validate TLS connections to the 
+# Root certificate authorities used to validate TLS connections to the
 # ngrok server.
 #
 # Allowed values:
@@ -263,9 +263,9 @@ Below is an example configuration file with all the options filled in.
 
 # This is the URL of the ngrok server to connect to.
 #
-#   (!) You should only set this value if you are using a Custom Agent 
+#   (!) You should only set this value if you are using a Custom Agent
 #       Ingress URL.
-# 
+#
 # https://ngrok.com/docs/agent/ingress/#customize-agent-ingress-address
 
 #server_addr: tunnel.us.ingress.example.com:443
@@ -318,18 +318,18 @@ version: 2
 # | Web Allow Hosts                                                    |
 # ----------------------------------------------------------------------
 
-# List of allowed Host headers for requests to the local agent web 
-# interface and API. The port is stripped from the Host header before 
+# List of allowed Host headers for requests to the local agent web
+# interface and API. The port is stripped from the Host header before
 # matching.
-# 
+#
 # Allowed formats:
 #           8.8.8.8  - Matches exact IP in Host header (e.g., 8.8.8.8).
 #   1:2:3:4:5:6:7:8  - Matches exact IPv6 in Host header.
 #        10.0.0.0/8  - Matches any IP within a CIDR range.
 #       example.com  - Matches exact hostname.
 #      .example.com  - Matches subdomains (e.g., sub.example.com).
-# 
-# The default only allows localhost-like Hosts (localhost, 127.0.0.1, 
+#
+# The default only allows localhost-like Hosts (localhost, 127.0.0.1,
 # ::1, etc.).
 
 #web_allow_hosts:
@@ -342,19 +342,19 @@ version: 2
 
 # Define individual tunnels and their configurations.
 #
-# Each entry under 'tunnels' represents a named tunnel that can be 
+# Each entry under 'tunnels' represents a named tunnel that can be
 # started using the 'ngrok start' command:
 #   https://ngrok.com/docs/agent/cli/#ngrok-start
-# 
+#
 # To start all tunnels at once, use:
 #   ngrok start --all
 #
 # List of common configuration fields:
 #   https://ngrok.com/docs/agent/config/#common-tunnel-configuration-properties
-# 
+#
 # List of HTTP configuration fields:
 #   https://ngrok.com/docs/agent/config/#http-configuration
-# 
+#
 # List of TCP configuration fields:
 #   https://ngrok.com/docs/agent/config/#tcp-configuration
 #
@@ -370,7 +370,7 @@ tunnels:
   # | Basic Tunnel Example                                             |
   # --------------------------------------------------------------------
 
-  # Tunnel configuration for a website protected by basic authentication 
+  # Tunnel configuration for a website protected by basic authentication
   # with a custom host header.
   #
   # Start with after uncommenting:
@@ -411,7 +411,7 @@ tunnels:
   #
   # Start with after uncommenting:
   #   ngrok start example-traffic-policy
-  # 
+  #
   # More info:
   #   https://ngrok.com/docs/http/traffic-policy/
   #   https://ngrok.com/docs/tls/traffic-policy/
@@ -449,7 +449,7 @@ tunnels:
   # Tunnel with load balancing based on labels.
   #
   # If you uncomment this, you can start this tunnel by running:
-  # 
+  #
   #    ngrok start example-load-balanced-edge
 
   # example-load-balanced-edge:
@@ -668,7 +668,7 @@ The following is a list of options that can be configured at the root of your co
 | [heartbeat_interval](#heartbeat_interval)   | How often the ngrok agent should heartbeat to the ngrok servers defined as a duration. Default is 10s.                                                                                             |
 | [heartbeat_tolerance](#heartbeat_tolerance) | Reconnect the agent tunnel session if the server does not respond to a heartbeat within this tolerance defined as a duration. Default is 15s.                                                      |
 | [inspect_db_size](#inspect_db_size)         | The size in bytes of the upper limit on memory to allocate to save requests over HTTP tunnels for inspection and replay.                                                                           |
-| [log_level](#log_level)                     | Logging level of detail. In increasing order of verbosity, possible values are: `crit`, `warn`, `error`, `info`, and `debug`.                                                                                                                   |
+| [log_level](#log_level)                     | Logging level of detail. In increasing order of verbosity, possible values are: `crit`, `warn`, `error`, `info`, and `debug`.                                                                      |
 | [log_format](#log_format)                   | Format of written log records.                                                                                                                                                                     |
 | [log](#log)                                 | Write logs to this target destination.                                                                                                                                                             |
 | [metadata](#metadata)                       | Opaque, user-supplied string that will be returned as part of the ngrok API response to the [list online sessions](/api/resources/tunnel-sessions) resource for all tunnels started by this agent. |

--- a/docs/agent/config.mdx
+++ b/docs/agent/config.mdx
@@ -41,69 +41,422 @@ merging are as follows:
 Below is an example configuration file with all the options filled in.
 
 ```yaml
-authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
-api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
-connect_timeout: 30s
-console_ui: true
-console_ui_color: transparent
-dns_resolver_ips:
-  - 1.1.1.1
-  - 8.8.8.8
-heartbeat_interval: 1m
-heartbeat_tolerance: 5s
-inspect_db_size: 104857600 # 100mb
-inspect_db_size: 50000000
-log_level: info
-log_format: json
-log: /var/log/ngrok.log
-metadata: '{"serial": "00012xa-33rUtz9", "comment": "For customer alan@example.com"}'
-proxy_url: socks5://localhost:9150
-remote_management: false
-root_cas: trusted
-update_channel: stable
-update_check: false
+# ngrok Configuration File v2
+# https://ngrok.com/docs/agent/config/
+
+# ######################################################################
+# # Agent Configuration                                                #
+# ######################################################################
+
+# ----------------------------------------------------------------------
+# | Authtoken (required)                                               |
+# ----------------------------------------------------------------------
+
+# Specifies the authentication token (authtoken) used to connect to the 
+# ngrok service. 
+# 
+#  (1) You can get your default authtoken through the dashboard:
+#      https://dashboard.ngrok.com/get-started/your-authtoken
+#
+#  (2) You can view and generate authtokens through the dashboard
+#      https://dashboard.ngrok.com/tunnels/authtokens
+
+#authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
+
+# ----------------------------------------------------------------------
+# | API Key                                                            |
+# ----------------------------------------------------------------------
+
+# The ngrok API key used to connect to the ngrok API.
+#
+#  (!) This is only needed when using the ngrok api command and should 
+#      not be confused with the authtoken.
+#
+#  (1) You can obtain and manage your API Keys through the dashboard:
+#      https://dashboard.ngrok.com/api-keys
+
+#api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
+
+# ----------------------------------------------------------------------
+# | Connect Timeout                                                    |
+# ----------------------------------------------------------------------
+
+# How long to wait when establishing an agent session connection to the 
+# ngrok service. 
+#
+# Accepts duration, the default is 10s
+
+#connect_timeout: 30s
+
+# ----------------------------------------------------------------------
+# | Console UI                                                         |
+# ----------------------------------------------------------------------
+
+# Enable or disable the console UI in the terminal.
+#
+# Options:
+#   true   - Enable the console UI.
+#   false  - Disable the console UI, use structured log format.
+#   iftty  - (Default) Enable UI only if standard out is a TTY.
+
+#console_ui: iftty
+
+# ----------------------------------------------------------------------
+# | Console UI Color                                                   |
+# ----------------------------------------------------------------------
+
+# Sets the console UI background color in the terminal.
+# 
+# To use a color other than black, set to `transparent` and adjust your 
+# terminal's background.
+
+#console_ui_color: transparent
+
+# ----------------------------------------------------------------------
+# | CRL No Verify                                                      |
+# ----------------------------------------------------------------------
+
+# Skip Certificate Revocation List (CRL) verification if set to true.
+#
+# Accepts a boolean. Default is `false`.
+
+#crl_noverify: false
+
+# ----------------------------------------------------------------------
+# | DNS Resolver IPs                                                   |
+# ----------------------------------------------------------------------
+
+# List of DNS servers for resolving tunnel session DNS.
+#
+# Defaults to using the local system DNS servers.
+
+#dns_resolver_ips:
+#  - 1.1.1.1
+#  - 8.8.8.8
+
+# ----------------------------------------------------------------------
+# | Heartbeat Interval                                                 |
+# ----------------------------------------------------------------------
+
+# How often the ngrok agent should heartbeat to the ngrok servers defined 
+# as a duration. 
+#
+# Accepts a duration (e.g., 10s, 1m). The default value is `10s`.
+
+#heartbeat_interval: 1m
+
+# ----------------------------------------------------------------------
+# | Heartbeat Tolerance                                                |
+# ----------------------------------------------------------------------
+
+# This setting defines the maximum duration to wait for a heartbeat 
+# response from the server before reconnecting the agent tunnel session. 
+# 
+# Accepts a duration (e.g., 10s, 1m). The default value is `15s`.
+
+#heartbeat_tolerance: 5s
+
+# ----------------------------------------------------------------------
+# | Inspect DB Size                                                    |
+# ----------------------------------------------------------------------
+
+# This is the upper limit in bytes on memory to allocate when saving 
+# requests over HTTP tunnels for inspection and reply. 
+# 
+# Accepts a numeric value. The default is `0`, equivalent to 50MB.
+#
+#   (!) To disable inspection for all tunnels, set the value to `-1`.
+
+#inspect_db_size: 104857600 # 100mb
+
+# ----------------------------------------------------------------------
+# | Log Level                                                          |
+# ----------------------------------------------------------------------
+
+# Sets the log detail level. Higher verbosity with each level.
+#
+# Allowed values:
+#    crit  - Critical issues.
+#    warn  - Warnings.
+#   error  - Errors.
+#    info  - Informational messages.
+#   debug  - Detailed debugging info.
+
+#log_level: info
+
+# ----------------------------------------------------------------------
+# | Log Format                                                         |
+# ----------------------------------------------------------------------
+
+# Specifies the format of log records.
+#
+# Allowed values:
+#   logfmt  - Human and machine-friendly key/value pairs.
+#     json  - Newline-separated JSON objects.
+#     term  - Colored format for TTY; otherwise, same as logfmt.
+
+#log_format: json
+
+# ----------------------------------------------------------------------
+# | Log                                                                |
+# ----------------------------------------------------------------------
+
+# This is the destination where ngrok should write the logs.
+#
+# Allowed values:
+#   stdout  - write to standard out
+#   stderr  - write to standard error
+#    false  - disable logging
+#   <path>  - write log records to file path on disk
+
+#log: /var/log/ngrok.log
+
+# ----------------------------------------------------------------------
+# | Metadata                                                           |
+# ----------------------------------------------------------------------
+
+# Custom string included in the ngrok API response for identifying tunnels.
+#
+# Maximum 4096 characters.
+
+#metadata: '{"serial": "00012xa-33rUtz9", "comment": "For customer alan@example.com"}'
+
+# ----------------------------------------------------------------------
+# | Proxy URL                                                          |
+# ----------------------------------------------------------------------
+
+# URL of an HTTP or SOCKS5 proxy for tunnel connections.
+#
+#   (!) ngrok will also respect the `http_proxy` and `http_proxy_env` 
+#       environment variables.
+
+#proxy_url: socks5://localhost:9150
+
+# ----------------------------------------------------------------------
+# | Remote Management                                                  |
+# ----------------------------------------------------------------------
+
+# Allows remote management of the ngrok agent (stop, restart, update) via 
+# the ngrok API or Dashboard. 
+#
+# Defaults to `true`.
+
+#remote_management: false
+
+# ----------------------------------------------------------------------
+# | Root CAs                                                           |
+# ----------------------------------------------------------------------
+
+# Root certificate authorities used to validate TLS connections to the 
+# ngrok server.
+#
+# Allowed values:
+#    trusted - Use only the trusted certificate root for ngrok.com.
+#       host - Use the root certificates trusted by the host's OS (useful for MITM proxies with DPI).
+#     <path> - Path to a PEM file with additional trusted certificate authorities.
+
+#root_cas: trusted
+
+# ----------------------------------------------------------------------
+# | Server Address                                                     |
+# ----------------------------------------------------------------------
+
+# This is the URL of the ngrok server to connect to.
+#
+#   (!) You should only set this value if you are using a Custom Agent 
+#       Ingress URL.
+# 
+# https://ngrok.com/docs/agent/ingress/#customize-agent-ingress-address
+
+#server_addr: tunnel.us.ingress.example.com:443
+
+# ----------------------------------------------------------------------
+# | Update Channel                                                     |
+# ----------------------------------------------------------------------
+
+# Determines the stability of builds for updates.
+#
+#   (!) Use `stable` for any production deployments.
+#
+# Allowed values:
+#     stable - (Default) Production-ready builds.
+#   unstable - Nightly builds; may be unstable. Not for production.
+#       beta - Beta builds; may be unstable. Not for production.
+
+#update_channel: stable
+
+# ----------------------------------------------------------------------
+# | Update Check                                                       |
+# ----------------------------------------------------------------------
+
+# Controls whether the ngrok agent checks for updates.
+#
+# Defaults to true.
+
+#update_check: false
+
+# ----------------------------------------------------------------------
+# | Version  (required)                                                |
+# ----------------------------------------------------------------------
+
+# Specifies the version of the config file to use.
+
 version: 2
-web_addr: localhost:4040
+
+# ----------------------------------------------------------------------
+# | Web Address                                                        |
+# ----------------------------------------------------------------------
+
+# Network address to bind for the local agent web interface and API.
+#
+# https://ngrok.com/docs/agent/web-inspection-interface/
+# https://ngrok.com/docs/agent/api/
+
+#web_addr: localhost:4040
+
+# ----------------------------------------------------------------------
+# | Web Allow Hosts                                                    |
+# ----------------------------------------------------------------------
+
+# List of allowed Host headers for requests to the local agent web 
+# interface and API. The port is stripped from the Host header before 
+# matching.
+# 
+# Allowed formats:
+#           8.8.8.8  - Matches exact IP in Host header (e.g., 8.8.8.8).
+#   1:2:3:4:5:6:7:8  - Matches exact IPv6 in Host header.
+#        10.0.0.0/8  - Matches any IP within a CIDR range.
+#       example.com  - Matches exact hostname.
+#      .example.com  - Matches subdomains (e.g., sub.example.com).
+# 
+# The default only allows localhost-like Hosts (localhost, 127.0.0.1, 
+# ::1, etc.).
+
+#web_allow_hosts:
+#  - 8.8.8.8
+#  - example.com
+
+# ######################################################################
+# # Tunnels Configuration                                              #
+# ######################################################################
+
+# Define individual tunnels and their configurations.
+#
+# Each entry under 'tunnels' represents a named tunnel that can be 
+# started using the 'ngrok start' command:
+#   https://ngrok.com/docs/agent/cli/#ngrok-start
+# 
+# To start all tunnels at once, use:
+#   ngrok start --all
+#
+# List of common configuration fields:
+#   https://ngrok.com/docs/agent/config/#common-tunnel-configuration-properties
+# 
+# List of HTTP configuration fields:
+#   https://ngrok.com/docs/agent/config/#http-configuration
+# 
+# List of TCP configuration fields:
+#   https://ngrok.com/docs/agent/config/#tcp-configuration
+#
+# List of TLS tunnel configuration fields:
+#   https://ngrok.com/docs/agent/config/#tls-configuration
+#
+# List of Labeled tunnel configuration fields:
+#   https://ngrok.com/docs/agent/config/#labeled-tunnel-configuration
+
 tunnels:
-  website:
-    addr: 8888
-    basic_auth:
-      - "bob:bobpassword"
-    schemes:
-      - https
-    host_header: "myapp.ngrok.dev"
-    inspect: false
-    proto: http
-    domain: myapp.ngrok.dev
 
-  e2etls:
-    addr: 9000
-    proto: tls
-    domain: myapp.example.com
-    crt: example.crt
-    key: example.key
+  # --------------------------------------------------------------------
+  # | Basic Tunnel Example                                             |
+  # --------------------------------------------------------------------
 
-  policyenforced:
-    traffic_policy:
-      inbound:
-        - name: LimitIPs
-          expressions:
-            - "conn.client_ip != '1.1.1.1'"
-          actions:
-            - type: deny
-    addr: 8000
-    proto: tcp
+  # Tunnel configuration for a website protected by basic authentication 
+  # with a custom host header.
+  #
+  # Start with after uncommenting:
+  #   ngrok start example-website
 
-  ssh-access:
-    addr: 22
-    proto: tcp
-    remote_addr: 1.tcp.ngrok.io:12345
+  # example-website:
+  #   addr: 8888
+  #   basic_auth:
+  #     - "bob:bobpassword"
+  #   schemes:
+  #     - https
+  #   host_header: "myapp.ngrok.dev"
+  #   inspect: false
+  #   proto: http
+  #   domain: myapp.ngrok.dev
 
-  my-load-balanced-website:
-    labels:
-      - env=prod
-      - team=infra
-    addr: 8000
+  # --------------------------------------------------------------------
+  # | End-to-End TLS Tunnel                                            |
+  # --------------------------------------------------------------------
+
+  # Tunnel configuration for end-to-end TLS connections.
+  #
+  # Start with after uncommenting:
+  #   ngrok start example-e2e-tls
+
+  # example-e2e-tls:
+  #   addr: 9000
+  #   proto: tls
+  #   domain: myapp.example.com
+  #   crt: example.crt
+  #   key: example.key
+
+  # --------------------------------------------------------------------
+  # | Tunnel with Traffic Policy                                       |
+  # --------------------------------------------------------------------
+
+  # Tunnel enforcing traffic policies.
+  #
+  # Start with after uncommenting:
+  #   ngrok start example-traffic-policy
+  # 
+  # More info:
+  #   https://ngrok.com/docs/http/traffic-policy/
+  #   https://ngrok.com/docs/tls/traffic-policy/
+  #   https://ngrok.com/docs/tcp/traffic-policy/
+
+  # example-traffic-policy:
+  #   traffic_policy:
+  #     inbound:
+  #       - name: LimitIPs
+  #         expressions:
+  #           - "conn.client_ip != '1.1.1.1'"  # Example rule to deny specific IPs.
+  #         actions:
+  #           - type: deny
+  #   addr: 8000
+  #   proto: tcp
+
+  # --------------------------------------------------------------------
+  # | SSH Access Tunnel                                                |
+  # --------------------------------------------------------------------
+
+  # Tunnel for SSH access.
+  #
+  # Start with:
+  #   ngrok start example-ssh-access
+
+  # example-ssh-access:
+  #   addr: 22
+  #   proto: tcp
+  #   remote_addr: 1.tcp.ngrok.io:12345
+
+  # --------------------------------------------------------------------
+  # | Load-Balanced Website Tunnel (Edges)                             |
+  # --------------------------------------------------------------------
+
+  # Tunnel with load balancing based on labels.
+  #
+  # If you uncomment this, you can start this tunnel by running:
+  # 
+  #    ngrok start example-load-balanced-edge
+
+  # example-load-balanced-edge:
+  #   labels:
+  #     - env=prod
+  #     - team=infra
+  #   addr: 8000
 ```
 
 ## Tunnel configurations
@@ -315,7 +668,7 @@ The following is a list of options that can be configured at the root of your co
 | [heartbeat_interval](#heartbeat_interval)   | How often the ngrok agent should heartbeat to the ngrok servers defined as a duration. Default is 10s.                                                                                             |
 | [heartbeat_tolerance](#heartbeat_tolerance) | Reconnect the agent tunnel session if the server does not respond to a heartbeat within this tolerance defined as a duration. Default is 15s.                                                      |
 | [inspect_db_size](#inspect_db_size)         | The size in bytes of the upper limit on memory to allocate to save requests over HTTP tunnels for inspection and replay.                                                                           |
-| [log_level](#log_level)                     | Logging level of detail. In increasing order of verbosity, possible values are:                                                                                                                    |
+| [log_level](#log_level)                     | Logging level of detail. In increasing order of verbosity, possible values are: `crit`, `warn`, `error`, `info`, and `debug`.                                                                                                                   |
 | [log_format](#log_format)                   | Format of written log records.                                                                                                                                                                     |
 | [log](#log)                                 | Write logs to this target destination.                                                                                                                                                             |
 | [metadata](#metadata)                       | Opaque, user-supplied string that will be returned as part of the ngrok API response to the [list online sessions](/api/resources/tunnel-sessions) resource for all tunnels started by this agent. |


### PR DESCRIPTION
Many users copy and paste the full example blindly into their configuration file which leads to issues. This change converts the full example into a fully documented configuration file similar to other tools which should lead to forcing users to read each section before enabling functionality. In addition to this, there are numerous improvements which include linking to configuration fields for tunnels, including links to dashboard for obtaining tokens and keys, etc.