### PR TITLE
feat: add conn.server_region to tcp / tls docs

### DIFF
--- a/traffic-policy/variables/conn-tcptls.mdx
+++ b/traffic-policy/variables/conn-tcptls.mdx
@@ -4,14 +4,14 @@ import ConfigExample from "/src/components/ConfigExample.tsx";
 
 The following variables are available under the `conn` namespace:
 
-| Name                                   | Type        | Description                                          |
-| -------------------------------------- | ----------- | ---------------------------------------------------- |
-| [`conn.client_ip`](#connclient_ip)     | `string`    | Source IP of the connection to the ngrok endpoint.   |
-| [`conn.client_port`](#connclient_port) | `int32`     | Source port of the connection to the ngrok endpoint. |
-| [`conn.server_ip`](#connserver_ip)     | `string`    | The IP that this connection was established on.      |
-| [`conn.server_port`](#connserver_port) | `int32`     | The port that this connection was established on.    |
+| Name                                       | Type        | Description                                                                                                                               |
+| ------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`conn.client_ip`](#connclient_ip)         | `string`    | Source IP of the connection to the ngrok endpoint.                                                                                        |
+| [`conn.client_port`](#connclient_port)     | `int32`     | Source port of the connection to the ngrok endpoint.                                                                                      |
+| [`conn.server_ip`](#connserver_ip)         | `string`    | The IP that this connection was established on.                                                                                           |
+| [`conn.server_port`](#connserver_port)     | `int32`     | The port that this connection was established on.                                                                                         |
 | [`conn.server_region`](#connserver_region) | `string`    | The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through. |
-| [`conn.ts.start`](#conntsstart)        | `timestamp` | Timestamp when the connection to ngrok was started.  |
+| [`conn.ts.start`](#conntsstart)            | `timestamp` | Timestamp when the connection to ngrok was started.                                                                                       |
 
 ### `conn.client_ip`
 

--- a/traffic-policy/variables/conn-tcptls.mdx
+++ b/traffic-policy/variables/conn-tcptls.mdx
@@ -10,6 +10,7 @@ The following variables are available under the `conn` namespace:
 | [`conn.client_port`](#connclient_port) | `int32`     | Source port of the connection to the ngrok endpoint. |
 | [`conn.server_ip`](#connserver_ip)     | `string`    | The IP that this connection was established on.      |
 | [`conn.server_port`](#connserver_port) | `int32`     | The port that this connection was established on.    |
+| [`conn.server_region`](#connserver_region) | `string`    | The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through. |
 | [`conn.ts.start`](#conntsstart)        | `timestamp` | Timestamp when the connection to ngrok was started.  |
 
 ### `conn.client_ip`
@@ -43,6 +44,16 @@ The port that this connection was established on.
 <ConfigExample
 	config={{
 		expressions: ["conn.server_port == 80"],
+	}}
+/>
+
+### `conn.server_region`
+
+The ngrok [PoP (Point of Presence)](/docs/network-edge/#points-of-presence) that this connection was established on and serviced through.
+
+<ConfigExample
+	config={{
+		expressions: ["conn.server_region == 'eu'"],
 	}}
 />
 


### PR DESCRIPTION
Adds `conn.server_region` to the TCP / TLS endpoint traffic policy connection variables.