### PR TITLE
Remove references to binding internal throughout the docs

### DIFF
--- a/docs/guides/api-gateway/get-started.mdx
+++ b/docs/guides/api-gateway/get-started.mdx
@@ -107,7 +107,6 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://api.internal
-          binding: internal
 ```
 
 ### Create a cloud endpoint
@@ -238,7 +237,6 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://v1.api.internal
-          binding: internal
   - name: "Route traffic to API v2"
     expressions:
       - "'2' in req.headers['x-api-version']"
@@ -246,12 +244,10 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://v2.api.internal
-          binding: internal
   - actions:
       - type: forward-internal
         config:
           url: https://v2.api.internal
-          binding: internal
 ```
 
 :::note
@@ -380,7 +376,6 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://hostB.api.internal
-          binding: internal
 ```
 
 :::note
@@ -443,7 +438,6 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://api.internal
-          binding: internal
 ```
 
 :::note
@@ -504,7 +498,6 @@ on_http_request:
       - type: forward-internal
         config:
           url: https://api.internal
-          binding: internal
 ```
 
 :::note
@@ -609,7 +602,6 @@ on_http_request:
       - type: "forward-internal"
         config:
           url: "https://api.internal"
-          binding: internal
 ```
 
 #### Test traffic policies

--- a/docs/guides/other-guides/forwarding-and-load-balancing-with-cloud-endpoints.mdx
+++ b/docs/guides/other-guides/forwarding-and-load-balancing-with-cloud-endpoints.mdx
@@ -139,7 +139,6 @@ and most common use cases: forwarding traffic to other endpoints
 						type: "forward-internal",
 						config: {
 							url: "https://your-domain-name.internal",
-							binding: "internal",
 						},
 					},
 				],

--- a/docs/guides/other-guides/path-based-routing-and-policy-decentralization-with-cloud-endpoints.mdx
+++ b/docs/guides/other-guides/path-based-routing-and-policy-decentralization-with-cloud-endpoints.mdx
@@ -191,7 +191,6 @@ full control over how traffic is handled.
 						type: "forward-internal",
 						config: {
 							url: "https://api.internal",
-							binding: "internal",
 						},
 					},
 				],
@@ -202,7 +201,6 @@ full control over how traffic is handled.
 						type: "forward-internal",
 						config: {
 							url: "https://homepage.internal",
-							binding: "internal",
 						},
 					},
 				],

--- a/docs/k8s/user-guide.mdx
+++ b/docs/k8s/user-guide.mdx
@@ -1083,7 +1083,6 @@ spec:
         - actions:
             - type: forward-internal
               config:
-                binding: internal
                 url: https://example-https-endpoint.internal
   upstream:
     protocol: http1

--- a/docs/network-edge/internal-endpoints.mdx
+++ b/docs/network-edge/internal-endpoints.mdx
@@ -15,7 +15,7 @@ Internal endpoints are available in ngrok's pay-as-you-go plan. An internal endp
 An internal endpoint may be created by specifying a binding of `internal` for your endpoint. Specifically, when using the agent, a `internal` endpoint may be created like so:
 
 ```bash
-ngrok http --binding internal --url "some.name.internal" 8080
+ngrok http --url "some.name.internal" 8080
 ```
 
 A internal endpoint may listen on any port (such as `--url "some.name.internal:1234"`) and any protocol scheme (such as `ngrok tcp` and `ngrok tls`).

--- a/docs/network-edge/internal-endpoints.mdx
+++ b/docs/network-edge/internal-endpoints.mdx
@@ -12,7 +12,7 @@ Internal endpoints are available in ngrok's pay-as-you-go plan. An internal endp
 
 ### Creating a Internal Endpoint
 
-A internal endpoint may be created by specifying a binding of `internal` for your endpoint. Specifically, when using the agent, a `internal` endpoint may be created like so:
+An internal endpoint may be created by specifying a binding of `internal` for your endpoint. Specifically, when using the agent, a `internal` endpoint may be created like so:
 
 ```bash
 ngrok http --binding internal --url "some.name.internal" 8080

--- a/traffic-policy/actions/forward-internal/config.mdx
+++ b/traffic-policy/actions/forward-internal/config.mdx
@@ -30,12 +30,6 @@ reference for this action.
 			Supports [CEL Interpolation](/traffic-policy/concepts/cel-interpolation).
 		</p>
 	</ConfigItem>
-	<ConfigItem title="binding" type="string">
-		<p>
-			Binding of the Endpoint (only <code>internal</code> is currently
-			supported).
-		</p>
-	</ConfigItem>
 	<ConfigItem title="on_error" type="enum">
 		<p>
 			Whether or not further actions in the Traffic Policy should run if there

--- a/traffic-policy/actions/forward-internal/examples/1-basic-example.mdx
+++ b/traffic-policy/actions/forward-internal/examples/1-basic-example.mdx
@@ -30,7 +30,7 @@ This example configuration will set up a public endpoint (`forward-internal-exam
 #### Start an Internal Endpoint
 
 ```shell
-ngrok http 80 --url example.internal --binding internal
+ngrok http 80 --url example.internal
 ```
 
 #### Start Public Endpoint with Traffic Policy


### PR DESCRIPTION
Slack discussion here:
- https://ngrok.slack.com/archives/C03LRGNSG6A/p1736525986652769

`binding: internal` is unnecessary, and we shouldn't document it anymore. This PR removes all references to `binding: internal` and `--binding internal` in CLI and Traffic Policy docs