### PR TITLE
Fix broken links in our error docs

### DIFF
--- a/docs/errors/details/_err_ngrok_1006.md
+++ b/docs/errors/details/_err_ngrok_1006.md
@@ -1,11 +1,17 @@
 ### Additional Information
 
-We encountered an issue when trying to process your card. We accept most major payment cards, but do not accept payment via PayPal, Venmo or any form of cryptocurrency at this time.
+We encountered an issue when trying to process your card.
 
-We also return this error when your card provider or bank declines your payment.
+- Your card provider or bank may have declined your payment.
+- We accept most major payment cards, but do not accept:
+  - PayPal
+  - Venmo
+  - Cryptocurrency
 
 ### Possible Solutions
 
-Please make sure you are using a credit card and that you have entered all the information correctly. If you are using a pre-paid card, please ensure your payment card account balance is enough to cover the cost of your purchase.
+- Confirm that you're using a valid credit card.
+- Confirm that your billing information is correct.
+- If you're using a pre-paid card, confirm that your account balance is sufficient.
 
 If you are repeatedly seeing this error, your bank or card provider may be able to provide additional information. While there's often not much we can do, you can email us with a request for further investigation.

--- a/docs/errors/details/_err_ngrok_107.md
+++ b/docs/errors/details/_err_ngrok_107.md
@@ -6,6 +6,6 @@ You may have been removed from a team where you were formerly a member or your c
 
 ### Possible Solutions
 
-1. Your authtoken may have been reset. Please check to make sure your authtoken at [https://dashboard.ngrok.com/get-started/your-authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) matches the one that appears in your ngrok.yml configuration file.
-2. Please contact your former team's account owner if you think you have been removed from the team in error or if you believe your credential should still be active.
-3. You are using the tunnel credentials api and your authtoken has been deleted, or is malformed. Please provision a new one or use the default authtoken. The following documentation includes steps on how to do that: [https://ngrok.com/docs/api#api-credentials](https://ngrok.com/docs/api#api-credentials).
+- Your authtoken may have been reset. Please check to make sure your authtoken at [https://dashboard.ngrok.com/get-started/your-authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) matches the one that appears in your ngrok.yml configuration file.
+- Please contact your former team's account owner if you think you have been removed from the team in error or if you believe your credential should still be active.
+- You are using the tunnel credentials api and your authtoken has been deleted, or is malformed. Please [provision a new one](/docs/api/resources/credentials/#create-tunnel-credential).

--- a/docs/errors/details/_err_ngrok_108.md
+++ b/docs/errors/details/_err_ngrok_108.md
@@ -2,7 +2,7 @@
 
 An ngrok account is limited in how many agents it can simultaneously run. This limit is listed for each plan as "online ngrok processes" on the [pricing page](https://ngrok.com/pricing). This error indicates you've exceeded that limit.
 
-The list of online ngrok processes is visible in the [dashboard](https://dashboard.ngrok.com/tunnel-agents/sessions).
+The list of online ngrok processes is visible in [the dashboard](https://dashboard.ngrok.com/agents).
 
 ### Possible Solutions
 

--- a/docs/errors/details/_err_ngrok_3004.md
+++ b/docs/errors/details/_err_ngrok_3004.md
@@ -4,4 +4,4 @@ This error usually occurs when users are hosting a secure upstream service (`htt
 
 ### Possible Solutions
 
-When starting the ngrok agent, use the full upstream service address. For example: `ngrok http https://localhost:8081`.
+- When starting the ngrok agent, use the full upstream service address. For example: `ngrok http https://localhost:8081`.

--- a/docs/errors/details/_err_ngrok_305.md
+++ b/docs/errors/details/_err_ngrok_305.md
@@ -4,6 +4,6 @@ Binding a custom subdomain on an ngrok domain requires a paid plan. Once you sig
 
 ### Possible Solutions
 
-[Sign up for a paid plan](https://dashboard.ngrok.com/signup). You'll need the Basic plan or better.
+- [Sign up for a paid plan](https://dashboard.ngrok.com/signup). You'll need either a Personal plan or higher or any pay-as-you-go plan.
 
 Add the authtoken from your account dashboard to your ngrok agent in your terminal.

--- a/docs/errors/details/_err_ngrok_305.md
+++ b/docs/errors/details/_err_ngrok_305.md
@@ -4,6 +4,6 @@ Binding a custom subdomain on an ngrok domain requires a paid plan. Once you sig
 
 ### Possible Solutions
 
-- [Sign up for a paid plan](https://dashboard.ngrok.com/signup). You'll need either a Personal plan or higher or any pay-as-you-go plan.
+- [Sign up for a paid plan](https://dashboard.ngrok.com/signup). You'll need at least a Personal plan or any pay-as-you-go plan.
 
 Add the authtoken from your account dashboard to your ngrok agent in your terminal.

--- a/docs/errors/details/_err_ngrok_305.md
+++ b/docs/errors/details/_err_ngrok_305.md
@@ -4,6 +4,6 @@ Binding a custom subdomain on an ngrok domain requires a paid plan. Once you sig
 
 ### Possible Solutions
 
-Sign up for a paid plan at https://dashboard.ngrok.com/signup You'll need the Basic plan or better.
+[Sign up for a paid plan](https://dashboard.ngrok.com/signup). You'll need the Basic plan or better.
 
 Add the authtoken from your account dashboard to your ngrok agent in your terminal.

--- a/docs/errors/details/_err_ngrok_306.md
+++ b/docs/errors/details/_err_ngrok_306.md
@@ -1,9 +1,5 @@
-### Additional Information
+## Possible Solutions
 
-Using a custom domain such as app.example.com requires a paid ngrok plan. You can upgrade to a paid plan under the [Billing](https://dashboard.ngrok.com/billing) section in the ngrok Dashboard. Once you upgrade, you will be able to [register and use a custom domain](/docs/guides/how-to-set-up-a-custom-domain/) immediately.
-
-### Possible Solutions
-
-Upgrade to a paid plan in the ngrok Dashboard under the [Billing](https://dashboard.ngrok.com/billing) section. You will need a Personal, Pro or Enterprise plan to use a custom hostname.
-
-If you haven't already, add [your authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) from your account dashboard to your ngrok agent in your terminal using `ngrok config add-authtoken TOKEN`.
+- You can upgrade to a paid plan in [the Billing section of the dashboard](https://dashboard.ngrok.com/billing). You will need a Personal, Pro or Enterprise plan to use a custom hostname.
+  - You can follow this guide to [register and use a custom domain](/guides/other-guides/how-to-set-up-a-custom-domain/).
+- If you haven't already, add [your authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) from your account dashboard to your ngrok agent in your terminal using `ngrok config add-authtoken TOKEN`.

--- a/docs/errors/details/_err_ngrok_306.md
+++ b/docs/errors/details/_err_ngrok_306.md
@@ -1,4 +1,4 @@
-## Possible Solutions
+### Possible Solutions
 
 - You can upgrade to a paid plan in [the Billing section of the dashboard](https://dashboard.ngrok.com/billing). You will need a Personal, Pro or Enterprise plan to use a custom hostname.
   - You can follow this guide to [register and use a custom domain](/guides/other-guides/how-to-set-up-a-custom-domain/).

--- a/docs/errors/details/_err_ngrok_306.md
+++ b/docs/errors/details/_err_ngrok_306.md
@@ -1,5 +1,5 @@
 ### Possible Solutions
 
-- You can upgrade to a paid plan in [the Billing section of the dashboard](https://dashboard.ngrok.com/billing). You will need a Personal, Pro or Enterprise plan to use a custom hostname.
+- You can upgrade to a paid plan in [the Billing section of the dashboard](https://dashboard.ngrok.com/billing). You will need at least a Personal plan or any pay-as-you-go-plan.
   - You can follow this guide to [register and use a custom domain](/guides/other-guides/how-to-set-up-a-custom-domain/).
 - If you haven't already, add [your authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) from your account dashboard to your ngrok agent in your terminal using `ngrok config add-authtoken TOKEN`.

--- a/docs/errors/details/_err_ngrok_314.md
+++ b/docs/errors/details/_err_ngrok_314.md
@@ -1,6 +1,6 @@
 ### Possible Solutions
 
-- Upgrade your account to a Pro or Business plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.
+- Upgrade your account to a Pro or Pay-as-you-go plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.
 
 :::tip
 If you don't need a fully-custom hostname, you can reserve a custom ngrok subdomain (like `example.ngrok.dev`) on our paid plans.

--- a/docs/errors/details/_err_ngrok_314.md
+++ b/docs/errors/details/_err_ngrok_314.md
@@ -1,9 +1,7 @@
-### Additional Information
-
-Custom hostnames such as something.com can only be reserved with a Pro or Business level plan. See our pricing page for more information [pricing](https://ngrok.com/pricing).
-
 ### Possible Solutions
 
-Upgrade your account to a Pro or Business plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.
+- Upgrade your account to a Pro or Business plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.
 
-If you don't need a fully-custom hostname, consider reserving a custom subdomain on one of our ngrok domains, such as something.ngrok.dev, which is available on our paid plans.
+:::tip
+If you don't need a fully-custom hostname, you can reserve a custom ngrok subdomain (like `example.ngrok.dev`) on our paid plans.
+:::

--- a/docs/errors/details/_err_ngrok_3200.md
+++ b/docs/errors/details/_err_ngrok_3200.md
@@ -9,7 +9,7 @@ ngrok is unable to assist with end user content as all content is neither hosted
 
 ### The most common causes of this error are:
 
-- **Agent Not Running** The ngrok Agent is no longer running, or you forgot to start the Agent. Verify that the Agent is running and showing the expected "Forwarding" address. Cloud Endpoints remain online independent of an agent. If you continue to have this problem, [use a cloud endpoint]. (/docs/network-edge/cloud-endpoints/)
+- **Agent Not Running** The ngrok Agent is no longer running, or you forgot to start the Agent. Verify that the Agent is running and showing the expected "Forwarding" address. Cloud Endpoints remain online independent of an agent. If you continue to have this problem, [use a cloud endpoint](/docs/network-edge/cloud-endpoints/).
 - **Session Timed Out or Stopped** The Agent session has timed out or stopped. Restart the ngrok Agent to restart the Agent and tunnel sessions.
 - **Endpoint Domain or Hostname Change** The endpoint domain or hostname has changed. If you are on the Free plan or have not set the `--domain` flag to set the domain on the tunnel, please be aware that the forwarding address will change each time the Agent and session are restarted. If you previously obtained a forwarding URL from an agent session but have since closed that session or closed the client window, the URL will change when a new Agent session starts.
 - **Typo in Endpoint Address** You have made a typo in the endpoint address you have entered in the browser. Verify that the tunnel hostname is correct. Incorrectly entering the address (a typo) in a browser address bar can also result in this error.

--- a/docs/errors/details/_err_ngrok_3200.md
+++ b/docs/errors/details/_err_ngrok_3200.md
@@ -1,6 +1,6 @@
 ### Additional Information
 
-This error occurs when there is no active tunnel using the hostname you are trying to reach. There can be multiple reasons why a tunnel that you expect to be running is showing a 3200 error.
+This error occurs when there is no active endpoint using the hostname you are trying to reach. There can be multiple reasons why an endpoint that you expect to be running is showing a 3200 error.
 
 If you are the ngrok Administrator for this account, please verify that the ngrok Agent is running and that the subdomain/hostname is correct.
 
@@ -10,10 +10,10 @@ ngrok is unable to assist with end user content as all content is neither hosted
 ### The most common causes of this error are:
 
 - **Agent Not Running** The ngrok Agent is no longer running, or you forgot to start the Agent. Verify that the Agent is running and showing the expected "Forwarding" address. Cloud Endpoints remain online independent of an agent. If you continue to have this problem, [use a cloud endpoint](/docs/network-edge/cloud-endpoints/).
-- **Session Timed Out or Stopped** The Agent session has timed out or stopped. Restart the ngrok Agent to restart the Agent and tunnel sessions.
-- **Endpoint Domain or Hostname Change** The endpoint domain or hostname has changed. If you are on the Free plan or have not set the `--domain` flag to set the domain on the tunnel, please be aware that the forwarding address will change each time the Agent and session are restarted. If you previously obtained a forwarding URL from an agent session but have since closed that session or closed the client window, the URL will change when a new Agent session starts.
-- **Typo in Endpoint Address** You have made a typo in the endpoint address you have entered in the browser. Verify that the tunnel hostname is correct. Incorrectly entering the address (a typo) in a browser address bar can also result in this error.
+- **Session Timed Out or Stopped** The Agent session has timed out or stopped. Restart the ngrok Agent to restart the Agent and endpoint sessions.
+- **Endpoint Domain or Hostname Change** The endpoint domain or hostname has changed. If you are on the Free plan or have not set the `--domain` flag to set the domain on the endpoint, please be aware that the forwarding address will change each time the Agent and session are restarted. If you previously obtained a forwarding URL from an agent session but have since closed that session or closed the client window, the URL will change when a new Agent session starts.
+- **Typo in Endpoint Address** You have made a typo in the endpoint address you have entered in the browser. Verify that the endpoint hostname is correct. Incorrectly entering the address (a typo) in a browser address bar can also result in this error.
 - **Network Issues** A network issue exists between the device the Agent is running on and ngrok. Your ngrok agent might have trouble reaching the ngrok service. Try running the [`ngrok diagnose`](/docs/agent/cli/#ngrok-diagnose) command to check for connectivity issues.
-- **Incorrect Scheme** You are attempting to run `--url http://...` on your agent using a domain that only supports https. All of the `.app` and `.dev` domains are HSTS or "HTTP Strict Transport Security" domains. Paid plan accounts are able to start http scheme tunnels on the `ngrok.io` domain, which is not HSTS enforced.
+- **Incorrect Scheme** You are attempting to run `--url http://...` on your agent using a domain that only supports https. All of the `.app` and `.dev` domains are HSTS or "HTTP Strict Transport Security" domains. Paid plan accounts are able to start http scheme endpoints on the `ngrok.io` domain, which is not HSTS enforced.
 
 If you are the Administrator for this ngrok account, and none of these steps work for you or you have additional questions, drop us a note at [support@ngrok.com](mailto:support@ngrok.com?subject=Help%20with%20ngrok%203200%20error).

--- a/docs/errors/details/_err_ngrok_3208.md
+++ b/docs/errors/details/_err_ngrok_3208.md
@@ -1,6 +1,6 @@
 ### Overview
 
-This error occurs when a ngrok account has been banned, usually due to suspected phishing or login capture activities. While the ban is in place, any tunnels or endpoints associated with the account will not function.
+This error occurs when a ngrok account has been banned, usually due to suspected phishing or login capture activities. While the ban is in place, any endpoints or endpoints associated with the account will not function.
 
 ### For Website Visitors
 

--- a/docs/errors/details/_err_ngrok_334.md
+++ b/docs/errors/details/_err_ngrok_334.md
@@ -4,9 +4,9 @@ You can only use a a tunnel URL for one tunnel session at a time. This error occ
 
 This error also appears if you attempt to create multiple tunnels using the same hostname.
 
-You can view tunnel status from your dashboard: [https://dashboard.ngrok.com/endpoints/status](https://dashboard.ngrok.com/endpoints/status)
+You can [view tunnel status from your dashboard](https://dashboard.ngrok.com/ingress).
 
-You can also view agent session status from your dashboard: [https://dashboard.ngrok.com/tunnel-agents/sessions](https://dashboard.ngrok.com/tunnel-agents/sessions)
+You can also [view agent session status from your dashboard](https://dashboard.ngrok.com/agents)
 
 ### Possible Solutions
 

--- a/docs/errors/details/_err_ngrok_334.md
+++ b/docs/errors/details/_err_ngrok_334.md
@@ -1,15 +1,13 @@
 ### Additional Information
 
-You can only use a a tunnel URL for one tunnel session at a time. This error occurs when an ngrok tunnel with the requested URL is already online.
+You can only use a tunnel URL for one tunnel session at a time. This error occurs when an ngrok tunnel with the requested URL is already online.
 
 This error also appears if you attempt to create multiple tunnels using the same hostname.
 
-You can [view tunnel status from your dashboard](https://dashboard.ngrok.com/ingress).
-
-You can also [view agent session status from your dashboard](https://dashboard.ngrok.com/agents)
+- You can [view tunnel status from your dashboard](https://dashboard.ngrok.com/endpoints).
+- You can also [view actively connected agents from your dashboard](https://dashboard.ngrok.com/agents). Select one from the list to view any tunnels that agent is handling.
 
 ### Possible Solutions
 
-Stop the tunnel that is currently running in order to make your desired URL available.
-
-Choose a different unique URL or hostname to start your tunnel.
+- Stop the tunnel that is currently running in order to make your desired URL available.
+- Choose a different unique URL or hostname to start your tunnel.

--- a/docs/errors/details/_err_ngrok_354.md
+++ b/docs/errors/details/_err_ngrok_354.md
@@ -1,3 +1,3 @@
 ### Possible solutions
 
-Reserve your subdomain in your ngrok account dashboard https://dashboard.ngrok.com/domains before starting a tunnel using that subdomain.
+- Reserve your subdomain [in the dashboard](https://dashboard.ngrok.com/domains) before starting a tunnel with it.

--- a/docs/errors/details/_err_ngrok_354.md
+++ b/docs/errors/details/_err_ngrok_354.md
@@ -1,3 +1,3 @@
 ### Possible solutions
 
-Reserve your subdomain in your ngrok account dashboard https://dashboard.ngrok.com/endpoints/domains before starting a tunnel using that subdomain.
+Reserve your subdomain in your ngrok account dashboard https://dashboard.ngrok.com/domains before starting a tunnel using that subdomain.

--- a/docs/errors/details/_err_ngrok_4000.md
+++ b/docs/errors/details/_err_ngrok_4000.md
@@ -1,4 +1,3 @@
 ### Possible solutions
 
-If you believe you own the email address in question, you can attempt a password
-reset to access the account or reach out to us.
+- If you believe you own the email address in question, you can attempt a password reset to access the account or reach out to us.

--- a/docs/errors/details/_err_ngrok_502.md
+++ b/docs/errors/details/_err_ngrok_502.md
@@ -5,4 +5,4 @@ ngrok resource limits are per-user, not per-account. For example, an account wit
 ### Possible Solutions
 
 - You can [invite more users to join your ngrok account](/docs/iam/users/#invitations).
-- If you need a more scalable option, [contact sales](https://ngrok.com/enterprise/contact).
+- If you need a more scalable option, consider a signing up for a [pay-as-you-go plan](https://ngrok.com/pricing).

--- a/docs/errors/details/_err_ngrok_502.md
+++ b/docs/errors/details/_err_ngrok_502.md
@@ -4,6 +4,5 @@ ngrok resource limits are per-user, not per-account. For example, an account wit
 
 ### Possible Solutions
 
-You can invite more users to join your ngrok account.
-
-If you need a more scalable option, contact sales [here](https://ngrok.com/enterprise/contact).
+- You can [invite more users to join your ngrok account](/docs/iam/users/#invitations).
+- If you need a more scalable option, [contact sales](https://ngrok.com/enterprise/contact).

--- a/docs/errors/details/_err_ngrok_702.md
+++ b/docs/errors/details/_err_ngrok_702.md
@@ -7,4 +7,4 @@
 
 ### Possible Solutions
 
-- Upgrade your account to a Pro or Business plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.
+- Upgrade your account to a Pro or Pay-as-you-go plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.

--- a/docs/errors/details/_err_ngrok_702.md
+++ b/docs/errors/details/_err_ngrok_702.md
@@ -1,3 +1,10 @@
 ### Additional Info
 
-ngrok limits the number of inbound connections to your tunnels. Limits are imposed on connections, not requests. If your HTTP clients use persistent connections aka HTTP keep-alive (most modern ones do), you'll likely never hit this limit. ngrok will return a 429 response to HTTP connections that exceed the rate limit. Connections to TCP and TLS tunnels violating the rate limit will be closed without a response.
+- ngrok limits the number of inbound connections to your tunnels.
+- Limits are imposed on connections, not requests. If your HTTP clients use persistent connections aka HTTP keep-alive (most modern ones do), you'll likely never hit this limit.
+- ngrok will return a `429` response to HTTP connections that exceed the rate limit.
+- Connections to TCP and TLS tunnels violating the rate limit will be closed without a response.
+
+### Possible Solutions
+
+- Upgrade your account to a Pro or Business plan from your [account dashboard](https://dashboard.ngrok.com/billing/plan) in order to reserve a custom hostname.

--- a/docs/errors/details/_err_ngrok_715.md
+++ b/docs/errors/details/_err_ngrok_715.md
@@ -1,12 +1,3 @@
-import HubspotForm from 'react-hubspot-form'
+### Possible Solutions
 
-### Additional Information
-
-We want to build a product that fits your needs. Tell us what you’re building so that we can improve ngrok. Your response here will go directly to the ngrok product team.
-
-<HubspotForm
-portalId='21124867'
-formId='53ded9ef-6aff-4dc2-8880-ffd1f3825fac'
-loading={<div>Loading...</div>}
-cssClass='width:50%;'
-/>
+- Contact support support@ngrok.com.

--- a/docs/errors/details/_err_ngrok_715.md
+++ b/docs/errors/details/_err_ngrok_715.md
@@ -7,8 +7,6 @@ We want to build a product that fits your needs. Tell us what you’re building 
 <HubspotForm
 portalId='21124867'
 formId='53ded9ef-6aff-4dc2-8880-ffd1f3825fac'
-onSubmit={() => console.log('Submit!')}
-onReady={(form) => console.log('Form ready!')}
 loading={<div>Loading...</div>}
-cssClass='width:50%'
+cssClass='width:50%;'
 />

--- a/docs/errors/details/_err_ngrok_717.md
+++ b/docs/errors/details/_err_ngrok_717.md
@@ -4,5 +4,5 @@ ngrok can be used without a registered account for limited use cases but is only
 
 ### Possible Solutions
 
-1. If you do not have an ngrok account, please [register for one](https://dashboard.ngrok.com) and install the authtoken for your agent using the command `ngrok config add-authtoken <TOKEN>`.
-2. If you have an ngrok account, ensure your authtoken is installed correctly using the command `ngrok config add-authtoken <TOKEN>`
+- If you do not have an ngrok account, please [register for one](https://dashboard.ngrok.com) and install the authtoken for your agent using the command `ngrok config add-authtoken <TOKEN>`.
+- If you have an ngrok account, ensure your authtoken is installed correctly using the command `ngrok config add-authtoken <TOKEN>`

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -242,6 +242,7 @@ const redirects = [
     [ fromExact(`/docs/traffic-policy/getting-started/`), `/docs/traffic-policy/getting-started/agent-endpoints/cli` ],
 
     [ fromIncludes(`/docs/tls/tls-termination/`), `/docs/tls/termination/` ],
+    [ fromIncludes(`/docs/guides/how-to-set-up-a-custom-domain/`), `/guides/other-guides/how-to-set-up-a-custom-domain/` ],
 ]
 
 // get current href from window


### PR DESCRIPTION
We have broken links in the non-generated content in our error docs. This PR fixes them and adds redirects where necessary.