### PR TITLE
Fix error in circuit-breaker example config

### DIFF
--- a/traffic-policy/actions/circuit-breaker/examples/basic-example.mdx
+++ b/traffic-policy/actions/circuit-breaker/examples/basic-example.mdx
@@ -2,7 +2,7 @@ import ConfigExample from "/src/components/ConfigExample.tsx";
 
 ### Basic Example
 
-This example configuration sets up an endpoint (`hotdog.ngrok.io`) that allows only 1 request every 60 seconds and trips the circuit breaker for 3 minutes.
+This example configuration sets up an endpoint (`hotdog.ngrok.io`) that allows only 1 request every 60 seconds and trips the circuit breaker for 2 minutes.
 
 #### Example Traffic Policy Document
 
@@ -21,7 +21,7 @@ This example configuration sets up an endpoint (`hotdog.ngrok.io`) that allows o
 							error_threshold: 0.0,
 							volume_threshold: 1,
 							window_duration: "60s",
-							tripped_duration: "3m",
+							tripped_duration: "2m",
 							enforce: true,
 						},
 					},


### PR DESCRIPTION
Was experimenting with the circuit breaker today for a blog post and noticed the config in the example fails because `tripped_duration` is set to `3m` when the maximum is `2m`:

```
ERROR:  failed to start tunnel: Failed to parse configuration for circuit-breaker: tripped_duration must be between 1s and 2m0s inclusive, was seconds:180.
```