### PR TITLE
API gateway guide: revert to `inbound`

### DIFF
--- a/docs/guides/api-gateway/kubernetes.mdx
+++ b/docs/guides/api-gateway/kubernetes.mdx
@@ -286,7 +286,7 @@ metadata:
   namespace: prod
 spec:
   policy:
-    on_http_request:
+    inbound:
       - name: "Rate limit POST requests"
         expressions:
           - "req.method == 'POST' || req.method == 'PUT'"


### PR DESCRIPTION
I didn't realize that the K8s Operator doesn't yet support phase-based naming, and while it's coming soon (https://github.com/ngrok/ngrok-operator/pull/456), I'd rather this work correctly right now and update it again in the future.