### PR TITLE
Remove conn geo variables in favor of ip intel ones

### DIFF
--- a/docs/traffic-policy/variables/connection.mdx
+++ b/docs/traffic-policy/variables/connection.mdx
@@ -2,10 +2,8 @@
 title: Connection Variables
 ---
 
-import ConnGeoVariables from "/traffic-policy/variables/conn.geo.mdx";
 import ConnVariables from "/traffic-policy/variables/conn.mdx";
 import ConnTlsVariables from "/traffic-policy/variables/conn.tls.mdx";
 
 <ConnVariables />
-<ConnGeoVariables />
 <ConnTlsVariables />


### PR DESCRIPTION
These are 'deprecated' in favor of the more comprehensive ip intel variables added