### PR TITLE
Switch --url back to --url when the argument is, in fact, a domain...

### DIFF
--- a/docs/guides/other-guides/how-to-do-weighted-load-balancing-with-ngrok-cloud-edges.mdx
+++ b/docs/guides/other-guides/how-to-do-weighted-load-balancing-with-ngrok-cloud-edges.mdx
@@ -53,7 +53,7 @@ Let’s reserve a subdomain on `ngrok.app`:
 
 ```bash
 ngrok api reserved-domains create \
-	--url ${NGROK_SUBDOMAIN}.ngrok.app
+	--domain ${NGROK_SUBDOMAIN}.ngrok.app
 ```
 
 - Replace or set `NGROK_SUBDOMAIN` as the subdomain you'd like to use for this guide.

--- a/docs/guides/other-guides/how-to-round-robin-load-balance-with-ngrok-cloud-edges.mdx
+++ b/docs/guides/other-guides/how-to-round-robin-load-balance-with-ngrok-cloud-edges.mdx
@@ -51,7 +51,7 @@ Let’s reserve a subdomain on `ngrok.app`:
 
 ```bash
 ngrok api reserved-domains create \
-	--url ${NGROK_SUBDOMAIN}.ngrok.app
+	--domain ${NGROK_SUBDOMAIN}.ngrok.app
 ```
 
 - Replace or set `NGROK_SUBDOMAIN` as the subdomain you'd like to use for this guide.


### PR DESCRIPTION
I got a little overly aggressive with my original regex replace for `--domain` to `--url`. I replaced some items where it _should_ be `domain` (`--url` doesn't make sense for creating a _domain_).