### PR TITLE
Fix links/redirects to traffic policy examples

### DIFF
--- a/docs/guides/api-gateway/get-started.mdx
+++ b/docs/guides/api-gateway/get-started.mdx
@@ -630,4 +630,4 @@ You'll receive a `401 Unauthorized` error. Your API is now protected from unauth
 
 You've successfully brought your API online and protected it with ngrok's API gateway, allowing you to offload non-functional
 requirements like rate limiting, authentication, routing, and global load balancing to ngrok. Check out our
-[rules gallery](/traffic-policy/examples/) to learn how to extend your traffic policy rules.
+[rules gallery](/traffic-policy/examples/a-b-tests/) to learn how to extend your traffic policy rules.

--- a/docs/traffic-policy/getting-started.mdx
+++ b/docs/traffic-policy/getting-started.mdx
@@ -48,5 +48,5 @@ You've successfully set up your first endpoint with a custom traffic policy usin
 To learn more about ngrok's Traffic Policy and it's capabilities, check out the following resources:
 
 - Learn about the [core concepts](/traffic-policy/concepts/) like phases and rules.
-- Check out the [examples, use-cases and guides](/traffic-policy/examples).
+- Check out the [examples, use-cases and guides](/traffic-policy/examples/a-b-tests/).
 - The list of [available actions](/traffic-policy/actions/), [macros](/traffic-policy/macros/) and [variables](/traffic-policy/variables/) you can use.

--- a/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
@@ -44,5 +44,5 @@ You've successfully set up your first Agent Endpoint with a custom Traffic Polic
 To learn more about ngrok's Traffic Policy and it's capabilities, check out the following resources:
 
 - Learn about the [core concepts](/traffic-policy/concepts/) like phases and rules.
-- Check out the [examples, use-cases and guides](/traffic-policy/examples).
+- Check out the [examples, use-cases and guides](/traffic-policy/examples/a-b-tests/).
 - The list of [available actions](/traffic-policy/actions/), [macros](/traffic-policy/macros/) and [variables](/traffic-policy/variables/) you can use.

--- a/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
@@ -68,5 +68,5 @@ You've successfully set up your first Agent Endpoint with a custom Traffic Polic
 To learn more about ngrok's Traffic Policy and it's capabilities, check out the following resources:
 
 - Learn about the [core concepts](/traffic-policy/concepts/) like phases and rules.
-- Check out the [examples, use-cases and guides](/traffic-policy/examples).
+- Check out the [examples, use-cases and guides](/traffic-policy/examples/a-b-tests/).
 - The list of [available actions](/traffic-policy/actions/), [macros](/traffic-policy/macros/) and [variables](/traffic-policy/variables/) you can use.

--- a/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
+++ b/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
@@ -59,5 +59,5 @@ You've successfully set up your first Cloud Endpoint with a custom Traffic Polic
 To learn more about ngrok's Traffic Policy and it's capabilities, check out the following resources:
 
 - Learn about the [core concepts](/traffic-policy/concepts/) like phases and rules.
-- Check out the [examples, use-cases and guides](/traffic-policy/examples).
+- Check out the [examples, use-cases and guides](/traffic-policy/examples/a-b-tests/).
 - The list of [available actions](/traffic-policy/actions/), [macros](/traffic-policy/macros/) and [variables](/traffic-policy/variables/) you can use.

--- a/docs/traffic-policy/index.mdx
+++ b/docs/traffic-policy/index.mdx
@@ -54,7 +54,7 @@ Learn how traffic policies work, key concepts, examples, and identity management
 		</div>
 	</Link>
 
-    <Link to={`/traffic-policy/examples/`}>
+    <Link to={`/traffic-policy/examples/a-b-tests`}>
     	<div className="ngrok--card hover:bg-card-hover">
     		<div className="ngrok--card-heading">
     			<h3 className="text-md sm:text-base">Examples / Use-Cases</h3>
@@ -62,18 +62,6 @@ Learn how traffic policies work, key concepts, examples, and identity management
     		<p className="flex-grow text-md sm:text-sm">Dive into practical examples, use-cases, and guides to see traffic policies in action.</p>
     	</div>
     </Link>
-
-    {/* <Link to={`/traffic-policy/identity/`}>
-    	<div className="ngrok--card hover:bg-card-hover">
-    		<div className="ngrok--card-heading">
-    			<h3 className="text-md sm:text-base">Traffic Identity</h3>
-    		</div>
-    		<p className="flex-grow text-md sm:text-sm">
-    			Learn how you can manage users authenticated with OAuth, SAML, and OIDC
-    			actions.
-    		</p>
-    	</div>
-    </Link> */}
 
 </div>
 

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -205,7 +205,7 @@ const redirects = [
     [ fromIncludes(`/docs/http-header-templates`), `/docs/traffic-policy/actions/add-headers/` ],
 
     // (DEC 2024) New Traffic Policy
-    [ fromIncludes(`/docs/traffic-policy/gallery/`), `/docs/traffic-policy/examples/` ],
+    [ fromIncludes(`/docs/traffic-policy/gallery/`), `/docs/traffic-policy/examples/a-b-tests/` ],
     [ fromIncludes(`/docs/http/traffic-policy/gallery/`), `/docs/traffic-policy/examples/` ],
     [ fromIncludes(`/docs/tls/traffic-policy/gallery/`), `/docs/traffic-policy/examples/` ],
     [ fromIncludes(`/docs/tcp/traffic-policy/gallery/`), `/docs/traffic-policy/examples/` ],


### PR DESCRIPTION
- [On this page in prod](https://ngrok.com/docs/traffic-policy/getting-started/agent-endpoints/cli/#step-3-test-it-out), when you click the link in "[examples, use-cases and guides](https://ngrok.com/docs/traffic-policy/examples/)," it takes you to a 404. This PR fixes that.
- This PR replaces links to `/traffic-policy/examples` as it doesn't exist