### PR TITLE
feat: adds conn.server_region variable to traffic policy docs

### DIFF
--- a/traffic-policy/variables/conn.mdx
+++ b/traffic-policy/variables/conn.mdx
@@ -4,16 +4,16 @@ import ConfigExample from "/src/components/ConfigExample.tsx";
 
 The following variables are available under the `conn` namespace:
 
-| Name                                   | Type        | Description                                                |
-| -------------------------------------- | ----------- | ---------------------------------------------------------- |
-| [`conn.bytes_in`](#connbytes_in)       | `int64`     | The number of bytes entering the endpoint from the client. |
-| [`conn.bytes_out`](#connbytes_out)     | `int64`     | The number of bytes leaving an endpoint to the client.     |
-| [`conn.client_ip`](#connclient_ip)     | `string`    | Source IP of the connection to the ngrok endpoint.         |
-| [`conn.client_port`](#connclient_port) | `int32`     | Source port of the connection to the ngrok endpoint.       |
-| [`conn.server_ip`](#connserver_ip)     | `string`    | The IP that this connection was established on.            |
-| [`conn.server_port`](#connserver_port) | `int32`     | The port that this connection was established on.          |
-| [`conn.server_region`](#connserver_region) | `string`     | The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through.       |
-| [`conn.ts.start`](#conntsstart)        | `timestamp` | Timestamp when the connection to ngrok was started.        |
+| Name                                       | Type        | Description                                                                                                                               |
+| ------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`conn.bytes_in`](#connbytes_in)           | `int64`     | The number of bytes entering the endpoint from the client.                                                                                |
+| [`conn.bytes_out`](#connbytes_out)         | `int64`     | The number of bytes leaving an endpoint to the client.                                                                                    |
+| [`conn.client_ip`](#connclient_ip)         | `string`    | Source IP of the connection to the ngrok endpoint.                                                                                        |
+| [`conn.client_port`](#connclient_port)     | `int32`     | Source port of the connection to the ngrok endpoint.                                                                                      |
+| [`conn.server_ip`](#connserver_ip)         | `string`    | The IP that this connection was established on.                                                                                           |
+| [`conn.server_port`](#connserver_port)     | `int32`     | The port that this connection was established on.                                                                                         |
+| [`conn.server_region`](#connserver_region) | `string`    | The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through. |
+| [`conn.ts.start`](#conntsstart)            | `timestamp` | Timestamp when the connection to ngrok was started.                                                                                       |
 
 ### `conn.bytes_in`
 

--- a/traffic-policy/variables/conn.mdx
+++ b/traffic-policy/variables/conn.mdx
@@ -12,6 +12,7 @@ The following variables are available under the `conn` namespace:
 | [`conn.client_port`](#connclient_port) | `int32`     | Source port of the connection to the ngrok endpoint.       |
 | [`conn.server_ip`](#connserver_ip)     | `string`    | The IP that this connection was established on.            |
 | [`conn.server_port`](#connserver_port) | `int32`     | The port that this connection was established on.          |
+| [`conn.server_region`](#connserver_region) | `string`     | The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through.       |
 | [`conn.ts.start`](#conntsstart)        | `timestamp` | Timestamp when the connection to ngrok was started.        |
 
 ### `conn.bytes_in`
@@ -65,6 +66,16 @@ The port that this connection was established on.
 <ConfigExample
 	config={{
 		expressions: ["conn.server_port == 80"],
+	}}
+/>
+
+### `conn.server_region`
+
+The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through.
+
+<ConfigExample
+	config={{
+		expressions: ["conn.server_region == 'eu'"],
 	}}
 />
 


### PR DESCRIPTION
This PR adds `conn.server_region` to the traffic policy connection variables. This allows users to look up what point of presence on ngrok serviced the connection for the current request.