### PR TITLE
Fix command to start tunnel with mTLS and add formatting

### DIFF
--- a/docs/guides/device-gateway/agent.md
+++ b/docs/guides/device-gateway/agent.md
@@ -221,7 +221,7 @@ curl \
 https://api.ngrok.com/bot_users
 ```
 
-You should receive a 201 response similar to the following:
+You should receive a `201` response similar to the following:
 
 ```json
 {
@@ -431,7 +431,7 @@ for `{PORT}`:
 curl \
 -H "Content-Type: application/json" -X  \
 POST https://agent.customer1.{YOUR_DOMAIN}/api/tunnels \
--d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"api.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"client-crt.pem", "key":"server-key.pem"'
+-d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"api.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"server-crt.pem", "key":"server-key.pem"}'
 ```
 
 Please note that these certificates should be used for testing purposes only. You should

--- a/docs/guides/site-to-site-apis-mtls/index.mdx
+++ b/docs/guides/site-to-site-apis-mtls/index.mdx
@@ -222,7 +222,7 @@ curl \
 https://api.ngrok.com/bot_users
 ```
 
-You should receive a 201 response similar to the following:
+You should receive a `201` response similar to the following:
 
 ```json
 {
@@ -433,7 +433,7 @@ for `{PORT}`:
 curl \
 -H "Content-Type: application/json" -X  \
 POST https://agent.customer1.{YOUR_DOMAIN}/api/tunnels \
--d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"api.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"client-crt.pem", "key":"server-key.pem"'
+-d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"api.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"server-crt.pem", "key":"server-key.pem"}'
 ```
 
 Please note that these certificates should be used for testing purposes only. You should

--- a/docs/guides/site-to-site-dbs-mtls/index.mdx
+++ b/docs/guides/site-to-site-dbs-mtls/index.mdx
@@ -226,7 +226,7 @@ curl \
 https://api.ngrok.com/bot_users
 ```
 
-You should receive a 201 response similar to the following:
+You should receive a `201` response similar to the following:
 
 ```json
 {
@@ -437,7 +437,7 @@ for `{PORT}`:
 curl \
 -H "Content-Type: application/json" -X  \
 POST https://agent.customer1.{YOUR_DOMAIN}/api/tunnels \
--d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"db.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"client-crt.pem", "key":"server-key.pem"'
+-d '{"name":"passthrough","proto":"tls","terminate_at": "agent", "addr":"{PORT}", "domain":"db.customer1.{YOUR_DOMAIN}","mutual_tls_cas":"ca-crt.pem", "crt":"server-crt.pem", "key":"server-key.pem"}'
 ```
 
 Please note that these certificates should be used for testing purposes only. You should


### PR DESCRIPTION
Changed `client-crt.pem` to `server-crt.pem` in the three new guides that use mTLS. Also formatted a `201` that was missing backticks. Simple PR.