### PR TITLE
Test if adding `title` to frontmatter improves search`

### DIFF
--- a/docs/guides/other-guides/how-to-set-up-a-custom-domain.mdx
+++ b/docs/guides/other-guides/how-to-set-up-a-custom-domain.mdx
@@ -1,4 +1,6 @@
-# How to Set Up a Custom Domain
+---
+title: Set Up a Custom Domain
+---
 
 ngrok allows for using hostnames from a custom domain that you own to be used with your tunnel endpoints or [Edges](/network-edge/edges/). Utilizing CNAMEs, ngrok will host an endpoint using your custom domain while also providing the ability to manage the complete TLS certficate lifecycyle for you.
 

--- a/docs/guides/other-guides/securing-your-tunnels.mdx
+++ b/docs/guides/other-guides/securing-your-tunnels.mdx
@@ -1,4 +1,6 @@
-# Securing ngrok
+---
+title: Securing ngrok
+---
 
 This guide will walk you through recommendations for ensuring you are using ngrok securely.
 

--- a/docs/k8s/crds.mdx
+++ b/docs/k8s/crds.mdx
@@ -1,4 +1,6 @@
-# CRDs
+---
+title: CRDs
+---
 
 Kubernetes has the concept of [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs) which allow you to define your own custom resources. This document will cover the CRDs you might use to achieve your goals with the ngrok Kubernetes Operator.
 


### PR DESCRIPTION
I believe adding `title` to the frontmatter of a page will improve its search performance. This PR does so to a couple docs as a small test.

## Results to improve

- "Custom domain" results in [the kubernetes guide](https://ngrok.com/docs/k8s/custom-domain/) first. The [second top-level result ](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/)is the preferred answer.
![image](https://github.com/user-attachments/assets/c62c9fba-4137-42dc-989e-8aa05b1cbaa3)


- "Secure" does not result in the "[Securing ngrok](https://ngrok.com/docs/guides/other-guides/securing-your-tunnels/)" guide
![image](https://github.com/user-attachments/assets/78e9438c-b4ea-42cb-9cc4-17ec35a215c1)


- "crd" does not result in [the CRDs page](https://ngrok.com/docs/k8s/crds/)
![image](https://github.com/user-attachments/assets/a872f13c-c4ed-4611-b252-b4cb3faa6f65)
