### PR TITLE
Correct variable name

### DIFF
--- a/docs/guides/device-gateway/sdk.md
+++ b/docs/guides/device-gateway/sdk.md
@@ -343,4 +343,4 @@ curl \
 ## Access the API running on the device or device gateway
 
 You should now be able to access the API on the device or device gateway using the value from
-`{YOUR_DOMAIN}` in the request to remote manage your device fleet.
+`{TUNNEL_DOMAIN}` in the request to remote manage your device fleet.


### PR DESCRIPTION
I used `{TUNNEL_DOMAIN}` in the command to start the tunnel and `{YOUR_DOMAIN}` in the block about access the API. I updated it to use the correct variable.