### PR TITLE
Add some new use cases to Traffic Policy examples

### DIFF
--- a/docs/traffic-policy/examples/index.mdx
+++ b/docs/traffic-policy/examples/index.mdx
@@ -32,15 +32,6 @@ Explore a curated collection of examples and configuration examples spanning fro
 
 A number of these examples come from a longer article about how ngrok [makes policy management accessible](https://ngrok.com/blog-post/api-gateway-policy-management-examples) to developers, including a simple Go-based application for testing these and other configurations.
 
-See the following categories for specific expressions and actions:
-
-- [Route requests](#route-requests)
-- [Add authentication](#authentication)
-- [Rate limit requests](#rate-limiting)
-- [Block unwanted traffic](#block-unwanted-traffic)
-- [Manipulate headers](#manipulate-headers)
-- [Other](#other)
-
 ## Route requests
 
 ### Forward to an internal endpoints based on request attributes

--- a/docs/traffic-policy/examples/index.mdx
+++ b/docs/traffic-policy/examples/index.mdx
@@ -62,7 +62,6 @@ on_http_request:
           url: https://${req.host.split('.example.com)[0]}.internal
 ```
 
-
 Forward requsets containing a `X-Customer-Value: {CUSTOMER}` header to `https://{CUSTOMER}.internal`.
 
 ```yaml mode=traffic-policy
@@ -207,7 +206,7 @@ on_http_response:
 
 ## Other
 
-### Deploy simple A/B tests 
+### Deploy simple A/B tests
 
 Using the [`rand.double()`
 macro](/docs/traffic-policy/macros/utility.mdx#randdouble--double) set to `>=
@@ -219,7 +218,7 @@ B test, e.g. `<= 0.1` for 10%.
 
 ```yaml mode=traffic-policy
 ---
-on_http_request: 
+on_http_request:
   - expressions:
       - "rand.double() <= 0.5"
     actions:
@@ -237,7 +236,7 @@ separate route.
 
 ```yaml mode=traffic-policy
 ---
-on_http_request: 
+on_http_request:
   - expressions:
       - "rand.double() <= 0.5"
     actions:
@@ -286,7 +285,6 @@ By include a `X-Api-Version` header in your API reference or developer documenta
 <DeprecateVersion />
 
 ### Manipulate request headers
-
 
 ### Add compression
 

--- a/docs/traffic-policy/examples/index.mdx
+++ b/docs/traffic-policy/examples/index.mdx
@@ -34,12 +34,46 @@ A number of these examples come from a longer article about how ngrok [makes pol
 
 See the following categories for specific expressions and actions:
 
-- [Authentication](#authentication)
-- [Rate limiting](#rate-limiting)
-- [Block unwanted requests](#block-unwanted-requests)
+- [Route requests](#route-requests)
+- [Add authentication](#authentication)
+- [Rate limit requests](#rate-limiting)
+- [Block unwanted traffic](#block-unwanted-traffic)
+- [Manipulate headers](#manipulate-headers)
 - [Other](#other)
 
-## Authentication
+## Route requests
+
+### Forward to an internal endpoints based on request attributes
+
+You can use [CEL
+interpolation](/docs/traffic-policy/concepts/cel-interpolation.mdx) to
+dynamically forward requests to different internal endpoints based on URL,
+hostname, path, headers, and more. This allows you to manage complex traffic
+topologies without manually creating and managing each [`forward-internal`
+action](/docs/traffic-policy/actions/forward-internal.mdx).
+
+Forward requests from `https://*.example.com` to `https://<SUBDOMAIN>.internal`.
+
+```yaml mode=traffic-policy
+on_http_request:
+  - actions:
+      - type: forward-internal
+        config:
+          url: https://${req.host.split('.example.com)[0]}.internal
+```
+
+
+Forward requsets containing a `X-Customer-Value: {CUSTOMER}` header to `https://{CUSTOMER}.internal`.
+
+```yaml mode=traffic-policy
+on_http_request:
+  - actions:
+      - type: "forward-internal"
+        config:
+          url: https://${getReqHeader(‘X-Customer-Value’)[0]}.internal
+```
+
+## Add authentication
 
 ### Add JWT authentication and key-based rate limiting
 
@@ -55,7 +89,7 @@ Building from our [Auth0 guide](/integrations/auth0/jwt-action/), these rules al
 
 <OIDCIdentityToken />
 
-## Rate limiting
+## Rate limit requests
 
 ### Rate limit for specific endpoint
 
@@ -77,6 +111,20 @@ Using a naming scheme in your upstream servers, and API calls using a `tier` hea
 <RateLimitPricing />
 
 ## Block unwanted requests
+
+### Deny traffic from Tor networks
+
+Use connection variables available in [IP Intelligence](/docs/traffic-policy/variables/ip-intel.mdx) to block Tor exit node IPs.
+
+```yaml traffic-policy
+on_http_request:
+  - expressions:
+      - "!('proxy.anonymous.tor' in conn.client_ip.categories)"
+    actions:
+      - type: deny
+        config:
+          status_code: 403
+```
 
 ### Disallow bots and crawlers with a `robots.txt`
 
@@ -121,7 +169,101 @@ Prevent excessively large user uploads, like text or images, that might cause pe
 
 <LimitSize />
 
+## Manipulate headers
+
+### Enrich your upstream service
+
+Add new headers to requests to give your upstream service more context about the
+consumer, which in turn allows for richer functionality, such as localized
+languages and pricing.
+
+```yaml mode=traffic-policy
+on_http_request:
+  - actions:
+      - type: add-headers
+        config:
+          headers:
+						x-is-ngrok: "1"
+            x-endpoint-id: "${endpoint.id}"
+            x-client-ip: "${conn.client_ip}"
+            x-client-conn-start: "${conn.ts.start}"
+            x-client-loc: "${conn.geo.city}, ${conn.geo.country}"
+            x-client-path: "${req.url.path}
+```
+
+### Remove service details from response headers
+
+Some frameworks, like Express, add headers like `X-Powered-By: Express` to
+responses, which you may not want to reveal to your users.
+
+```yaml mode=traffic-policy
+on_http_response:
+  - actions:
+      - type: remove-headers
+        config:
+          headers:
+            - "X-Powered-By"
+```
+
 ## Other
+
+### Deploy simple A/B tests 
+
+Using the [`rand.double()`
+macro](/docs/traffic-policy/macros/utility.mdx#randdouble--double) set to `>=
+0.5`, you can equally split incoming requests to two different internal agent
+endpoints, which forward traffic to the two versions of your service.
+
+You can manipulate `<= 0.5` to match the percentage of requests to route to your
+B test, e.g. `<= 0.1` for 10%.
+
+```yaml mode=traffic-policy
+---
+on_http_request: 
+  - expressions:
+      - "rand.double() <= 0.5"
+    actions:
+      - type: "forward-internal"
+        config:
+          url: https://b.internal
+  - actions:
+      - type: "forward-internal"
+        config:
+          url: https://a.internal
+```
+
+If you don't have multiple services, you could also route B traffic to a
+separate route.
+
+```yaml mode=traffic-policy
+---
+on_http_request: 
+  - expressions:
+      - "rand.double() <= 0.5"
+    actions:
+      - type: "url-rewrite"
+        config:
+					from: "/path/to/test"
+          to: "/path/to/test-b"
+```
+
+### Create 'pretty' URLs for SEO
+
+You can map the permalinks created by a blog CMS to "pretty" alternatives that
+are easier for both humans and SEO bot to grok. The following rule rewrites the
+user-friendly `/blog/11/example-title` to
+`/blog/index.php?p=11&title=example-title`, which is readable by your CMS.
+
+```yaml mode=traffic-policy
+on_http_request:
+  - expressions:
+      - "req.url.path.startsWith('/blog')"
+    actions:
+      - type: "url-rewrite"
+        config:
+          from: "/blog/([0-9]+)/([a-zA-Z]+)/"
+          to: "/blog/index.php?p=$1&title=$2"
+```
 
 ### User agent filtering
 
@@ -145,9 +287,6 @@ By include a `X-Api-Version` header in your API reference or developer documenta
 
 ### Manipulate request headers
 
-Add new headers to requests to give your upstream service more context about the consumer, which in turn allows for richer functionality, such as localized languages and pricing.
-
-<ManipulateHeaders />
 
 ### Add compression
 

--- a/docs/traffic-policy/examples/index.mdx
+++ b/docs/traffic-policy/examples/index.mdx
@@ -37,11 +37,11 @@ A number of these examples come from a longer article about how ngrok [makes pol
 ### Forward to an internal endpoints based on request attributes
 
 You can use [CEL
-interpolation](/docs/traffic-policy/concepts/cel-interpolation.mdx) to
+interpolation](/docs/traffic-policy/concepts/cel-interpolation) to
 dynamically forward requests to different internal endpoints based on URL,
 hostname, path, headers, and more. This allows you to manage complex traffic
 topologies without manually creating and managing each [`forward-internal`
-action](/docs/traffic-policy/actions/forward-internal.mdx).
+action](/docs/traffic-policy/actions/forward-internal).
 
 Forward requests from `https://*.example.com` to `https://<SUBDOMAIN>.internal`.
 
@@ -50,7 +50,7 @@ on_http_request:
   - actions:
       - type: forward-internal
         config:
-          url: https://${req.host.split('.example.com)[0]}.internal
+          url: https://${req.host.split('.example.com')[0]}.internal
 ```
 
 Forward requsets containing a `X-Customer-Value: {CUSTOMER}` header to `https://{CUSTOMER}.internal`.
@@ -60,7 +60,7 @@ on_http_request:
   - actions:
       - type: "forward-internal"
         config:
-          url: https://${getReqHeader(‘X-Customer-Value’)[0]}.internal
+          url: https://${getReqHeader('X-Customer-Value')[0]}.internal
 ```
 
 ## Add authentication
@@ -104,7 +104,7 @@ Using a naming scheme in your upstream servers, and API calls using a `tier` hea
 
 ### Deny traffic from Tor networks
 
-Use connection variables available in [IP Intelligence](/docs/traffic-policy/variables/ip-intel.mdx) to block Tor exit node IPs.
+Use connection variables available in [IP Intelligence](/docs/traffic-policy/variables/ip-intel) to block Tor exit node IPs.
 
 ```yaml traffic-policy
 on_http_request:
@@ -183,8 +183,11 @@ on_http_request:
 
 ### Remove service details from response headers
 
-Some frameworks, like Express, add headers like `X-Powered-By: Express` to
-responses, which you may not want to reveal to your users.
+Some frameworks, like [Express](https://expressjs.com/), add headers like
+`X-Powered-By: Express` to responses, which you may not want to reveal to your
+users.
+
+The following example removes the `X-Powered-By` header.
 
 ```yaml mode=traffic-policy
 on_http_response:
@@ -200,7 +203,7 @@ on_http_response:
 ### Deploy simple A/B tests
 
 Using the [`rand.double()`
-macro](/docs/traffic-policy/macros/utility.mdx#randdouble--double) set to `>=
+macro](/docs/traffic-policy/macros/utility#randdouble--double) set to `>=
 0.5`, you can equally split incoming requests to two different internal agent
 endpoints, which forward traffic to the two versions of your service.
 
@@ -240,9 +243,13 @@ on_http_request:
 ### Create 'pretty' URLs for SEO
 
 You can map the permalinks created by a blog CMS to "pretty" alternatives that
-are easier for both humans and SEO bot to grok. The following rule rewrites the
-user-friendly `/blog/11/example-title` to
-`/blog/index.php?p=11&title=example-title`, which is readable by your CMS.
+are easier for both humans and [SEO
+bots](https://developers.google.com/search/docs/crawling-indexing/googlebot) to
+understand.
+
+The following rule rewrites the a user-friendly URL like
+`/blog/11/example-title` to `/blog/index.php?p=11&title=example-title`, which is
+readable by your CMS.
 
 ```yaml mode=traffic-policy
 on_http_request:


### PR DESCRIPTION
During the interlock today I remembered that I had some sitting around to add here. I also started to use the new Mantle-based code editor—if no one else jumps on it, I can continue working on converting them in a separate PR.