### PR TITLE
Update private -> internal naming in docs

### DIFF
--- a/traffic-policy/actions/forward-internal/behavior.mdx
+++ b/traffic-policy/actions/forward-internal/behavior.mdx
@@ -1,8 +1,8 @@
 ## Behavior
 
-When the Forward Internal action executes, it will look up the specified endpoint and relay any incoming traffic. The endpoint being forwarded to will behave as if the traffic was sent directly to it and execute all of the actions in its associated Traffic Policy. The endpoint being forwarded to must exist in the same ngrok account and be the same protocol as the forwarding endpoint (e.g. an HTTP public endpoint can only forward to an HTTP private endpoint). You also may not forward traffic to a second private endpoint or back to the original endpoint in a loop.
+When the Forward Internal action executes, it will look up the specified endpoint and relay any incoming traffic. The endpoint being forwarded to will behave as if the traffic was sent directly to it and execute all of the actions in its associated Traffic Policy. The endpoint being forwarded to must exist in the same ngrok account and be the same protocol as the forwarding endpoint (e.g. an HTTP public endpoint can only forward to an HTTP internal endpoint). You also may not forward traffic to a second internal endpoint or back to the original endpoint in a loop.
 
-If the forwarding is successful, the response from the upstream for the private endpoint will be sent back to the client making the original request. No further actions in the `inbound` phase will be executed and no traffic will be sent to the upstream for the public endpoint.
+If the forwarding is successful, the response from the upstream for the internal endpoint will be sent back to the client making the original request. No further actions in the `inbound` phase will be executed and no traffic will be sent to the upstream for the public endpoint.
 
 If the forwarding is unsuccessful because the specified endpoint doesn't exist, is offline, or encounters another error, the action will return an error and follow the behavior that is specified by `on_error` (see [Managing Fallback Behavior](#on-error)).
 
@@ -12,7 +12,7 @@ Even if you do not plan to send traffic to a local service when creating a forwa
 
 ### HTTP Headers
 
-When forwarding HTTP requests to another endpoint, the `Host` header will be set to the hostname of the forwarding endpoint. For example, if `example.ngrok.io` is forwarding HTTP requests to `example.private`, the `Host` header received by the upstream will be `example.ngrok.io`.
+When forwarding HTTP requests to another endpoint, the `Host` header will be set to the hostname of the forwarding endpoint. For example, if `example.ngrok.io` is forwarding HTTP requests to `example.internal`, the `Host` header received by the upstream will be `example.ngrok.io`.
 
 The action will also set the `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` headers when making the upstream request. See [Upstream Headers](/docs/http#upstream-headers) for more information.
 

--- a/traffic-policy/actions/forward-internal/config.mdx
+++ b/traffic-policy/actions/forward-internal/config.mdx
@@ -12,7 +12,7 @@ reference for this action.
 | Parameter  | Type     | Description                                                                                                                          |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `url`      | `string` | **Required.** URL of the Endpoint to forward traffic to.                                                                             |
-| `binding`  | `string` | Binding of the Endpoint (only `private` is currently supported).                                                                     |
+| `binding`  | `string` | Binding of the Endpoint (only `internal` is currently supported).                                                                     |
 | `on_error` | `string` | Whether or not further actions in the Traffic Policy should run if there is an error. Must be either `halt` (default) or `continue`. |
 
 ### Supported Directions

--- a/traffic-policy/actions/forward-internal/examples/basic-example.mdx
+++ b/traffic-policy/actions/forward-internal/examples/basic-example.mdx
@@ -2,7 +2,7 @@ import ConfigExample from "/src/components/ConfigExample.tsx";
 
 ### Basic Example
 
-This example configuration will set up a public endpoint (`forward-internal-example.ngrok.io`) forwarding all traffic it receives to a private endpoint (`example.private`) that forwards the request to port `80` on your local machine. Since it is forwarding all traffic to the private endpoint, no traffic will be sent to `8080` which is the upstream port for the public endpoint.
+This example configuration will set up a public endpoint (`forward-internal-example.ngrok.io`) forwarding all traffic it receives to a internal endpoint (`example.internal`) that forwards the request to port `80` on your local machine. Since it is forwarding all traffic to the internal endpoint, no traffic will be sent to `8080` which is the upstream port for the public endpoint.
 
 #### Example Traffic Policy Document
 
@@ -18,7 +18,7 @@ This example configuration will set up a public endpoint (`forward-internal-exam
 					{
 						type: "forward-internal",
 						config: {
-							url: "https://example.private",
+							url: "https://example.internal",
 						},
 					},
 				],
@@ -27,10 +27,10 @@ This example configuration will set up a public endpoint (`forward-internal-exam
 	}}
 />
 
-#### Start Private Endpoint
+#### Start an Internal Endpoint
 
 ```shell
-ngrok http 80 --url example.private --binding private
+ngrok http 80 --url example.internal --binding internal
 ```
 
 #### Start Public Endpoint with Traffic Policy
@@ -51,7 +51,7 @@ $ curl https://forward-internal-example.ngrok.io -v
 ...
 ```
 
-This request will be forwarded to the private endpoint `https://example.private` which will then forward the request to port `80` on your local machine.
+This request will be forwarded to the internal endpoint `https://example.internal` which will then forward the request to port `80` on your local machine.
 
 ```
 GET / HTTP/1.1

--- a/traffic-policy/actions/forward-internal/index.mdx
+++ b/traffic-policy/actions/forward-internal/index.mdx
@@ -1,3 +1,3 @@
 ## Overview
 
-The **Forward Internal** Traffic Policy action enables you to forward traffic from an endpoint to a private endpoint within the same ngrok account. This is useful for safely and securely routing traffic from your public endpoints to other services, giving you the ability to choose when and how your endpoints are made publicly available.
+The **Forward Internal** Traffic Policy action enables you to forward traffic from an endpoint to a internal endpoint within the same ngrok account. This is useful for safely and securely routing traffic from your public endpoints to other services, giving you the ability to choose when and how your endpoints are made publicly available.


### PR DESCRIPTION
We've updated the naming of this feature internally while it's still sufficiently feature-flagged off that it's safe to do so.

Update the docs as well to match that!