### PR TITLE
Make autofix script run manually

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,7 +1,7 @@
 name: autofix.ci # needed to securely identify the workflow
 
 on:
-  workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   autofix:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,7 +1,7 @@
 name: autofix.ci # needed to securely identify the workflow
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
At the moment it triggers with each commit, which requires you to pull the changes every time. Sometimes you may forget to pull, make changes, then have annoying merge conflicts