### PR TITLE
Update index.mdx

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -17,6 +17,12 @@ own application running locally.
 <Tabs groupId="os" queryString="os">
 <TabItem value="macos" label="Mac OS" default>
 
+Add our tap so Homebrew knows where to find the official ngrok formula. This will be more up to date than what may be in homebrew's default repository
+```bash
+brew tap ngrok/ngrok
+```
+
+Now install the tap so you can use the software
 ```bash
 brew install ngrok/ngrok/ngrok
 ```


### PR DESCRIPTION
Updated documentation so that setup for Macs work

Notes: 
* I had ngrok installed, ran the command, got the message "Press ctrl+U to update", updated, ran the command again, then got errors like "zsh: command ngrok not found" until I uninstalled. After looking into it, and trying to myself, using `brew install ngrok/ngrok/ngrok` only works if you tap the repo first. This update adds that to the setup. 

* This is updating the documentation, but I'm not sure how your https://download.ngrok.com/mac-os works, and also has this issue

* Lastly, MacOS isn't my daily driver, I hope this fix is correct, but you may want to refer to someone with more experience. All I know is that trying the set up instructions didn't work as written, and this fixed it, and makes sense for why as I understand it