### PR TITLE
Potentially fix integrations pages

### DIFF
--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -22,7 +22,7 @@ export default function IntegrationPageList({ name }: Props) {
 						title={
 							doc.frontMatter?.title ||
 							doc.contentTitle ||
-							doc.frontmatter?.name ||
+							doc.frontMatter?.name ||
 							"Integration"
 						}
 						description={doc.frontMatter?.description || doc.excerpt}

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -22,7 +22,6 @@ export default function IntegrationPageList({ name }: Props) {
 						title={
 							doc.frontMatter?.title ||
 							doc.contentTitle ||
-							doc.frontMatter?.name ||
 							"Integration"
 						}
 						description={doc.frontMatter?.description || doc.excerpt}

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -19,11 +19,7 @@ export default function IntegrationPageList({ name }: Props) {
 					<NgrokCard
 						to={doc.path}
 						size="sm"
-						title={
-							doc.frontMatter?.title ||
-							doc.contentTitle ||
-							"Integration"
-						}
+						title={doc.frontMatter?.title || doc.contentTitle || "Integration"}
 						description={doc.frontMatter?.description || doc.excerpt}
 					/>
 				</li>

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -19,7 +19,7 @@ export default function IntegrationPageList({ name }: Props) {
 					<NgrokCard
 						to={doc.path}
 						size="sm"
-						title={doc.frontMatter?.title || doc.contentTitle}
+						title={doc.frontMatter?.title || doc.contentTitle || doc.frontmatter?.name || "Integration"}
 						description={doc.frontMatter?.description || doc.excerpt}
 					/>
 				</li>

--- a/src/components/IntegrationPageList.tsx
+++ b/src/components/IntegrationPageList.tsx
@@ -19,7 +19,12 @@ export default function IntegrationPageList({ name }: Props) {
 					<NgrokCard
 						to={doc.path}
 						size="sm"
-						title={doc.frontMatter?.title || doc.contentTitle || doc.frontmatter?.name || "Integration"}
+						title={
+							doc.frontMatter?.title ||
+							doc.contentTitle ||
+							doc.frontmatter?.name ||
+							"Integration"
+						}
 						description={doc.frontMatter?.description || doc.excerpt}
 					/>
 				</li>

--- a/src/components/integrations/schema.ts
+++ b/src/components/integrations/schema.ts
@@ -9,7 +9,7 @@ const docFrontMatterSchema = z.object({
 
 const integrationDocSchema = z.object({
 	content: z.string().trim().min(1),
-	contentTitle: z.string().trim().min(1),
+	contentTitle: z.string().trim().min(1).optional(),
 	excerpt: z.string().trim().min(1).optional(),
 	frontMatter: docFrontMatterSchema.optional(),
 	path: z.string().trim().min(1),


### PR DESCRIPTION
I noticed earlier today that all the integrations pages are broken—the [integrations hub](https://ngrok.com/docs/integrations/) is empty, as are the individual hubs for each provider.

Error I'm seeing on any integrations page:

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      11,
      "docs",
      0,
      "contentTitle"
    ],
    "message": "Required"
  }
]
```

I poked around a bit and figured that error was getting thrown because not every integrations guide explicitly has a `title:` in the frontmatter, and this Zod dude doesn't like an undefined required string. Making `contentTitle` optional _seems_ to fix the error and restore the integrations hubs... but at what cost?