### PR TITLE
Fix self-referential "next" links

### DIFF
--- a/docs/obs/index.mdx
+++ b/docs/obs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+pagination_next: obs/traffic-inspection
 ---
 
 # Traffic Observability

--- a/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
@@ -1,6 +1,7 @@
 ---
 title: Getting Started with Agent Endpoints and Traffic Policy via CLI Flags
 sidebar_label: via CLI Flags
+pagination_next: traffic-policy/getting-started/agent-endpoints/config-file
 ---
 
 import { GettingStarted } from "/traffic-policy/getting-started/GettingStarted";

--- a/docs/traffic-policy/index.mdx
+++ b/docs/traffic-policy/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+pagination_next: traffic-policy/getting-started/agent-endpoints/cli
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/universal-gateway/overview.mdx
+++ b/docs/universal-gateway/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+pagination_next: universal-gateway/domains
 ---
 
 # Universal Gateway


### PR DESCRIPTION
The next/previous article links at the bottoms of the top-level "Overview" pages link to themselves.

This is because these overview pages are both the top-level link for the section (For example, click on Universal Gateway in the nav and it takes you to the overview), but we also list them as sub-pages under the section. That means, technically, the next item in the list after the top-level overview page _is_ the overview page.

```
{
  label: "Universal Gateway",
  link: { type: "doc", id: "universal-gateway/overview" },
  items: [
    "universal-gateway/overview",
    ...
  ]
}
```

We might be able to swizzle the sidebar component to address this, but for now we can manually use `pagination_next` in the frontmatter to fix this