### PR TITLE
fix: inbound -> on_http_request for forward-internal example

### DIFF
--- a/traffic-policy/actions/forward-internal/examples/1-basic-example.mdx
+++ b/traffic-policy/actions/forward-internal/examples/1-basic-example.mdx
@@ -12,7 +12,7 @@ This example configuration will set up a public endpoint (`forward-internal-exam
 	jsonMetastring="{5-51}"
 	yamlMetastring="{4-28}"
 	config={{
-		inbound: [
+		on_http_request: [
 			{
 				actions: [
 					{


### PR DESCRIPTION
we use `on_http_request` now :)