### PR TITLE
Add the delete flag to aws s3 sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Deploy
         run: |
-          aws s3 sync ./build s3://docs-s3.dev-ngrok.com/docs --acl public-read
+          aws s3 sync ./build s3://docs-s3.dev-ngrok.com/docs --delete --acl public-read
           aws s3 sync ./build s3://docs-s3.stage-ngrok.com/docs --acl public-read
           aws s3 sync ./build s3://docs-s3.ngrok.com/docs --acl public-read


### PR DESCRIPTION
We want to remove files that are in the remote but not source directory, so that we stop indexing old content. 

This is to test on dev. 

Docs: 
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html

