### PR TITLE
Add Traffic Policy macros to the What's New page

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -14,7 +14,7 @@ You can expect this page to update regularly (at least monthly). We'll include t
 
 ## December 2024
 
-- 2024-12-20 - Released [Traffic Policy macros](/traffic-policy/macros), which enable you to encode or decode query strings, Base64 data, and JSON. This simplifies handling [action result variables](/traffic-policy/variables/action/) for OAuth and [custom response](/traffic-policy/actions/custom-response/#action-result-variables) actions.
+- 2024-12-20 - Released [Traffic Policy macros](/traffic-policy/macros) that enable you to encode or decode query strings, Base64 data, and JSON. This simplifies handling [action result variables](/traffic-policy/variables/action/) for OAuth and [custom response](/traffic-policy/actions/custom-response/#action-result-variables) actions.
 
 - 2024-12-19 - Add tls termination to V3 agent configs.
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -14,6 +14,8 @@ You can expect this page to update regularly (at least monthly). We'll include t
 
 ## December 2024
 
+- 2024-12-20 - Released [Traffic Policy macros](/traffic-policy/macros), which enable you to encode or decode query strings, Base64 data, and JSON. This simplifies handling [action result variables](/traffic-policy/variables/action/) for OAuth and [custom response](/traffic-policy/actions/custom-response/#action-result-variables) actions.
+
 - 2024-12-19 - Add tls termination to V3 agent configs.
 
 ## November 2024


### PR DESCRIPTION
Adds a section for Traffic Policy macros to the What's New page