### PR TITLE
Update basic-auth.mdx

### DIFF
--- a/docs/http/basic-auth.mdx
+++ b/docs/http/basic-auth.mdx
@@ -13,7 +13,7 @@ import SshExample from "/examples/ssh/http-basic-auth.mdx";
 
 ## Overview
 
-This modules enforces HTTP Basic Authentication in front of your endpoints.
+This module enforces HTTP Basic Authentication in front of your endpoints.
 Requests with a valid username and password will be sent to your upstream
 service, all others will be rejected with a 401 Unauthorized response.
 
@@ -74,10 +74,8 @@ The HTTP Basic Auth realm is always 'ngrok'. It may not be configured.
 ### Basic Auth on Upstream Service
 
 If your upstream service also enforces HTTP Basic Auth, it is not recommended
-to use this module with it. Instead, you should choose to either not use this
-module or to disable http basic auth enforcement on your upstream service. If
-you absolutely must use HTTP Basic Auth on both your ngrok endpoint and your
-upstream service, you have two options:
+to use this module with it. If you absolutely must use HTTP Basic Auth on
+both your ngrok endpoint and your upstream service, you have two options:
 
 1. Ensure that the username/password credentials enforced by ngrok and those
    enforced by the upstream service are identical. If you don't, no requests will
@@ -86,7 +84,7 @@ upstream service, you have two options:
 
 2. Use the [Request Headers](/http/request-headers) module to rewrite the
    `authorization` header to the value expected by the upstream service. For
-   example, if you want to accept requests with credentials of "username:password,
+   example, if you want to accept requests with credentials of "username:password",
    but the upstream service expects credentials of "Aladdin:open sesame", you
    could use the following command. Keep in mind that you need to base64 encode
    the username and password for the upstream service.
@@ -104,7 +102,7 @@ ngrok http 80 \
 
 | Parameter       | Description                                                                                                                               |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Credentials** | A list of username/password pairs specified as 'username:password'. Passwords must be at least 8 characters and more than 128 characters. |
+| **Credentials** | A list of username/password pairs specified as 'username:password'. Passwords must be at least 8 characters and less than 128 characters. |
 
 ### Upstream Headers {#upstream-headers}
 


### PR DESCRIPTION
Removed a repetitive and confusing sentence. 
Fixed some typos.
Changed "more than 128 characters" to "less than 128 characters". I don't know the actual parameter, but logically it made sense that the password should be 8 to 128 characters.