### PR TITLE
Update fix-redirect.js

### DIFF
--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -51,7 +51,7 @@ const redirects = [
     [ fromIncludes(`/docs/secure-tunnels/tunnels/ssh-reverse-tunnel-agent`), `/docs/agent/ssh-reverse-tunnel-agent` ],
 
     // /docs/guides -> /docs/guides/other-guides
-    // /docs/guides/how-to-set-up-a-custom-domai -> /docs/guides/other-guides/how-to-set-up-a-custom-domain
+    // /docs/guides/how-to-set-up-a-custom-domain -> /docs/guides/other-guides/how-to-set-up-a-custom-domain
     [ fromIncludes(`/docs/guides/how-to-set-up-a-custom-domain`), `/docs/guides/other-guides/how-to-set-up-a-custom-domain` ],
 
     // /docs/guides/limits -> /docs/guides/other-guides/limits

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -242,7 +242,6 @@ const redirects = [
     [ fromExact(`/docs/traffic-policy/getting-started/`), `/docs/traffic-policy/getting-started/agent-endpoints/cli` ],
 
     [ fromIncludes(`/docs/tls/tls-termination/`), `/docs/tls/termination/` ],
-    [ fromIncludes(`/docs/guides/how-to-set-up-a-custom-domain/`), `/guides/other-guides/how-to-set-up-a-custom-domain/` ],
 ]
 
 // get current href from window

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -51,8 +51,8 @@ const redirects = [
     [ fromIncludes(`/docs/secure-tunnels/tunnels/ssh-reverse-tunnel-agent`), `/docs/agent/ssh-reverse-tunnel-agent` ],
 
     // /docs/guides -> /docs/guides/other-guides
-    // /docs/guides/other-guides/how-to-set-up-a-custom-domain -> /docs/guides/other-guides/how-to-set-up-a-custom-domain
-    [ fromIncludes(`/docs/guides/other-guides/how-to-set-up-a-custom-domain`), `/docs/guides/other-guides/how-to-set-up-a-custom-domain` ],
+    // /docs/guides/how-to-set-up-a-custom-domai -> /docs/guides/other-guides/how-to-set-up-a-custom-domain
+    [ fromIncludes(`/docs/guides/how-to-set-up-a-custom-domain`), `/docs/guides/other-guides/how-to-set-up-a-custom-domain` ],
 
     // /docs/guides/limits -> /docs/guides/other-guides/limits
     [ fromIncludes(`/docs/guides/limits`), `/docs/guides/other-guides/limits` ],


### PR DESCRIPTION
This was changed recently https://github.com/ngrok/ngrok-docs/pull/1132 We also noticed a huge spike in traffic to https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/ It turns out, its caught in an infinite redirect loop

This looks like a copy paste error based on the patterns in this file where this section should be redirecting from `/docs/guides/*` to `/docs/guides/other-guides/*`. Otherwise its doing a redirect from the same URL to the same one.

I also noticed there is another value
https://github.com/ngrok/ngrok-docs/blob/3bf72bf28e157ee7b3c6a1480a28f99871c7a416/static/scripts/fix-redirect.js#L245
But I'm not sure what this is for as that URL to redirect to I don't think is valid