### PR TITLE
Fix lang switcher layout shift

### DIFF
--- a/src/components/ConfigExample.tsx
+++ b/src/components/ConfigExample.tsx
@@ -106,9 +106,15 @@ export default function ConfigExample({
 		agentConfig.yamlConfig,
 		agentConfig.jsonConfig,
 	);
-	if (!components.h3) return <p>Error rendering config example.</p>;
+	if (hideAgentConfig && hideTrafficPolicy)
+		throw new Error(
+			"At least one of hideAgentConfig or hideTrafficPolicy must be false",
+		);
 	return (
-		<Tabs orientation="horizontal" defaultValue="traffic-policy">
+		<Tabs
+			orientation="horizontal"
+			defaultValue={hideTrafficPolicy ? "agent-config" : "traffic-policy"}
+		>
 			<TabsList>
 				{hideTrafficPolicy ? null : (
 					<TabsTrigger value="traffic-policy">Traffic Policy</TabsTrigger>

--- a/src/components/ConfigExample.tsx
+++ b/src/components/ConfigExample.tsx
@@ -1,3 +1,4 @@
+import { useMDXComponents } from "@mdx-js/react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ngrok/mantle/tabs";
 import { type ReactNode } from "react";
 import YAML, { type ToStringOptions } from "yaml";
@@ -69,14 +70,16 @@ export type ConfigExampleProps = {
 	jsonMetastring?: string;
 	title?: string;
 	icon?: ReactNode;
-	showAgentConfig?: boolean;
+	hideAgentConfig?: boolean;
 };
 
 export default function ConfigExample({
 	// Show the agent config by default
-	showAgentConfig = true,
+	hideAgentConfig = false,
 	...props
 }: ConfigExampleProps) {
+	const components = useMDXComponents();
+
 	const yamlOptions = {
 		indent: 2,
 		directives: true,
@@ -101,14 +104,19 @@ export default function ConfigExample({
 		agentConfig.yamlConfig,
 		agentConfig.jsonConfig,
 	);
+	if (!components.h3) return <p>Error rendering config example.</p>;
 	return (
 		<Tabs orientation="horizontal" defaultValue="traffic-policy">
 			<TabsList>
 				<TabsTrigger value="traffic-policy">Traffic Policy</TabsTrigger>
-				<TabsTrigger value="agent-config">Agent Config</TabsTrigger>
+				{hideAgentConfig ? null : (
+					<TabsTrigger value="agent-config">Agent Config</TabsTrigger>
+				)}
 			</TabsList>
 			<TabsContent value="traffic-policy">{policySnippet}</TabsContent>
-			<TabsContent value="agent-config">{agentConfigSnippet}</TabsContent>
+			{hideAgentConfig ? null : (
+				<TabsContent value="agent-config">{agentConfigSnippet}</TabsContent>
+			)}
 		</Tabs>
 	);
 }

--- a/src/components/ConfigExample.tsx
+++ b/src/components/ConfigExample.tsx
@@ -1,4 +1,3 @@
-import { useMDXComponents } from "@mdx-js/react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ngrok/mantle/tabs";
 import { type ReactNode } from "react";
 import YAML, { type ToStringOptions } from "yaml";
@@ -78,8 +77,6 @@ export default function ConfigExample({
 	showAgentConfig = true,
 	...props
 }: ConfigExampleProps) {
-	const components = useMDXComponents();
-
 	const yamlOptions = {
 		indent: 2,
 		directives: true,
@@ -104,7 +101,6 @@ export default function ConfigExample({
 		agentConfig.yamlConfig,
 		agentConfig.jsonConfig,
 	);
-	if (!components.h3) return <p>Error rendering config example.</p>;
 	return (
 		<Tabs orientation="horizontal" defaultValue="traffic-policy">
 			<TabsList>

--- a/src/components/ConfigExample.tsx
+++ b/src/components/ConfigExample.tsx
@@ -71,11 +71,13 @@ export type ConfigExampleProps = {
 	title?: string;
 	icon?: ReactNode;
 	hideAgentConfig?: boolean;
+	hideTrafficPolicy?: boolean;
 };
 
 export default function ConfigExample({
 	// Show the agent config by default
 	hideAgentConfig = false,
+	hideTrafficPolicy = false,
 	...props
 }: ConfigExampleProps) {
 	const components = useMDXComponents();
@@ -108,12 +110,16 @@ export default function ConfigExample({
 	return (
 		<Tabs orientation="horizontal" defaultValue="traffic-policy">
 			<TabsList>
-				<TabsTrigger value="traffic-policy">Traffic Policy</TabsTrigger>
+				{hideTrafficPolicy ? null : (
+					<TabsTrigger value="traffic-policy">Traffic Policy</TabsTrigger>
+				)}
 				{hideAgentConfig ? null : (
 					<TabsTrigger value="agent-config">Agent Config</TabsTrigger>
 				)}
 			</TabsList>
-			<TabsContent value="traffic-policy">{policySnippet}</TabsContent>
+			{hideTrafficPolicy ? null : (
+				<TabsContent value="traffic-policy">{policySnippet}</TabsContent>
+			)}
 			{hideAgentConfig ? null : (
 				<TabsContent value="agent-config">{agentConfigSnippet}</TabsContent>
 			)}

--- a/src/components/ConfigExample.tsx
+++ b/src/components/ConfigExample.tsx
@@ -1,4 +1,3 @@
-import { useMDXComponents } from "@mdx-js/react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ngrok/mantle/tabs";
 import { type ReactNode } from "react";
 import YAML, { type ToStringOptions } from "yaml";
@@ -80,8 +79,6 @@ export default function ConfigExample({
 	hideTrafficPolicy = false,
 	...props
 }: ConfigExampleProps) {
-	const components = useMDXComponents();
-
 	const yamlOptions = {
 		indent: 2,
 		directives: true,

--- a/src/components/LangSwitcher/index.tsx
+++ b/src/components/LangSwitcher/index.tsx
@@ -41,7 +41,7 @@ export function LangSwitcher({ children, className, ...props }: any) {
 	// This also needs to be updated to use the right codeblock data, not [0]
 	const { meta } = matchingBlock;
 	const collapsible =
-		meta.collapsible && matchingBlock.content.split("\n").length > 20;
+		meta.collapsible && matchingBlock.content.split("\n").length > 10;
 
 	return (
 		<BrowserOnly

--- a/src/components/LangSwitcher/utils.ts
+++ b/src/components/LangSwitcher/utils.ts
@@ -1,7 +1,7 @@
 import { parseLanguage, parseMetastring } from "@ngrok/mantle/code-block";
 
 export const getCodeBlocks = (children: any) => {
-	return children.map((child: any) => {
+	return children.map((child: any, index: number) => {
 		const { className, metastring, children, language } =
 			child.props.children.props ?? child.props;
 		const parsedLanguage = language || parseLanguage(className);
@@ -10,8 +10,13 @@ export const getCodeBlocks = (children: any) => {
 		return {
 			language: parsedLanguage,
 			content: children,
-			meta,
+			meta: {
+				...meta,
+				// Make it collapsible by default
+				collapsible: true,
+			},
 			title,
+			childIndex: index,
 		};
 	});
 };


### PR DESCRIPTION
There are pages with lots of `<LangSwitcher>` components, like [this page](https://ngrok.com/docs/traffic-policy/actions/restrict-ips/#restricting-access-with-allow-and-deny-lists), which uses a ton of `<ConfigExample>`s, which use `<LangSwitcher>` under the hood. These pages experience layout shift because when you change the language on one block, it changes the language on all the blocks, which cumulatively changes the size of the page drastically.

This makes code blocks in the langswitcher collapsible by default, with a shorter height than standard code blocks, to reduce overall layout shift. There's probably a better solution but this is good for now.

## Note

This also adds the ability to hide the agent config or traffic policy tabs from the `<ConfigExample>` component