### PR TITLE
fix: /docs/network-edge/pops redirect loop

### DIFF
--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -6,7 +6,7 @@ const toReplace = (to) => (path, from) => path.replace(from, to)            // a
 // List of redirects
 //  String values are treated as exacts by default.
 //  Exact matches should be listed first as redirects are stacked
-// 
+//
 // To change behavior you can use the following method structures:
 //  [0 - from]: (path) => [matchStr, boolean (true for match, false for do not match)]
 //  [1 - to]:  (path, from) => string (returned value becomes the new path)
@@ -21,8 +21,8 @@ const redirects = [
     [ fromIncludes(`/docs/platform/events`), `/docs/events/` ],
     [ fromIncludes(`/docs/events/filtering`), `/docs/events/#filters` ],
     [ fromIncludes(`/docs/http-header-templates/`), `/docs/network-edge/http-header-templates/` ],
-    [ fromIncludes(`/docs/network-edge/pops`), `/docs/network-edge/pops/` ],
-    [ fromIncludes(`/docs/platform/pops`), `/docs/network-edge/pops/` ],
+    [ fromIncludes(`/docs/network-edge/pops`), `/docs/network-edge/#points-of-presence` ],
+    [ fromIncludes(`/docs/platform/pops`), `/docs/network-edge/#points-of-presence` ],
     [ fromIncludes(`/docs/best-practices/security-dev-productivity/`), `/docs/guides/security-dev-productivity/` ],
     [ fromIncludes(`/docs/platform/ip-policies/`), `/docs/network-edge/ip-policies/` ],
     [ fromIncludes(`/docs/platform/botusers/`), `/docs/user-management/#bot-users` ],
@@ -147,6 +147,8 @@ for (const redirect of redirects) {
 }
 
 // redirect when the path has changed
-if (newPath != currentPath) {
+if (newPath != currentPath && newPath != window.location.pathname) {
     window.location.href = newPath
+} else {
+    console.error(`ignoring redirect from ${window.location.href} to ${newPath}; looks loopy`)
 }


### PR DESCRIPTION
Before this, going to https://ngrok.com/docs/network-edge/pops/ would redirect loop.

The reason for this is twofold:

1. The match should have been exact, since the redirect was a prefix of itself
2. The redirect check at the bottom checked href ('https://ngrok.com/docs/....') against a path ('/docs/') to see if they were the same, and so they never were.

This updates that check as well.