### PR TITLE
Mandy/fix quickstart

### DIFF
--- a/docs/traffic-policy/getting-started.mdx
+++ b/docs/traffic-policy/getting-started.mdx
@@ -18,6 +18,7 @@ on_http_request:
   - actions:
     - type: custom-response
       config:
+        status_code: 200
         content: "Hello, World!"
 ```
 

--- a/traffic-policy/actions/basic-auth/behavior.mdx
+++ b/traffic-policy/actions/basic-auth/behavior.mdx
@@ -9,7 +9,7 @@ finally to your application; if verification fails, the request will be terminat
 
 ### Additional Restrictions
 
-You can specify only a limited number of `username:password` pairs. The password must be at least
+You can specify up to 10 `username:password` pairs. The password must be at least
 8 characters and no more than 128 characters. Including multiple colons in the `username:password`
 pair will result in the first colon being treated as the delimiter between the username and password.
 Realm cannot exceed 128 characters, and cannot contain non-ASCII characters.

--- a/traffic-policy/actions/basic-auth/config.mdx
+++ b/traffic-policy/actions/basic-auth/config.mdx
@@ -17,7 +17,7 @@ reference for this action.
 
 <Config>
     <ConfigItem title="credentials" type="array of strings" required={true}>
-        <p>A list of allowed <code>username:password</code> credential pairs.</p>
+        <p>A list of up to 10 allowed <code>username:password</code> credential pairs.</p>
         <p>Password must be at least <code>8</code> characters and no more than <code>128</code> characters.</p>
     </ConfigItem>
 


### PR DESCRIPTION
* Updated the traffic policy getting started example to include the required `status_code`
* Updated basic auth docs to indicate you can specify up to 10 sets of credentials