### PR TITLE
Update K8s endpoint docs

### DIFF
--- a/docs/k8s/crds/boundendpoint.mdx
+++ b/docs/k8s/crds/boundendpoint.mdx
@@ -28,7 +28,7 @@ The ngrok operator includes a container argument `--bindings-endpoint-selectors`
 the cluster that this operator is running in. Unless this is configured, by default all Kubernetes bound endpoints will be projected into the cluster when the bindings feature is enabled.
 
 For more information about Kubernetes bound endpoints, you can reference the [Kubernetes endpoints](/universal-gateway/kubernetes-endpoints) page.
-For a guide on using Kubernetes bound endpoints with the ngrok operator, please see the [bound endpoints guide](/kubernetes/guides/bindings).
+For a guide on using Kubernetes bound endpoints with the ngrok operator, please see the [bound endpoints guide](/k8s/guides/bindings).
 
 ## BoundEndpoint Structure and Types
 

--- a/docs/k8s/crds/domain.mdx
+++ b/docs/k8s/crds/domain.mdx
@@ -12,7 +12,7 @@ Domains define the hostnames that should be reserved for your ngrok endpoints.
 They are automatically created by the controller based on the `Ingress`, `Gateway`, `CloudEndpoint` and `AgentEndpoint` custom resources you create.
 Standard ngrok subdomains will automatically be created and reserved for you.
 Custom domains will also be created and reserved, but will be up to you to configure the DNS records for them.
-See the [custom domain](/kubernetes/guides/custom-domain) guide for more details.
+See the [custom domain](/k8s/guides/custom-domain) guide for more details.
 
 If you delete all the `Ingress`/`Gateway`/`CloudEndpoint`/`AgentEndpoint` objects for a particular host, as a safety precaution, the Operator does _NOT_ delete the domains and thus does not unregister them.
 This ensures you don't lose domains while modifying or recreating ingress objects.

--- a/docs/k8s/installation/install.mdx
+++ b/docs/k8s/installation/install.mdx
@@ -147,6 +147,10 @@ Select one of the below options based on which method you are comfortable with.
 
 The following will help you learn more about the ngrok Kubernetes operator and get started with it.
 
+### Use Endpoint bindings
+
+See [the docs on using Kubernetes Endpoint bindings](/docs/k8s/guides/bindings) to learn how to control how your Kubernetes Endpoints are accessed.
+
 ### Quickstart
 
 Head to the [quickstart guide](/k8s/guides/quickstart) to get started with an example deployment.

--- a/docs/universal-gateway/kubernetes-endpoints.mdx
+++ b/docs/universal-gateway/kubernetes-endpoints.mdx
@@ -143,7 +143,7 @@ spec:
   externalName: <endpoint-id>.ngrok-operator.svc.cluster.local
 ```
 
-## Endpoint Selector
+## How do I update endpoint selectors?
 
 If you don't want all kubernetes endpoints in your account to appear inside of
 a cluster, you may specify an Endpoint Selector which filters which Kubernetes
@@ -152,12 +152,7 @@ CEL expression which is evaluated against each Kubernetes Endpoint in your
 account. The operator will only projects endpoints that the selector returns
 `true` for.
 
-For example, to only project kubernetes endpoints in the billing namespace, you would
-add the following flag when installing the Kubernetes Operator:
-
-```bash
-  --set binding.endpointSelector="ep.hostname.endsWith('.billing')" \
-```
+See [the docs on enabling bindings](/docs/k8s/guides/bindings/#enable-bindings-for-the-operator) to learn more.
 
 ## Coming Soon
 

--- a/docs/universal-gateway/kubernetes-endpoints.mdx
+++ b/docs/universal-gateway/kubernetes-endpoints.mdx
@@ -154,6 +154,12 @@ account. The operator will only projects endpoints that the selector returns
 
 See [the docs on enabling bindings](/docs/k8s/guides/bindings/#enable-bindings-for-the-operator) to learn more.
 
+## How do I enable or disable Kubernetes endpoints on an existing installation?
+
+By default, if you don't change the default endpoint selector, all endpoints with a Kubernetes binding will be bound to the cluster the Operator is installed on. Changing the binding allows you to restrict which endpoints that operator will handle.
+
+See [the docs on enabling bindings](/docs/k8s/guides/bindings/#enable-bindings-for-the-operator) to learn more.
+
 ## Coming Soon
 
 This feature is in developer preview, more documentation is coming soon.


### PR DESCRIPTION
- Fixes a couple broken links
- Adds more info to [the Kubernetes Endpoints page](https://ngrok-docs-git-shaquil-doc-227-update-k8s-docs-ngrok-dev.vercel.app/docs/universal-gateway/kubernetes-endpoints/#how-do-i-update-endpoint-selectors)

[Preview](https://ngrok-docs-git-shaquil-doc-227-update-k8s-docs-ngrok-dev.vercel.app/docs/universal-gateway/kubernetes-endpoints/#how-do-i-update-endpoint-selectors)