### PR TITLE
Make it so the deploy workflow doesn't clobber the rss feed file in t…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Build website
         run: pnpm run build
 
+      - name: Fetch and Modify RSS Feed
+        run: |
+          curl -s https://webflow.dev-ngrok.com/blog-post/rss.xml | sed 's/webflow.dev-ngrok.com/dev-ngrok.com/g' > dev-rss.xml
+          curl -s https://webflow.stage-ngrok.com/blog-post/rss.xml | sed 's/webflow.stage-ngrok.com/stage-ngrok.com/g' > stage-rss.xml
+          curl -s https://webflow.ngrok.com/blog-post/rss.xml | sed 's/webflow.ngrok.com/ngrok.com/g' > rss.xml
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -36,6 +42,11 @@ jobs:
 
       - name: Deploy
         run: |
+          mv dev-rss.xml ./build/blog-post/rss.xml
           aws s3 sync ./build s3://docs-s3.dev-ngrok.com/docs --delete --acl public-read
+
+          mv stage-rss.xml ./build/blog-post/rss.xml
           aws s3 sync ./build s3://docs-s3.stage-ngrok.com/docs --delete --acl public-read
+
+          mv rss.xml ./build/blog-post/rss.xml
           aws s3 sync ./build s3://docs-s3.ngrok.com/docs --delete --acl public-read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Build website
         run: pnpm run build
 
+      # This is mostly the same as the write-rss.yml workflow
+      # Its duplicated because the below Deploy step will --delete any
+      # files in the S3 bucket that are not in the build directory
+      # But we are keeping the other workflow as well so it can run
+      # on a schedule to keep the RSS feeds up to date
       - name: Fetch and Modify RSS Feed
         run: |
           curl -s https://webflow.dev-ngrok.com/blog-post/rss.xml | sed 's/webflow.dev-ngrok.com/dev-ngrok.com/g' > dev-rss.xml

--- a/.github/workflows/write-rss.yml
+++ b/.github/workflows/write-rss.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      # This is partially duplicated from the deploy.yml workflow
       - name: Fetch and Modify RSS Feed
         run: |
           curl -s https://webflow.dev-ngrok.com/blog-post/rss.xml | sed 's/webflow.dev-ngrok.com/dev-ngrok.com/g' > dev-rss.xml


### PR DESCRIPTION
…he bucket

We found that the rss feed will 404 sometimes depending on how recently a deploy job happened. This makes it so a deploy won't remove the RSS files