### PR TITLE
fix: Change templates title, fix links

### DIFF
--- a/docs/traffic-policy/index.mdx
+++ b/docs/traffic-policy/index.mdx
@@ -52,7 +52,7 @@ Learn how traffic policies work, key concepts, examples, and identity management
 		</div>
 	</Link>
 
-    <Link to={`/traffic-policy/gallery/`}>
+    <Link to={`/traffic-policy/templates/`}>
     	<div className="ngrok--card hover:bg-card-hover">
     		<div className="ngrok--card-heading">
     			<h3 className="text-md sm:text-base">Examples / Use-Cases</h3>

--- a/docs/traffic-policy/templates/index.mdx
+++ b/docs/traffic-policy/templates/index.mdx
@@ -24,10 +24,9 @@ import {
 	UserAgentFilter,
 } from "/traffic-policy/gallery.mdx";
 
-# Rule Gallery
+# Templates
 
-Explore a curated collection of example configurations spanning from common to
-unconventional use cases for the Traffic Policy module.
+Explore a curated collection of examples and configuration templates spanning from common to unconventional use cases for the Traffic Policy module.
 
 A number of these examples come from a longer article about how ngrok [makes policy management accessible](https://ngrok.com/blog-post/api-gateway-policy-management-examples) to developers, including a simple Go-based application for testing these and other configurations.
 

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -188,9 +188,9 @@ const redirects = [
 
     // (DEC 2024) New Traffic Policy
     [ fromIncludes(`/docs/traffic-policy/gallery/`), `/docs/traffic-policy/templates/` ],
-    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
-    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
-    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/http/traffic-policy/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/tls/traffic-policy/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/tcp/traffic-policy/gallery/`), `/docs/traffic-policy/templates/` ],
     [ fromIncludes(`/docs/http/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],
     [ fromIncludes(`/docs/tls/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],
     [ fromIncludes(`/docs/tcp/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -187,6 +187,10 @@ const redirects = [
     [ fromIncludes(`/docs/http-header-templates`), `/docs/http/request-headers/` ],
 
     // (DEC 2024) New Traffic Policy
+    [ fromIncludes(`/docs/traffic-policy/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
+    [ fromIncludes(`/docs/http/traffic-policy/expressions/gallery/`), `/docs/traffic-policy/templates/` ],
     [ fromIncludes(`/docs/http/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],
     [ fromIncludes(`/docs/tls/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],
     [ fromIncludes(`/docs/tcp/traffic-policy/expressions/writing-guide/`), `/docs/traffic-policy/concepts/expressions/#writing-expressions` ],


### PR DESCRIPTION
Fixes the title of the templates section, adds redirects and fixes the overview page link.