### PR TITLE
Put agent cli back in the sideabar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -192,6 +192,7 @@ const sidebars = {
 			items: [
 				"agent/index",
 				"agent/web-inspection-interface",
+				"agent/cli",
 				"agent/cli-api",
 				{
 					label: "Configuration file",


### PR DESCRIPTION
This was removed accidentally