### PR TITLE
Docs update for aud claim optionality in jwt-validation actions

### DIFF
--- a/traffic-policy/actions/jwt-validation/behavior.mdx
+++ b/traffic-policy/actions/jwt-validation/behavior.mdx
@@ -23,9 +23,9 @@ any trailing slashes (`/`) present in the `iss` claim.
 
 ### Multiple Audience Claims
 
-You can specify multiple audience claims for JWT validation.
+You can optionally specify one or more audience (`aud`) claims for JWT validation.
 
-The JWT **must** contain at least one of the specified audience claims and
+If present, the `aud` claim **must** contain at least one of the specified audience claims and
 exactly match for validation to succeed.
 
 ### Multiple Signing Keys

--- a/traffic-policy/actions/jwt-validation/config.mdx
+++ b/traffic-policy/actions/jwt-validation/config.mdx
@@ -36,13 +36,13 @@ reference for this action.
         </ConfigChildren>
     </ConfigItem>
 
-    <ConfigItem title="audience" type="object" required={true}>
+    <ConfigItem title="audience" type="object" required={false}>
         <p>Configuration object for the Audience(s) of the JWTs.</p>
         <ConfigChildren>
-            <ConfigItem title="allow_list" type="array of objects" required={true}>
+            <ConfigItem title="allow_list" type="array of objects" required={false}>
                 <p>List of allowed audiences. Minimum `1`.</p>
                 <ConfigChildren>
-                    <ConfigItem title="allow_list[*].value" type="string" required={true}>
+                    <ConfigItem title="allow_list[*].value" type="string" required={false}>
                         <p>Audience claim value. This can be found in the <code>aud</code> claim after decoding the JWT or from the request used to create the token in the first place.</p>
                     </ConfigItem>
                 </ConfigChildren>


### PR DESCRIPTION
`aud` is required for `oauth2` and `openid` actions, but not for unspecified JWT usage