### PR TITLE
Update request-headers.mdx to reduce uneccessary words and fix typos

### DIFF
--- a/docs/http/request-headers.mdx
+++ b/docs/http/request-headers.mdx
@@ -60,22 +60,22 @@ make them dynamic.
 You may interpolate variables into header values. Variables are interpolated
 into headers with JSONPath expressions surrounded by the `${}` syntax.
 
-For example to include geographical data about the client IP that initiated the
-request, you may construct a header value like so.
+For example, to include geographical data about the client IP that initiated the
+request, you may construct a header value:
 
 ```bash
 ngrok http 80 --request-header-add 'country: ${conn.geo.country_code}'
 ```
 
 If you are specifying variable interpolation from the command line, make sure
-to use single quotes for the command line argument otherwise it is likely that
+to use single quotes for the command line argument. Otherwise it is likely that
 the shell will interpret your variable definition.
 
 Consult the [Variables Reference](#variables) for the available variables.
 
 ### Automatic Headers {#automatic-headers}
 
-Regardless of whether you enable the request headers module or not,other-guides/ [ngrok adds
+Regardless of whether you enable the request headers module or not, [ngrok adds
 default headers to every HTTP request](/http/#upstream-headers).
 
 You may remove these default headers with the request headers module. For example:
@@ -94,7 +94,7 @@ example:
 ngrok http 80 --request-header-add "foo: bar" --request-header-add "foo: baz"
 ```
 
-will result in a header with multiple values set
+This will result in a header with multiple values set:
 
 ```http
 GET / HTTP/1.1
@@ -139,8 +139,7 @@ foo: original-value
 foo: new-value
 ```
 
-If you wish to replace a header, you can combine header removal and addition to
-achieve that effect.
+If you wish to replace a header, you can combine header removal and addition:
 
 ```bash
 ngrok http 80 --request-header-remove "foo" --request-header-add "foo: new-value"
@@ -175,7 +174,7 @@ transmitted to the upstream service.
 - You may not remove the `host` header without adding it with a different value.
 - Adding a `host` header will replace the existing value instead of adding a second value.
 - You may not use this module to add the `ngrok-skip-browser-warning` header to
-  skip the ngrok browser warning on free accounts. For more information about the abuse interstitial, please check out the [free plan limits guide](/docs/pricing-limits/free-plan-limits#why-is-there-an-interstitial-in-front-of-my-html-content).
+  skip the ngrok browser warning on free accounts. For more information about the abuse interstitial, see the [free plan limits guide](/docs/pricing-limits/free-plan-limits#why-is-there-an-interstitial-in-front-of-my-html-content).
 
 ## Reference
 
@@ -216,7 +215,7 @@ This module is available on all plans.
 
 ## Try it out
 
-To try out the request headers module we're going to foward to httpbin.
+To try out the request headers module, foward to httpbin:
 
 ```bash
 ngrok http https://httpbin.org --url your-domain.ngrok.app
@@ -238,7 +237,7 @@ curl https://your-domain.ngrok.app/headers
 }
 ```
 
-Now, let's try manipulating the headers. We'll remove the `user-agent` header
+Now, let's try manipulating the headers. Remove the `user-agent` header
 and add a header of our own with geo data. Stop your previous instance of ngrok
 with `Ctrl+C` and then restart ngrok with a new command.
 


### PR DESCRIPTION
Fixed a typo in the Automatic Headers section that looks like a copy/paste error.  
Made the descriptor sentences between code snippets more consistent.