### PR TITLE
Docs: Clarify that automatically provisioned cert private key material is inaccessible

### DIFF
--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -157,8 +157,8 @@ card while the certificate is provisioning:
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are 
-not accessible to the requester. This ensures the security and integrity of the certificate by preventing 
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are
+not accessible to the requester. This ensures the security and integrity of the certificate by preventing
 key exposure.
 
 :::

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -157,7 +157,9 @@ card while the certificate is provisioning:
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are not accessible to the requester. This ensures the security and integrity of the certificate by preventing key exposure.
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are 
+not accessible to the requester. This ensures the security and integrity of the certificate by preventing 
+key exposure.
 
 :::
 

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -155,6 +155,14 @@ card while the certificate is provisioning:
 
 ![](/img/docs/certificate-provisioning-delayed.png)
 
+:::note
+
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their 
+private keys are not accessible to users. This ensures the security and integrity of the 
+certificate by preventing key exposure.
+
+:::
+
 ## Why customize the ingress address?
 
 ### Branded Connectivity

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -157,9 +157,7 @@ card while the certificate is provisioning:
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their
-private keys are not accessible to the requester. This ensures the security and integrity
-of the certificate by preventing key exposure.
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are not accessible to the requester. This ensures the security and integrity of the certificate by preventing key exposure.
 
 :::
 

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -157,8 +157,8 @@ card while the certificate is provisioning:
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their 
-private keys are not accessible to the requester. This ensures the security and integrity 
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their
+private keys are not accessible to the requester. This ensures the security and integrity
 of the certificate by preventing key exposure.
 
 :::

--- a/docs/agent/ingress.mdx
+++ b/docs/agent/ingress.mdx
@@ -158,8 +158,8 @@ card while the certificate is provisioning:
 :::note
 
 Certificates automatically provisioned from Let's Encrypt are securely managed, and their 
-private keys are not accessible to users. This ensures the security and integrity of the 
-certificate by preventing key exposure.
+private keys are not accessible to the requester. This ensures the security and integrity 
+of the certificate by preventing key exposure.
 
 :::
 

--- a/docs/guides/other-guides/securing-your-tunnels.mdx
+++ b/docs/guides/other-guides/securing-your-tunnels.mdx
@@ -30,9 +30,7 @@ For custom domains, use ngrok's [Automated TLS certificates](/universal-gateway/
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their
-private keys are not accessible to the requester. This ensures the security and integrity
-of the certificate by preventing key exposure.
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their private keys are not accessible to the requester. This ensures the security and integrity of the certificate by preventing key exposure.
 
 :::
 

--- a/docs/guides/other-guides/securing-your-tunnels.mdx
+++ b/docs/guides/other-guides/securing-your-tunnels.mdx
@@ -30,8 +30,8 @@ For custom domains, use ngrok's [Automated TLS certificates](/universal-gateway/
 
 :::note
 
-Certificates automatically provisioned from Let's Encrypt are securely managed, and their 
-private keys are not accessible to the requester. This ensures the security and integrity 
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their
+private keys are not accessible to the requester. This ensures the security and integrity
 of the certificate by preventing key exposure.
 
 :::

--- a/docs/guides/other-guides/securing-your-tunnels.mdx
+++ b/docs/guides/other-guides/securing-your-tunnels.mdx
@@ -28,6 +28,14 @@ If your local service is not running on the same machine as the ngrok agent, we 
 
 For custom domains, use ngrok's [Automated TLS certificates](/universal-gateway/tls-certificates/#automated) to have ngrok automatically provision a TLS certificate for your endpoint from Let's Encrypt.
 
+:::note
+
+Certificates automatically provisioned from Let's Encrypt are securely managed, and their 
+private keys are not accessible to the requester. This ensures the security and integrity 
+of the certificate by preventing key exposure.
+
+:::
+
 ### Using a custom ingress domain
 
 If your organization uses a custom ingress domain, your default ngrok configuration will not work. Edit your ngrok agent configuration to add a [`connect_url`](/agent/config/v3/#connect_url) parameter to use the custom ingress domain of your organization.


### PR DESCRIPTION
Clarifies documentation to state that private key material from automatically provisioned certs is unavailable