### PR TITLE
Update index.mdx

### DIFF
--- a/docs/http/index.mdx
+++ b/docs/http/index.mdx
@@ -128,10 +128,10 @@ import SchemesSshExample from "/examples/ssh/http-schemes.mdx";
 ## Overview
 
 ngrok's HTTP endpoints enable you to serve APIs, web services, websocket servers,
-websites and more.
+websites, and more.
 
 Serving a web application is as simple as `ngrok http 80`. You can also layer
-on additional capabilities like auth, observability, load balancing and more.
+on additional capabilities like auth, observability, load balancing, and more.
 
 ## Example Usage
 
@@ -170,7 +170,7 @@ Create an HTTPS endpoint on a randomly assigned ngrok domain.
 
 ### Static domain
 
-Create an HTTPS endpoint on `example.ngrok.app`
+Create an HTTPS endpoint on `example.ngrok.app`.
 
 <Tabs groupId="connectivity" queryString="cty">
 	<TabItem value="agent-cli" label="Agent CLI" default>
@@ -209,8 +209,8 @@ You will need to create a CNAME DNS record to bring your own domain. [Create a
 Domain record](https://dashboard.ngrok.com/cloud-edge/domains) on your ngrok
 dashboard and follow the instructions.
 
-Consult the documentation about [setting up branded
-domains](/network-edge/domains-and-tcp-addresses/#branded-domains) for additional details.
+For addtional details, see [setting up branded
+domains](/network-edge/domains-and-tcp-addresses/#branded-domains).
 
 <Tabs groupId="connectivity" queryString="cty">
 	<TabItem value="agent-cli" label="Agent CLI" default>
@@ -378,7 +378,7 @@ header instead of appending a second value.
 
 <br />
 
-### Forward to non-local
+### Forward to Non-local
 
 Forward traffic to a HTTP server running on your network at `192.168.1.2:80`.
 
@@ -608,7 +608,7 @@ Anyone can access your ngrok endpoints unless you secure them with
 authentication. ngrok supports many different forms of authentication. The
 easiest to get started with are Basic Auth and OAuth. Basic Auth lets you set a
 username and password for your endpoint. With OAuth, you can restrict access to
-a specific email address with a Google, Microsoft or GitHub account.
+a specific email address with a Google, Microsoft, or GitHub account.
 
 #### Examples
 
@@ -627,7 +627,7 @@ There are many other forms of auth for more advanced use cases as well:
 
 [The Domains documentation](/network-edge/domains-and-tcp-addresses/#domains)
 contains details about how ngrok chooses domains, what managed based domains
-ngrok operates, how to set up branded domains, how wildcard domains work and
+ngrok operates, how to set up branded domains, how wildcard domains work, and
 more.
 
 #### Static Domains
@@ -724,12 +724,12 @@ setup, configure or manage.
 
 Regardless of whether your domain is a subdomain of ngrok's managed base
 domains (like `ngrok.app`) or you brought your own domain, ngrok will
-automatically provision and renew TLS certificates for you. You can optionally
-bring your own certificates if you'd like though.
+automatically provision and renew TLS certificates for you. Optionally, 
+you can bring your own certificates.
 
 Read the [TLS Certificates documentation](/network-edge/tls-certificates/) for
 additional details of how ngrok automatically provisions certificates for your
-domains as well as how you can bring your own certificates.
+domains, as well as explaining how you can bring your own certificates.
 
 ### Routes
 
@@ -817,7 +817,7 @@ via an Agent or Agent SDK.
   traffic to domains associated with your HTTPS edges is automatically redirected
   to HTTPS.
 - When you create an HTTPS Edge via the dashboard, it will automatically create
-  a new Domain with a random name and assign it to your Edge. If you are on the
+  a new domain with a random name and assign it to your Edge. If you are on the
   free plan and have created your free domain, it will adopt that domain.
 - When you create an HTTPS Edge via the dashboard, it will automatically create
   a Failover Backend with two entries. First, a tunnel group backend with a


### PR DESCRIPTION
Fixed a few typos.
Reworded two sentences for better readability.
I prefer the oxford comma (the extra comma at the end of a set of three or more items) because in legal language this can get confusing. If I say split the proceeds evenly between A, B and C. One way to read that is that A gets 50% and the duo of B and C get the other 50%. In technical terms you might specify to divide resources between A, B and C and a user might not know if they should give A 50% or 33.33%.