### PR TITLE
add k8s agent endpoint docs

### DIFF
--- a/docs/k8s/crds.md
+++ b/docs/k8s/crds.md
@@ -292,16 +292,24 @@ See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config
 
 #### `url` notes
 
-The following formats are accepted
+The following formats are accepted:
+
 **Domain** - `example.org`
-When using the domain format you are only defining the domain. The scheme and port will be inferred.
+
+- When using the domain format you are only defining the domain. The scheme and port will be inferred.
+
 **Origin** - `https://example.ngrok.app` or `https://example.ngrok.app:443` or `tcp://1.tcp.ngrok.io:12345` or `tls://example.ngrok.app`
-When using the origin format you are defining the protocol, domain and port. HTTP endpoints accept ports 80 or 443 with respective protocol.
+
+- When using the origin format you are defining the protocol, domain and port. HTTP endpoints accept ports 80 or 443 with respective protocol.
+
 **Scheme** (shorthand) - `https://` or `tcp://` or `tls://` or `http://`
-When using scheme you are defining the protocol and will receive back a randomly assigned ngrok address.
+
+- When using scheme you are defining the protocol and will receive back a randomly assigned ngrok address.
+
 **Internal** - `some.domain.internal`
-When ending your url with .internal, an internal endpoint will be created. nternal Endpoints cannot be accessed directly, but rather
-can only be accessed using the forward-internal traffic policy action.
+
+- When ending your url with .internal, an internal endpoint will be created.
+- Internal Endpoints cannot be accessed directly, but rather can only be accessed using the forward-internal traffic policy action.
 
 ### EndpointUpstream
 
@@ -313,28 +321,36 @@ can only be accessed using the forward-internal traffic policy action.
 
 #### `upstream.url` notes
 
+The following formats are supported:
+
 **Origin** - `https://example.org` or `http://example.org:80` or `tcp://127.0.0.1:80`
-When using the origin format you are defining the protocol, domain and port.
-When no port is present and scheme is https or http the port will be inferred.
-For `https` port will be `443`.
-For `http` port will be `80`.
+
+- When using the origin format you are defining the protocol, domain and port.
+- When no port is present and scheme is https or http the port will be inferred.
+  - For `https` port will be `443`.
+  - For `http` port will be `80`.
+
 **Domain** - `example.org`
-This is only allowed for https and http endpoints.
-For tcp and tls endpoints host and port is required.
-When using the domain format you are only defining the host.
-Scheme will default to `http`.
-Port will default to `80`.
+
+- This is only allowed for https and http endpoints. For tcp and tls endpoints host and port is required.
+- When using the domain format you are only defining the host.
+- Scheme will default to `http`.
+- Port will default to `80`.
+
 **Scheme** (shorthand) - `https://`
-This only works for `https` and `http`.
-For `tcp` and `tls` host and port is required.
-When using scheme you are defining the protocol and the port will be inferred on the local host.
-For `https` port will be `443`.
-For `http` port will be `80`.
-Host will be localhost.
+
+- This only works for `https` and `http`.
+- For `tcp` and `tls` host and port is required.
+- When using scheme you are defining the protocol and the port will be inferred on the local host.
+  - For `https` port will be `443`.
+  - For `http` port will be `80`.
+  - Host will be localhost.
+
 **Port** (shorthand) - `8080`
-When using port you are defining the port on the local host that will receive traffic.
-Scheme will default to `http`.
-Host will default to `localhost`.
+
+- When using port you are defining the port on the local host that will receive traffic.
+- Scheme will default to `http`.
+- Host will default to `localhost`.
 
 ### TrafficPolicyCfg
 

--- a/docs/k8s/crds.md
+++ b/docs/k8s/crds.md
@@ -264,3 +264,89 @@ If using a [TCP](#tcp-edges) or [TLS](#tls-edges) CRD, you may need to create an
 | Field              | Type | Required | Description |
 | ------------------ | ---- | -------- | ----------- |
 | No fields defined. |      |          |             |
+
+## Agent Endpoints
+
+Agent endpoints are ephemeral endpoints tied to the lifetime of the agent. When used with the ngrok Kubernetes operator, the operator will manage, create, and delete
+agent endpoints for you according to the configuration of the `AgentEndpoint` custom resources you create.
+
+See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
+
+| Field      | Type                                                                                    | Required | Description                                                                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| apiVersion | string                                                                                  | Yes      | The API version for this custom resource.                                                                                                                                                                                     |
+| kind       | string                                                                                  | Yes      | The kind of the custom resource.                                                                                                                                                                                              |
+| metadata   | [metav1.ObjectMeta](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta) | No       | Standard object's metadata. More info: [https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions#metadata](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions#metadata) |
+| spec       | [AgentEndpointSpec](#agentendpointspec)                                                 | Yes      | Specification of the agent endpoint.                                                                                                                                                                                          |
+
+### AgentEndpointSpec
+
+| Field         | Type                                  | Required | Description                                                                                                                                                                       |
+| ------------- | ------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url           | string                                | Yes      | The unique URL for this agent endpoint. This URL is the public address                                                                                                            |
+| upstream      | [EndpointUpstream](#endpointupstream) | Yes      | Defines the destination for traffic to this agent endpoint                                                                                                                        |
+| trafficPolicy | [TrafficPolicyCfg](#trafficpolicycfg) | No       | Allows configuring a TrafficPolicy to be used with this AgentEndpoint. When configured, the traffic policy is provided inline or as a reference to an NgrokTrafficPolicy resource |
+| description   | string                                | No       | Human-readable description of this agent endpoint                                                                                                                                 |
+| metadata      | string                                | No       | String of arbitrary data associated with the object in the ngrok API/Dashboard                                                                                                    |
+| bindings      | []string                              | No       | List of Binding IDs to associate with the endpoint. Accepted values are `"public"`, `"internal"`, or strings matching the pattern `"k8s/*"`                                       |
+
+#### `url` notes
+
+The following formats are accepted
+**Domain** - `example.org`
+When using the domain format you are only defining the domain. The scheme and port will be inferred.
+**Origin** - `https://example.ngrok.app` or `https://example.ngrok.app:443` or `tcp://1.tcp.ngrok.io:12345` or `tls://example.ngrok.app`
+When using the origin format you are defining the protocol, domain and port. HTTP endpoints accept ports 80 or 443 with respective protocol.
+**Scheme** (shorthand) - `https://` or `tcp://` or `tls://` or `http://`
+When using scheme you are defining the protocol and will receive back a randomly assigned ngrok address.
+**Internal** - `some.domain.internal`
+When ending your url with .internal, an internal endpoint will be created. nternal Endpoints cannot be accessed directly, but rather
+can only be accessed using the forward-internal traffic policy action.
+
+### EndpointUpstream
+
+| Field                | Type         | Required | Description                                                                                                                                            |
+| -------------------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| url                  | string       | Yes      | The local or remote address you would like to incoming traffic to be forwarded to                                                                      |
+| protocol             | enum(string) | No       | Specifies the protocol to use when connecting to the upstream. Currently only http1 and http2 are supported with prior knowledge (defaulting to http1) |
+| proxyProtocolVersion | enum(string) | No       | Optionally specify the version of proxy protocol to use if the upstream requires it                                                                    |
+
+#### `upstream.url` notes
+
+**Origin** - `https://example.org` or `http://example.org:80` or `tcp://127.0.0.1:80`
+When using the origin format you are defining the protocol, domain and port.
+When no port is present and scheme is https or http the port will be inferred.
+For `https` port will be `443`.
+For `http` port will be `80`.
+**Domain** - `example.org`
+This is only allowed for https and http endpoints.
+For tcp and tls endpoints host and port is required.
+When using the domain format you are only defining the host.
+Scheme will default to `http`.
+Port will default to `80`.
+**Scheme** (shorthand) - `https://`
+This only works for `https` and `http`.
+For `tcp` and `tls` host and port is required.
+When using scheme you are defining the protocol and the port will be inferred on the local host.
+For `https` port will be `443`.
+For `http` port will be `80`.
+Host will be localhost.
+**Port** (shorthand) - `8080`
+When using port you are defining the port on the local host that will receive traffic.
+Scheme will default to `http`.
+Host will default to `localhost`.
+
+### TrafficPolicyCfg
+
+See [policy configuration](https://ngrok.com/docs/traffic-policy/) for traffic policy configuration options
+
+| Field     | Type                          | Required | Description                                                                                                         |
+| --------- | ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| inline    | json.RawMessage               | No       | Provides an inline traffic policy for the agent endpoint                                                            |
+| targetRef | [K8sObjectRef](#k8sobjectref) | No       | Identifies an NgrokTrafficPolicy custom resource by name to use as the traffic policy config for the agent endpoint |
+
+### K8sObjectRef
+
+| Field | Type   | Required | Description                                                                                                                                         |
+| ----- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name  | string | Yes      | Identifies a kubernetes resource by name. This resource and the referenced resource must be in the same namespace. The type of the expected/allowed |

--- a/docs/k8s/crds.md
+++ b/docs/k8s/crds.md
@@ -365,6 +365,6 @@ Kubernetes cluster. See [policy configuration](https://ngrok.com/docs/traffic-po
 
 ### K8sObjectRef
 
-| Field | Type   | Required | Description                                                                                                                                         |
-| ----- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Field | Type   | Required | Description                                                                                                        |
+| ----- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
 | name  | string | Yes      | Identifies a kubernetes resource by name. This resource and the referenced resource must be in the same namespace. |

--- a/docs/k8s/crds.md
+++ b/docs/k8s/crds.md
@@ -267,8 +267,9 @@ If using a [TCP](#tcp-edges) or [TLS](#tls-edges) CRD, you may need to create an
 
 ## Agent Endpoints
 
-Agent endpoints are ephemeral endpoints tied to the lifetime of the agent. When used with the ngrok Kubernetes operator, the operator will manage, create, and delete
-agent endpoints for you according to the configuration of the `AgentEndpoint` custom resources you create.
+Agent endpoints are ephemeral endpoints tied to the lifetime of the agent. When used with the ngrok Kubernetes operator, this means that the Agent Endpoints are tied to the operator's `operator-agent` pod (which is deployed by default when installing the operator). The operator will manage, create, and delete
+agent endpoints for you according to the configuration of the `AgentEndpoint` custom resources you create. So long as at least one instance of the `operator-agent` pod is running, your agent endpoints will be available. You may occasionally notice
+the IDs of Agent Endpoints managed by the operator change if the operator pods restart, this will not halt traffic through your agent endpoints unless all of the operator pods have stopped.
 
 See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
 
@@ -325,36 +326,37 @@ The following formats are supported:
 
 **Origin** - `https://example.org` or `http://example.org:80` or `tcp://127.0.0.1:80`
 
-- When using the origin format you are defining the protocol, domain and port.
-- When no port is present and scheme is https or http the port will be inferred.
-  - For `https` port will be `443`.
-  - For `http` port will be `80`.
+- When using the origin format you are defining the protocol, domain and port
+- When no port is present and scheme is https or http the port will be inferred
+  - For `https` port will be `443`
+  - For `http` port will be `80`
 
 **Domain** - `example.org`
 
-- This is only allowed for https and http endpoints. For tcp and tls endpoints host and port is required.
-- When using the domain format you are only defining the host.
-- Scheme will default to `http`.
-- Port will default to `80`.
+- This is only allowed for https and http endpoints. For tcp and tls endpoints host and port is required
+- When using the domain format you are only defining the host
+- Scheme will default to `http`
+- Port will default to `80`
 
 **Scheme** (shorthand) - `https://`
 
-- This only works for `https` and `http`.
-- For `tcp` and `tls` host and port is required.
-- When using scheme you are defining the protocol and the port will be inferred on the local host.
-  - For `https` port will be `443`.
-  - For `http` port will be `80`.
-  - Host will be localhost.
+- This only works for `https` and `http`
+- For `tcp` and `tls` host and port is required
+- When using scheme you are defining the protocol and the port will be inferred on the local host
+  - For `https` port will be `443`
+  - For `http` port will be `80`
+  - Host will be localhost
 
 **Port** (shorthand) - `8080`
 
-- When using port you are defining the port on the local host that will receive traffic.
-- Scheme will default to `http`.
-- Host will default to `localhost`.
+- When using port you are defining the port on the local host that will receive traffic
+- Scheme will default to `http`
+- Host will default to `localhost`
 
 ### TrafficPolicyCfg
 
-See [policy configuration](https://ngrok.com/docs/traffic-policy/) for traffic policy configuration options
+Configuration for a traffic policy that may be provided inline or via a reference to an `NgrokTrafficPolicy` resource in the
+Kubernetes cluster. See [policy configuration](https://ngrok.com/docs/traffic-policy/) for traffic policy configuration options
 
 | Field     | Type                          | Required | Description                                                                                                         |
 | --------- | ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -365,4 +367,4 @@ See [policy configuration](https://ngrok.com/docs/traffic-policy/) for traffic p
 
 | Field | Type   | Required | Description                                                                                                                                         |
 | ----- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name  | string | Yes      | Identifies a kubernetes resource by name. This resource and the referenced resource must be in the same namespace. The type of the expected/allowed |
+| name  | string | Yes      | Identifies a kubernetes resource by name. This resource and the referenced resource must be in the same namespace. |

--- a/docs/k8s/crds.md
+++ b/docs/k8s/crds.md
@@ -273,6 +273,10 @@ the IDs of Agent Endpoints managed by the operator change if the operator pods r
 
 See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
 
+**Note:** Agent Endpoints are currently in feature-preview for the ngrok Kubernetes operator. You will need to use `--version 0.17.0-rc.1` (or newer) when using
+`helm` to install or update the operator. See [the deployment guide](https://ngrok-docs-git-alicewasko-agent-endpoint-k8s-ngrok-dev.vercel.app/docs/k8s/deployment-guide/) for information about installing
+the ngrok Kubernetes operator.
+
 | Field      | Type                                                                                    | Required | Description                                                                                                                                                                                                                   |
 | ---------- | --------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | apiVersion | string                                                                                  | Yes      | The API version for this custom resource.                                                                                                                                                                                     |

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -961,7 +961,7 @@ spec:
 The following example showcases how a traffic policy with the [terminate-tls action](https://ngrok.com/docs/traffic-policy/actions/terminate-tls/) can be used to control TLS termination options.
 More information and examples about configuring traffic policies on Agent Endpoints can be found in [the traffic policy section below](#traffic-policies-with-agent-endpoints).
 
-For HTTPS endpoints, ngrok will already terminate TLS connections for you even if you do not explicitly use this action in your Traffic Policy. If you specify this action in your Traffic 
+For HTTPS endpoints, ngrok will already terminate TLS connections for you even if you do not explicitly use this action in your Traffic Policy. If you specify this action in your Traffic
 Policy without any configuration, you will see no change in behavior for your endpoints.
 
 ```yaml
@@ -977,11 +977,11 @@ spec:
   trafficPolicy:
     inline:
       on_tcp_connect:
-      - actions:
-        - type: terminate-tls
-          config:
-            min_version: 1.2
-            max_version: 1.3
+        - actions:
+            - type: terminate-tls
+              config:
+                min_version: 1.2
+                max_version: 1.3
   upstream:
     protocol: http2
     url: https://test-service.default:8443
@@ -1010,7 +1010,6 @@ spec:
 ### TLS Endpoints
 
 [TLS endpoints](https://ngrok.com/docs/tls/) enable you to deliver any network service that runs over a TLS-based protocol. TLS endpoints make no assumptions about the wrapped protocol being transported.
-
 
 ```yaml
 ---
@@ -1045,11 +1044,11 @@ spec:
   trafficPolicy:
     inline:
       on_tcp_connect:
-      - actions:
-        - type: terminate-tls
-          config:
-            min_version: 1.2
-            max_version: 1.3
+        - actions:
+            - type: terminate-tls
+              config:
+                min_version: 1.2
+                max_version: 1.3
   upstream:
     url: tls://test-service.default:9000
   url: https://example-tls-domain.ngrok.io

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -883,3 +883,282 @@ CoreDNS is running at https://tlsedgetest.ngrok.app/api/v1/namespaces/kube-syste
 
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 ```
+
+## Agent Endpoints
+
+Agent Endpoints along with [Cloud Endpoints](https://ngrok.com/docs/network-edge/cloud-endpoints/) are the successors to [Edges](https://ngrok.com/docs/network-edge/edges/). Agent Endpoints are ephemeral and tied to the lifetime of the ngrok agent.
+
+Using Agent Endpoints, you can easily expose your Kubernetes services to internet, or use `.internal` domains to allow other ngrok endpoints to route to them internally without exposing them to the public internet.
+
+The ngrok kubernetes operator ensures that you always have a set of Agent Endpoints according to the configuration of any and all `AgentEndpoint` custom resources ([AgentEndpoint CRD reference](https://ngrok.com/docs/k8s/crds/#agent-endpoints)). you have applied. You may see the ID's of any agent endpoints
+within the ngrok dashboard change over time if they are managed by the operator whenever the operator is restarted, but their configuraiton and availability will always be consistent so long as the operator is running.
+
+See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
+
+### HTTP Endpoints
+
+This Agent Endpoint accepts cleartext HTTP connections at `http://example-http-domain.ngrok.io`, and forwards to the kubernetes service `test-service.default` on port 8080 over cleartext HTTP.
+While the public url is `http://`, the `upstream.url` does not need to also use `http://`. You can forward traffic to HTTPS or cleartext HTTP upstream urls.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: http-k8s
+  namespace: default
+spec:
+  description: example HTTP agent endpoint # optional description
+  metadata: '{"owned-by":"ngrok-operator"}' # optional metadata
+  upstream:
+    protocol: http1 # optional, allows http1/http2. defaults to http1 for HTTP/HTTPS agent endpoints
+    url: test-service.default:8080
+  url: http://example-http-domain.ngrok.io
+```
+
+### HTTPS Endpoints
+
+This Agent Endpoint accepts HTTPS connections at `https://example-https-domain.ngrok.io`, terminates TLS, and forwards to the kubernetes service `test-service.default` on port 8443 over HTTPS.
+While the public url is `https://`, the `upstream.url` does not need to also use `https://`. You can forward traffic to HTTPS or cleartext HTTP upstream urls.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: https-k8s
+  namespace: default
+spec:
+  description: example HTTPS agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    protocol: http2
+    url: https://test-service.default:8443
+  url: https://example-https-domain.ngrok.io
+```
+
+The following example showcases forwarding traffic to a publicy routable url outside of Kubernetes, but will also work with an HTTP Agent Endpoint.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: https-external
+  namespace: default
+spec:
+  description: example HTTPS agent endpoint with external upstream
+  metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    protocol: http2
+    url: https://httpbin.org
+  url: https://example-https-domain-external-upstream.ngrok.io
+```
+
+### TCP Endpoints
+
+TCP Agent Endpoints can be used to forward raw TCP traffic. In order to create a TCP Agent Endpoint, you must first [reserve a TCP address through the ngrok dashboard](https://dashboard.ngrok.com/tcp-addresses).
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: tcp-k8s
+  namespace: default
+spec:
+  description: example TCP agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    url: tcp://test-service.default:9000
+  url: tcp://5.tcp.ngrok.io:24429 # TCP address reserved from the ngrok dashboard
+```
+
+### TLS Endpoints
+
+[TLS endpoints](https://ngrok.com/docs/tls/) enable you to deliver any network service that runs over a TLS-based protocol. TLS endpoints make no assumptions about the wrapped protocol being transported.
+
+TODO: more info about TLS termination when we have that config in place
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: tls-k8s
+  namespace: default
+spec:
+  description: test tls agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    url: tls://test-service.default:9000
+  url: https://example-tls-domain.ngrok.io
+```
+
+### Internal Endpoints
+
+Agent Endpoints with a `url` ending in `.internal` can be used to create [Internal Endpoints](https://ngrok.com/docs/network-edge/internal-endpoints/).
+
+All internal endpoints end in `.internal`, and are specific to one ngrok account. Requests may only be forwarded to a internal endpoint on the same account as the the internal endpoint, and the target must be of the same protocol (i.e. an HTTP Endpoint may only forward to an HTTP Internal Endpoint).
+In addition, the target's traffic policy may only specify policy for the current protocol, for example if [forward-internal](https://ngrok.com/docs/traffic-policy/actions/forward-internal/) is used in the `on_http_request` traffic policy phase,
+the internal endpoint may only have `on_http_request` and `on_http_response` sections in its traffic policy configuration.
+
+#### 1. Create a public Agent Endpoint
+
+The following Agent Endpoint will forward all traffic to an internal Agent Endpoint that will be created next
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: forward-internal
+  namespace: default
+spec:
+  description: forwards to the following internal agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    inline:
+      on_http_request:
+        - actions:
+            - type: forward-internal
+              config:
+                binding: internal
+                url: https://example-https-endpoint.internal
+  upstream:
+    protocol: http1
+    url: foo.bar:8080
+  url: https://example-forward-internal-aep.ngrok.io
+```
+
+Since the above endpoint is forwarding all traffic to the below internal endpoint, no traffic will be sent to `foo.bar:8080` which is the upstream.
+
+#### 2. Create an internal Agent Endpoint
+
+This internal Agent Endpoint is not accessible from the public internet, but may receive traffic from other Cloud and Agent Endpoints using their
+traffic policy's `forward-internal` action.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: internal
+  namespace: default
+spec:
+  description: example internal agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    protocol: http1
+    url: test-service.default:8080
+  url: https://example-https-endpoint.internal
+  bindings:
+    - internal
+```
+
+#### 3. Create a Cloud Endpoint
+
+The following showcases how you could also use a [Cloud Endpoint](https://ngrok.com/docs/network-edge/cloud-endpoints/) to forward traffic to your internal Agent Endpoint
+
+Cloud Endpoints can created with Kubernetes resources such as with the following example, but they can also be created
+from the [ngrok dashboard](https://dashboard.ngrok.com) and [the ngrok API](https://ngrok.com/docs/api/).
+
+Cloud Endpoints enable you to:
+
+- Centrally manage your traffic policy configurations in Kubernetes and/or ngrok's cloud service
+- Load balance traffic to different ngrok agents/operators
+- Apply different configurations for each path in your application. For example, you may apply OAuth on `/app` and Compression on `/static/css`
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: CloudEndpoint
+metadata:
+  name: forward-internal
+  namespace: default
+spec:
+  description: https cloud endpoint forwarding to internal agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    policy:
+      on_http_request:
+        - actions:
+            - type: forward-internal
+              config:
+                url: https://example-https-endpoint.internal
+  url: https://example-forward-internal-cep.ngrok.io
+```
+
+### Traffic Policies with Agent Endpoints
+
+The follwoing example showcases how to inline a traffic policy configuration for an Agent Endpoint.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: inline-traffic-policy
+  namespace: default
+spec:
+  description: https agent endpoint with inline traffic policy
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    inline:
+      on_http_request:
+        - actions:
+            - type: custom-response
+              config:
+                status_code: 503
+                content:
+                  <html><body><h1>Service Unavailable</h1><p>Our servers are currently
+                  down for maintenance. Please check back later.</p></body></html>
+                headers:
+                  content-type: text/html
+  upstream:
+    protocol: http2
+    url: https://httpbin.org
+  url: https://example-endpoint-tp-inline.ngrok.io
+```
+
+The follwoing example showcases how to supply a traffic policy configuration via reference to an `NgrokTrafficPolicy` custom resource
+for an Agent Endpoint. Note that the referenced `NgrokTrafficPolicy` must be in the same namespace as the `AgentEndpoint` it is being referenced from.
+
+```yaml
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: NgrokTrafficPolicy
+metadata:
+  name: example-policy
+  namespace: default
+spec:
+  policy:
+    on_http_request:
+      - actions:
+          - type: custom-response
+            config:
+              status_code: 503
+              content:
+                <html><body><h1>Service Unavailable</h1><p>Our servers are currently
+                down for maintenance. Please check back later.</p></body></html>
+              headers:
+                content-type: text/html
+```
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: referenced-traffic-policy
+  namespace: default
+spec:
+  description: https agent endpoint with referenced traffic policy
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    targetRef:
+      name: example-policy
+  upstream:
+    protocol: http2
+    url: https://httpbin.org
+  url: https://example-endpoint-tp-ref.ngrok.io
+```

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -895,6 +895,9 @@ within the ngrok dashboard change over time if they are managed by the operator 
 
 See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
 
+**Note:** Agent Endpoints are currently in feature-preview for the ngrok Kubernetes operator. You will need to use `--version 0.17.0-rc.1` (or newer) when using
+`helm` to install or update the operator.
+
 ### HTTP Endpoints
 
 This Agent Endpoint accepts cleartext HTTP connections at `http://example-http-domain.ngrok.io`, and forwards to the kubernetes service `test-service.default` on port 8080 over cleartext HTTP.
@@ -955,6 +958,36 @@ spec:
   url: https://example-https-domain-external-upstream.ngrok.io
 ```
 
+The following example showcases how a traffic policy with the [terminate-tls action](https://ngrok.com/docs/traffic-policy/actions/terminate-tls/) can be used to control TLS termination options.
+More information and examples about configuring traffic policies on Agent Endpoints can be found in [the traffic policy section below](#traffic-policies-with-agent-endpoints).
+
+For HTTPS endpoints, ngrok will already terminate TLS connections for you even if you do not explicitly use this action in your Traffic Policy. If you specify this action in your Traffic 
+Policy without any configuration, you will see no change in behavior for your endpoints.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: https-k8s
+  namespace: default
+spec:
+  description: example HTTPS agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    inline:
+      on_tcp_connect:
+      - actions:
+        - type: terminate-tls
+          config:
+            min_version: 1.2
+            max_version: 1.3
+  upstream:
+    protocol: http2
+    url: https://test-service.default:8443
+  url: https://example-https-domain.ngrok.io
+```
+
 ### TCP Endpoints
 
 TCP Agent Endpoints can be used to forward raw TCP traffic. In order to create a TCP Agent Endpoint, you must first [reserve a TCP address through the ngrok dashboard](https://dashboard.ngrok.com/tcp-addresses).
@@ -978,7 +1011,6 @@ spec:
 
 [TLS endpoints](https://ngrok.com/docs/tls/) enable you to deliver any network service that runs over a TLS-based protocol. TLS endpoints make no assumptions about the wrapped protocol being transported.
 
-TODO: more info about TLS termination when we have that config in place
 
 ```yaml
 ---
@@ -990,6 +1022,34 @@ metadata:
 spec:
   description: test tls agent endpoint
   metadata: '{"owned-by":"ngrok-operator"}'
+  upstream:
+    url: tls://test-service.default:9000
+  url: https://example-tls-domain.ngrok.io
+```
+
+The following example showcases how a traffic policy with the [terminate-tls action](https://ngrok.com/docs/traffic-policy/actions/terminate-tls/) can be used to control TLS termination options.
+More information and examples about configuring traffic policies on Agent Endpoints can be found in [the traffic policy section below](#traffic-policies-with-agent-endpoints).
+
+For TLS endpoints, ngrok will not terminate the TLS connection by default and it is up to you to handle TLS termination in your upstream service.
+
+```yaml
+---
+apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+kind: AgentEndpoint
+metadata:
+  name: tls-k8s
+  namespace: default
+spec:
+  description: test tls agent endpoint
+  metadata: '{"owned-by":"ngrok-operator"}'
+  trafficPolicy:
+    inline:
+      on_tcp_connect:
+      - actions:
+        - type: terminate-tls
+          config:
+            min_version: 1.2
+            max_version: 1.3
   upstream:
     url: tls://test-service.default:9000
   url: https://example-tls-domain.ngrok.io

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -896,7 +896,8 @@ within the ngrok dashboard change over time if they are managed by the operator 
 See the [ngrok agent CLI configuration page](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions), for more information about using the CLI to start agent endpoints outside of Kubernetes.
 
 **Note:** Agent Endpoints are currently in feature-preview for the ngrok Kubernetes operator. You will need to use `--version 0.17.0-rc.1` (or newer) when using
-`helm` to install or update the operator.
+`helm` to install or update the operator. See [the deployment guide](https://ngrok-docs-git-alicewasko-agent-endpoint-k8s-ngrok-dev.vercel.app/docs/k8s/deployment-guide/) for information about installing
+the ngrok Kubernetes operator.
 
 ### HTTP Endpoints
 


### PR DESCRIPTION
Adds CRD reference documentation and usage guides for the ngrok operator agent endpoints feature