### PR TITLE
Avoid running deploys in parallel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: "deploy"
+
 jobs:
   deploy:
     name: Deploy ngrok docs


### PR DESCRIPTION
The `aws s3 sync --delete` we're using can conflict with itself if run in parallel.

Specifically, if one action is trying to deploy a new version of docs, and at the same time another action is trying to deploy a different, also new version of docs, they can race such that i.e. we get "index.html" from one, but "main.<hash>.js" from the other, and for `main.<hash>.js` from one to be deleted by the other run

In order to avoid that happening, add github's concurrency control to stop any previous runs before we start a new deploy.

At least, based on my reading of the github action docs, this should do what we want! 