### PR TITLE
add components to read endpoint url from search params

### DIFF
--- a/src/components/search-params-endpoint-url.tsx
+++ b/src/components/search-params-endpoint-url.tsx
@@ -12,7 +12,7 @@ const searchParamKey = "endpoint_url";
  *
  * Provide a `fallback` to render when the search param is not present.
  */
-function EndpointHostnameFromSearchParams({ fallback }: Props) {
+function EndpointUrlHostname({ fallback }: Props) {
 	const endpointUrl = useEndpointUrlFromSearchParams();
 	return endpointUrl?.hostname ?? fallback;
 }
@@ -22,7 +22,7 @@ function EndpointHostnameFromSearchParams({ fallback }: Props) {
  *
  * Provide a `fallback` to render when the search param is not present.
  */
-function EndpointOriginFromSearchParams({ fallback }: Props) {
+function EndpointUrlOrigin({ fallback }: Props) {
 	const endpointUrl = useEndpointUrlFromSearchParams();
 	return endpointUrl?.origin ?? fallback;
 }
@@ -39,8 +39,8 @@ function useEndpointUrlFromSearchParams() {
 
 export {
 	//,
-	EndpointHostnameFromSearchParams,
-	EndpointOriginFromSearchParams,
+	EndpointUrlHostname,
+	EndpointUrlOrigin,
 	useEndpointUrlFromSearchParams,
 };
 

--- a/src/components/search-params-endpoint-url.tsx
+++ b/src/components/search-params-endpoint-url.tsx
@@ -1,0 +1,60 @@
+import { useLocation } from "@docusaurus/router";
+import { useMemo, type ReactNode } from "react";
+
+type Props = {
+	fallback?: ReactNode;
+};
+
+const searchParamKey = "endpoint_url";
+
+/**
+ * Renders the URL hostname from the `endpoint_url` search param.
+ *
+ * Provide a `fallback` to render when the search param is not present.
+ */
+function EndpointHostnameFromSearchParams({ fallback }: Props) {
+	const endpointUrl = useEndpointUrlFromSearchParams();
+	return endpointUrl?.hostname ?? fallback;
+}
+
+/**
+ * Renders the URL origin from the `endpoint_url` search param.
+ *
+ * Provide a `fallback` to render when the search param is not present.
+ */
+function EndpointOriginFromSearchParams({ fallback }: Props) {
+	const endpointUrl = useEndpointUrlFromSearchParams();
+	return endpointUrl?.origin ?? fallback;
+}
+
+/**
+ * Returns the `endpoint_url` search param as a URL, if present.
+ */
+function useEndpointUrlFromSearchParams() {
+	const location = useLocation();
+	const searchParams = new URLSearchParams(location.search);
+	const endpointUrl = toUrl(searchParams.get(searchParamKey));
+	return useMemo(() => endpointUrl, [endpointUrl]);
+}
+
+export {
+	//,
+	EndpointHostnameFromSearchParams,
+	EndpointOriginFromSearchParams,
+	useEndpointUrlFromSearchParams,
+};
+
+/**
+ * Converts a string to a URL, or `undefined` if the given value is not a valid URL.
+ */
+function toUrl(value: string | undefined | null) {
+	if (!value) {
+		return undefined;
+	}
+
+	try {
+		return new URL(value);
+	} catch (_) {
+		return undefined;
+	}
+}


### PR DESCRIPTION
These are not used yet, but will be in an upcoming change to our error docs generation.