### PR TITLE
Add the delete flag to remove old docs in stage and prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Deploy
         run: |
           aws s3 sync ./build s3://docs-s3.dev-ngrok.com/docs --delete --acl public-read
-          aws s3 sync ./build s3://docs-s3.stage-ngrok.com/docs --acl public-read
-          aws s3 sync ./build s3://docs-s3.ngrok.com/docs --acl public-read
+          aws s3 sync ./build s3://docs-s3.stage-ngrok.com/docs --delete --acl public-read
+          aws s3 sync ./build s3://docs-s3.ngrok.com/docs --delete --acl public-read


### PR DESCRIPTION
We want to remove files that are in the remote but not source directory, so that we stop indexing old content.

Tested on dev, this is for stage and prod. 

Note: cleaning up dev took almost 2 hours of action run time, for both stage and prod we may see some timeouts on deploy. 

Docs:
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html
