### PR TITLE
Update index.mdx

### DIFF
--- a/docs/tls/index.mdx
+++ b/docs/tls/index.mdx
@@ -60,7 +60,7 @@ TLS endpoints enable you to deliver any network service that runs over a
 TLS-based protocol. TLS endpoints make no assumptions about the wrapped
 protocol being transported.
 
-TLS endpoints use the [Server Name Information (SNI)](#compatible-clients) data
+TLS endpoints use the [Server Name Indication (SNI)](#compatible-clients) data
 on incoming TLS connections to route connections to the appropriate endpoint.
 
 Because the TLS protocol has limited application-level semantics, ngrok can
@@ -292,15 +292,15 @@ Wikipedia](https://en.wikipedia.org/wiki/Server_Name_Indication#No_support)
 Module configurations in the ngrok dashboard or API instead of defining them
 via an Agent or Agent SDK.
 
-- A TLS Edge is attached to one or more Domains. For each Domain, it creates
+- A TLS Edge is attached to one or more domains. For each Domain, it creates
   a TLS Endpoint that it listens for traffic on.
-- When a Domain is associated with a TLS Edge, agents may no longer start
-  endpoints on that Domain. You can always detach a Domain from your Edge if you
+- When a domain is associated with a TLS Edge, agents may no longer start
+  endpoints on that domain. You can always detach a domain from your Edge if you
   want to create Endpoints on it from an Agent or Agent SDK.
 - Modules on a TLS Edge are attached directly to the edge itself. There are no
   Routes.
 - When you create a TLS Edge via the dashboard, it will automatically create a
-  new Domain with a random name and assign it to your Edge.
+  new domain with a random name and assign it to your Edge.
 - When you create an TLS Edge via the dashboard, it will automatically create
   a [Tunnel Group Backend](/network-edge/edges/#tunnel-group) with a unique label.
 
@@ -312,7 +312,7 @@ Use modules to modify the behavior of traffic flowing through your endpoints.
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [Mutual TLS](mutual-tls)           | Perform mutual TLS authentication when terminating TLS connections with a configured set of certificate authorities. |
 | [TLS](tls-termination)             | Configure whether ngrok terminates TLS traffic at its edge or forwards the TLS traffic through unterminated.         |
-| [IP Restrictions](ip-restrictions) | Allow or deny traffic based on the source IP of connections                                                          |
+| [IP Restrictions](ip-restrictions) | Allow or deny traffic based on the source IP of connections.                                                         |
 
 ### Observability
 
@@ -328,7 +328,7 @@ published.
 If the TLS handshake fails, a TLS abort code will be sent to the client.
 
 In all other cases, if an error is encountered while handling TLS connections
-to your endpoints (e.g. no available backends or internal server error), the
+to your endpoints (e.g., no available backends or internal server error), the
 connection will simply be closed. The TLS protocol and its implementations are
 not sufficiently flexible enough to deliver additional rich error information
 when failures are encountered.


### PR DESCRIPTION
I believe SNI is Server Name Indication so I changed that reference. I'm not sure why Domain is capitalized some times and sometimes not. In my opinion, it should not be capitalized unless it's a proper name (like Domain CityGate Luxury Apartments). Found a few typos.