### PR TITLE
[WIP] Update integration guides to use new Operator features

### DIFF
--- a/docs/integrations/vcluster/k8s.md
+++ b/docs/integrations/vcluster/k8s.md
@@ -102,43 +102,11 @@ If you don't have a cluster already, create one locally with minikube and instal
 
 ## **Step 2**: Install the ngrok Kubernetes Operator {#install-the-ngrok-ingress-controller}
 
-Now that you have a Kubernetes cluster integrated with vcluster, you can install the [ngrok Kubernetes Ingress
-Controller](https://github.com/ngrok/ngrok-operator) to provide ingress to any services you want to run
-on your virtual cluster.
+Now that you have a Kubernetes cluster integrated with vcluster, you can install
+the ngrok Kubernetes Operator to get traffic to your Kubernetes workloads.
 
-1. Add the ngrok Helm repository if you haven't already.
-
-   ```bash
-   helm repo add ngrok https://charts.ngrok.com
-   ```
-
-1. Set up the `AUTHTOKEN` and `API_KEY` exports, which allows Helm to install the Operator using your ngrok credentials. Find your `AUTHTOKEN` under [**Your Authtoken**](https://dashboard.ngrok.com/get-started/your-authtoken) in the ngrok dashboard.
-
-   To create a new API key, navigate to the [**API** section](https://dashboard.ngrok.com/api) of the ngrok dashboard, click the **New API Key** button, change the description or owner, and click the **Add API Key** button. Copy the API key token shown in the modal window before closing it, as the ngrok dashboard will not show you the token again.
-
-   ```bash
-   export NGROK_AUTHTOKEN=[YOUR-AUTHTOKEN]
-   export NGROK_API_KEY=[YOUR-API-KEY]
-   ```
-
-1. Install the ngrok Kubernetes Operator with Helm under a new `ngrok-ingress-controller` namespace.
-
-   ```bash
-   helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
-     --namespace ngrok-ingress-controller \
-     --create-namespace \
-     --set credentials.apiKey=$NGROK_API_KEY \
-     --set credentials.authtoken=$NGROK_AUTHTOKEN
-   ```
-
-1. Verify you have installed the ngrok Kubernetes Operator successfully and that pods are healthy.
-
-   ```bash
-   kubectl get pods -l 'app.kubernetes.io/name=kubernetes-ingress-controller' --namespace ngrok-ingress-controller
-
-   NAME                                                              READY   STATUS    RESTARTS   AGE
-   ngrok-ingress-controller-kubernetes-ingress-controller-man2fg5p   1/1     Running   0          2m23s
-   ```
+Check out our [Operator installation doc](/docs/k8s/installation/install/) for
+details on how to use Helm to install with your ngrok credentials.
 
 ## **Step 3**: Install a sample application {#install-a-sample-application}
 
@@ -146,28 +114,23 @@ At this point, you have a functional vcluster with the ngrok Kubernetes Operator
 ngrok credentials. To demonstrate how the Operator simplifies routing external traffic to your primary
 cluster, virtual cluster, and ultimately an exposed service or endpoint, you can install a sample application.
 
-1. Create a ngrok static subdomain for ingress if you don't have one already. Navigate to the [**Domains**
+1. Reserve a domain for ingress if you don't have one already. Navigate to the [**Domains**
    section](https://dashboard.ngrok.com/domains) of the ngrok dashboard and click **Create Domain** or **New
-   Domain**. This static subdomain will be your `NGROK_DOMAIN` for the remainder of this guide.
+   Domain**. We'll refer to this as `<NGROK_DOMAIN>` for the remainder of this guide.
 
    By creating a subdomain on the ngrok network, you provide a public route to accept HTTP, HTTPS, and TLS traffic.
 
 1. Create a new Kubernetes manifest (`2048.yaml`) with the below contents. This manifest defines the 2048 application
    service and deployment, then configures the ngrok Kubernetes Operator to connect the `game-2048` service to the ngrok
-   edge via your `NGROK_DOMAIN`.
+   network. Be sure to replace `<NGROK_DOMAIN>` with the domain you reserved a
+	 moment ago.
 
-   :::tip
-
-   Make sure you edit line 45 of the manifest below, which contains the `NGROK_DOMAIN` variable, with the ngrok subdomain you created in the previous step. It should look something like `one-two-three.ngrok.app`.
-
-   :::
-
-   ```yaml showLineNumbers
+   ```yaml 
    apiVersion: v1
    kind: Service
    metadata:
      name: game-2048
-     namespace: ngrok-ingress-controller
+     namespace: default
    spec:
      ports:
        - name: http
@@ -180,7 +143,7 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    kind: Deployment
    metadata:
      name: game-2048
-     namespace: ngrok-ingress-controller
+     namespace: default
    spec:
      replicas: 1
      selector:
@@ -203,13 +166,11 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    kind: Ingress
    metadata:
      name: game-2048-ingress
-     namespace: ngrok-ingress-controller
+     namespace: default
    spec:
      ingressClassName: ngrok
      rules:
-       # highlight-start
-       - host: NGROK_DOMAIN
-         # highlight-end
+       - host: <NGROK_DOMAIN>
          http:
            paths:
              - path: /
@@ -234,23 +195,6 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
 
    :::
 
-1. Confirm your vcluster successfully deployed your 2048 application by navigating to the [**Edges**
-   section](https://dashboard.ngrok.com/edges) in the ngrok dashboard.
-
-   An edge connects your 2048 application, running in your vcluster, to the rest of the world through the ngrok Ingress
-   Controller. You should see a new edge configuration created by `kubernetes-ingress-controller` that matches the domain
-   name you entered on L45 of your `2048.yaml` manifest.
-
-   Under the **Backend** section of your edge configuration, you can also see cluster details as annotations, like the
-   namespace and connected service, to validate that your demo application is accessible to external traffic via the
-   Operator.
-
-   !["Looking at existing Edge configurations in the ngrok dashboard"](img/ngrok-k8s-vcluster_edges.png)
-
-   Click on your edge configuration to see additional details and options for advanced ingress needs, like creating
-   multiple tunnels for load balancing, enabling the [Mutual TLS module](/traffic-policy/actions/terminate-tls/), adding
-   compression, and more. We'll use one of these options, OAuth, in the next step.
-
 1. Access your 2048 demo app by navigating to the your domain, e.g. `https://one-two-three.ngrok.app`. ngrok's edge
    and your Operator will route traffic to your app from any device or external network as long as your
    vcluster remains operational.
@@ -262,70 +206,38 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
 Let's take your ingress needs a little further by assuming you want to add edge security, in the form of Google OAuth,
 to the endpoint where your 2048 application is humming along.
 
-By default, ngrok manages OAuth protection entirely at the cloud edge, which means you don't need to add any additional
-services to your cluster, or alter routes, to ensure ngrok's edge authenticates and authorizes all requests before
-allowing ingress and access to your endpoint.
+With our [Traffic Policy system](/docs/traffic-policy/) and the [`oauth`
+action](/docs/traffic-policy/actions/oauth), ngrok manages OAuth protection
+entirely at the cloud edge, which means you don't need to add any
+additional services to your cluster, or alter routes, to ensure ngrok's edge
+authenticates and authorizes all requests before allowing ingress and access to
+your endpoint.
 
-1. Edit your existing `2048.yaml` manifest with the following configuration.
+To enable the `oauth` action, you'll create a new `NgrokTrafficPolicy` custom
+resource and apply it to your entire `Ingress` with an annotation. You can also
+apply the policy to just a specific backend or as the default backend for an
+`Ingress`—see our doc on using the [Operator with
+Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingress).
 
-   :::tip
+1. Edit your existing `2048.yaml` manifest with the following, leaving the
+	 `Service` and `Deployment` as they were. Note the new `annotations` field and
+	 the `NgrokTrafficPolicy` CR.
 
-   - See L42-43 for the additional annotation that this OAuth setup requires.
-   - See L58-69 for the newly added configuration for ngrok's OAuth module, replacing `acme.com` or `ngrok.com` with the domain name for your email address. You can also [configure the OAuth module](https://github.com/ngrok/ngrok-operator/blob/main/docs/user-guide/route-modules.md#ngrok-managed-oauth-application) to authenticate individual email addresses.
-
-   :::
-
-   ```yaml showLineNumbers
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: game-2048
-     namespace: ngrok-ingress-controller
-   spec:
-     ports:
-       - name: http
-         port: 80
-         targetPort: 80
-     selector:
-       app: game-2048
-   ---
-   # Configuration for the 2048 application, service, and deployment
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: game-2048
-     namespace: ngrok-ingress-controller
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: game-2048
-     template:
-       metadata:
-         labels:
-           app: game-2048
-       spec:
-         containers:
-           - name: backend
-             image: alexwhen/docker-2048
-             ports:
-               - name: http
-                 containerPort: 80
+   ```yaml
+	 ...
    ---
    # Configuration for ngrok's Kubernetes Operator
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
      name: game-2048-ingress
-     namespace: ngrok-ingress-controller
-     # highlight-start
+     namespace: default
      annotations:
-       k8s.ngrok.com/modules: oauth
-     # highlight-end
+       k8s.ngrok.com/traffic-policy: oauth
    spec:
      ingressClassName: ngrok
      rules:
-       - host: NGROK_DOMAIN
+       - host: <NGROK_DOMAIN>
          http:
            paths:
              - path: /
@@ -336,20 +248,18 @@ allowing ingress and access to your endpoint.
                    port:
                      number: 80
    ---
-   # highlight-start
-   # Configuration for ngrok's OAuth authentication module
-   kind: NgrokModuleSet
-   apiVersion: ingress.k8s.ngrok.com/v1alpha1
+   # Traffic Policy configuration for OAuth
+   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+   kind: NgrokTrafficPolicy
    metadata:
      name: oauth
-     namespace: ngrok-ingress-controller
-   modules:
-     oauth:
-       google:
-         emailDomains:
-           - acme.com
-           - ngrok.com
-   #highlight-end
+     namespace: default
+   spec:
+     policy:
+		   on_http_request:
+			   - type: oauth
+				   config:
+				     provider: google
    ```
 
 1. Re-apply your `2048.yaml` configuration.
@@ -358,14 +268,40 @@ allowing ingress and access to your endpoint.
    kubectl apply -f 2048.yaml
    ```
 
-1. Visit the [**Edges** section](https://dashboard.ngrok.com/edges/) of the ngrok dashboard, click on the
-   edge for your deployment, then click **OAuth** to confirm the module is using the configuration you added to your
-   `2048.yaml` manifest.
+1. When you open your demo app again, you'll be asked to log in via Google.
+	 That's a start, but what if you want to authenticate only yourself or colleagues?
 
-   ![Verifying the OAuth module configuration in the ngrok dashboard](img/ngrok-k8s-vcluster_oauth-config.png)
+1. You can use [expressions](/docs/traffic-policy/concepts/expressions) and [CEL
+	 interpolation](/docs/traffic-policy/concepts/cel-interpolation) to filter out
+	 and reject OAuth logins that don't contain `example.com`. Update the
+	 `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
+	 your domain.
 
-1. Access your 2048 app at your domain (e.g. `https://one-two-three.ngrok.app`) to verify that it requests
-   authentication via Google OAuth before allowing you to access the 2048 app.
+   ```yaml 
+   ---
+   # Traffic Policy configuration for OAuth
+   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+   kind: NgrokTrafficPolicy
+   metadata:
+     name: oauth
+     namespace: default
+   spec:
+     policy:
+		   on_http_request:
+			   - type: oauth
+				   config:
+				     provider: google
+				 - expressions:
+				     - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+           actions:
+             - type: custom-response
+               config:
+                 content: Hey, no auth for you ${actions.ngrok.oauth.identity.name}!
+                 status_code: 400
+   ```
+
+1. Check out your deployed 2048 app once again. If you log in with an email that
+	 doesn't match your domain, ngrok rejects your request. Authentication... done!
 
 ## What's next?
 
@@ -382,13 +318,9 @@ vcluster disconnect
 vcluster delete my-vcluster
 ```
 
-You can also extend your new vcluster and ngrok Kubernetes Operator with [additional
-modules](https://github.com/ngrok/ngrok-operator/blob/main/docs/user-guide/route-modules.md), a [fanout
-configuration](https://github.com/ngrok/ngrok-operator/blob/main/docs/user-guide/ingress-to-edge-relationship.md#simple-fanout)
-to route traffic to multiple services from a single domain or IP address, or even [multiple Ingress
-Controller](https://github.com/ngrok/ngrok-operator/blob/main/docs/deployment-guide/multiple-installations.md)
-installations running alongside one another.
+For next steps, explore our [Kubernetes docs](/docs/k8s/) for more details on
+how the Operator works, different ways you can integrate ngrok with an existing
+production cluster, or use more advanced features like
+[bindings](docs/k8s/guides/bindings/) or [endpoint
+pooling](/docs/k8s/guides/pooling/).
 
-Learn more about the ngrok Kubernetes Operator, or contribute, by checking out the [GitHub
-repository](https://github.com/ngrok/ngrok-operator) and the [project-specific
-documentation](https://github.com/ngrok/ngrok-operator/tree/main/docs).


### PR DESCRIPTION
Updating these "old" integrations guides alongside #1213. This should only be merged after that, since otherwise we'll have a ton of broken links to docs that only exist in that PR.

The goals:

1. Remove references to `ngrok-ingress-controller`, especially in install instructions
2. Updated existing Ingress/Gateway API configs as needed to make them work with current Operator
3. Remove references to edges and modules in favor of Traffic Policy

Started with vcluster as a POC... a lot of work to go.

- [ ] ArgoCD
- [ ] Amazon EKS
- [ ] Azure AD
- [ ] AKS
- [ ] Consul
- [ ] DigitalOcean
- [ ] GKE
- [ ] Linkerd
- [ ] microk8s
- [ ] Rancher
- [ ] Rafay
- [ ] Spectro Cloud
- [x] vcluster