### PR TITLE
Fix for self-ref next link (SSO)

### DIFF
--- a/docs/iam/sso.mdx
+++ b/docs/iam/sso.mdx
@@ -1,3 +1,7 @@
+---
+pagination_next: iam/rbac
+---
+
 # Single Sign-On
 
 ## Overview


### PR DESCRIPTION
Fix for self-referential 'Next' button in footer.

Fixes: https://ngrok.com/docs/iam/sso/