### PR TITLE
restrict conn.tls vars to http phases

### DIFF
--- a/docs/tls/traffic-policy/expressions/variables.mdx
+++ b/docs/tls/traffic-policy/expressions/variables.mdx
@@ -5,7 +5,6 @@ import RestrictIPs from "/traffic-policy/actions/restrict-ips/variables.mdx";
 
 import ConnVariables from "/traffic-policy/variables/conn-tcptls.mdx";
 import ConnGeoVariables from "/traffic-policy/variables/conn.geo.mdx";
-import ConnTlsVariables from "/traffic-policy/variables/conn.tls.mdx";
 import EndpointVariables from "/traffic-policy/variables/endpoint.mdx";
 import TimeVariables from "/traffic-policy/variables/time.mdx";
 
@@ -26,8 +25,6 @@ import TimeVariables from "/traffic-policy/variables/time.mdx";
 <ConnVariables />
 
 <ConnGeoVariables />
-
-<ConnTlsVariables />
 
 <EndpointVariables />
 

--- a/examples/agent-config/tls-traffic-policy.mdx
+++ b/examples/agent-config/tls-traffic-policy.mdx
@@ -1,22 +1,13 @@
 ```yaml
 tunnels:
   example:
-    proto: tls
-    addr: 443
+    proto: tcp
+    addr: 22
     traffic_policy:
       on_tcp_connect:
-        - name: EnforceTLS1.3
+        - name: DenyTrafficOutsideUS
           expressions:
-            - "conn.tls.version != '1.3'"
+            - "conn.geo.country_code != 'US'"
           actions:
             - type: deny
-        - name: "LogRequestsFromKnownIP"
-          expressions:
-            - "conn.client_ip == '110.0.0.1'"
-          actions:
-            - type: log
-              config:
-                metadata:
-                  event: "known-ip"
-                  data: "110.0.0.1"
 ```


### PR DESCRIPTION
These variables will no longer be available in the on_tcp_connect phase, which is all that's available to tls endpoints. I copied the example from TCP to remove reference to tls variables.