### PR TITLE
Add fix to multicloud API gateway guide routing

### DIFF
--- a/docs/guides/api-gateway/multicloud.mdx
+++ b/docs/guides/api-gateway/multicloud.mdx
@@ -339,7 +339,7 @@ headers.
     			actions:
     				- type: forward-internal
     					config:
-    						url: https://xyz.cloud-b.internal
+    						url: https://xyz-cloud-b.internal
     	```
 
     	Hit **Save** to lock in the new policy.
@@ -365,7 +365,7 @@ headers.
     			actions:
     				- type: forward-internal
     					config:
-    						url: https://xyz.cloud-b.internal
+    						url: https://xyz-cloud-b.internal
     	```
 
     	Update your cloud endpoint.


### PR DESCRIPTION
Just a small fix that didn't get translated into the doc after building/testing this locally.