### PR TITLE
add-server-addr is deprecated, so we need to update the documentation…

### DIFF
--- a/docs/agent/cli.mdx
+++ b/docs/agent/cli.mdx
@@ -134,7 +134,7 @@ ngrok completion [flags]
 
 The `ngrok config` command updates or verifies ngrok's configuration file.
 
-Use `add-authtoken`, `add-api-key`, or `add-server-addr` to set the corresponding properties.
+Use `add-authtoken`, `add-api-key`, or `add-connect-url` to set the corresponding properties.
 
 Use `check` to test a configuration file for validity. If you have an old configuration file, you can also use `upgrade` to automatically upgrade to the latest version.
 
@@ -150,7 +150,7 @@ ngrok config [flags]
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [add-api-key](#ngrok-config-add-api-key)         | save an API key to configuration file. The API key can be generated in the [API section of the ngrok dashboard](https://dashboard.ngrok.com/api). |
 | [add-authtoken](#ngrok-config-add-authtoken)     | save authtoken to configuration file                                                                                                              |
-| [add-server-addr](#ngrok-config-add-server-addr) | adds the server address (server_addr) to configuration file for custom agent ingress                                                              |
+| [add-connect-url](#ngrok-config-add-connect-url) | adds the server address (server_addr) to configuration file for custom agent ingress                                                              |
 | [check](#ngrok-config-check)                     | check configuration file                                                                                                                          |
 | [edit](#ngrok-config-edit)                       | opens the config file in your system's default editor. It looks specifically for the `SHELL` and `EDITOR` environment variables.                  |
 | [upgrade](#ngrok-config-upgrade)                 | auto-upgrade configuration file                                                                                                                   |
@@ -215,17 +215,17 @@ ngrok config add-authtoken 1rlHSX3HqrqmOWZdeJ6bIv8rfuo_4cmS1QswRGyxcQD8NOukF
 | `--log-format string` | log record format: `term`, `logfmt`, `json` (default `term`)      |
 | `--log-level string`  | `debug`, `info`, `warn`, `error`, `crit` (default `info`)         |
 
-## ngrok config add-server-addr
+## ngrok config add-connect-url
 
-The `ngrok config add-server-addr` command updates the connect url ([`connect_url`](/docs/agent/config/v3/#connect_url)) in the configuration file. This is useful when your account is using [Custom Agent Ingress](/docs/agent/ingress/#customize-agent-ingress-address) and need to configure the `connect_url` to point to your new ingress domain.
+The `ngrok config add-connect-url` command updates the connect url ([`connect_url`](/docs/agent/config/v3/#connect_url)) in the configuration file. This is useful when your account is using [Custom Agent Ingress](/docs/agent/ingress/#customize-agent-ingress-address) and need to configure the `connect_url` to point to your new ingress domain.
 
 ### Usage
 
-    ngrok config add-server-addr agent.example.com:443 [flags]
+    ngrok config add-connect-url agent.example.com:443 [flags]
 
 ### Examples
 
-    ngrok config add-server-addr agent.example.com:443
+    ngrok config add-connect-url agent.example.com:443
 
 ### Flags
 

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -30,7 +30,7 @@ do this by delegating control of a DNS subdomain. ngrok will then populate the
 A/AAAA records and issue the certificates for your new agent ingress address.
 Lastly, you must update the `ngrok.yml` [config file](/agent/config/) to instruct
 your ngrok agent to connect to the new address. You can use the helper command
-[`ngrok config add-server-addr`](/docs/agent/cli/#ngrok-config-add-server-addr) to do this.
+[`ngrok config add-connect-url`](/docs/agent/cli/#ngrok-config-add-connect-url) to do this.
 
 Agents authenticating to your agent ingress address must authenticate to your
 ngrok account. Agents attempting to authenticate with credentials for other
@@ -65,7 +65,7 @@ records on the domain you chose.
 Finally, you must reconfigure your ngrok agent or agent SDKs to use your new
 agent ingress address by adding the [`connect_url`](/docs/agent/config/v3/#connect_url)
 option to your ngrok agent's configuration file. You can use the helper command
-[`ngrok config add-server-addr`](/docs/agent/cli/#ngrok-config-add-server-addr) to do this.
+[`ngrok config add-connect-url`](/docs/agent/cli/#ngrok-config-add-connect-url) to do this.
 
 For example, if the domain of your custom agent ingress is
 `ingress.example.com` then you might add the following line to the agent's

--- a/examples/agent-cli/custom-agent-ingress.mdx
+++ b/examples/agent-cli/custom-agent-ingress.mdx
@@ -1,3 +1,3 @@
 ```bash
-ngrok config add-server-addr tunnel.us.ingress.example.com:443
+ngrok config add-connect-url tunnel.us.ingress.example.com:443
 ```


### PR DESCRIPTION
Okay, technically it's "aliased", but we're going to deprecate it. I've updated to use `add-connect-url`.
