### PR TITLE
Adding TCP endpoint limits for free tier on main pricing page within …

### DIFF
--- a/docs/pricing-limits/index.mdx
+++ b/docs/pricing-limits/index.mdx
@@ -17,6 +17,7 @@ For information on free plans, see [Free Plan Limts](/pricing-limits/free-plan-l
 | **Domains**                                   | 1 static domain     | 1 per license                                 | No limit, priced on-demand                                        |
 | **Endpoints**                                 | 3                   | 3 per license                                 | No limit, priced on-demand                                        |
 | **Cloud Endpoints**                           | 3                   | NA                                            | No limit, priced on-demand                                        |
+| **TCP Endpoints**                             | 3 per agent session | 1 per TCP address                             | No limit, priced on-demand                                        |  
 | **TCP Addresses**                             | 1 with verification | 1 per license                                 | Priced on-demand, platform limit of 100. Contact us to increase.  |
 | **Endpoint Hours**                            | No limit            | No limit                                      | No limit, can be priced on-demand, contact us                     |
 | **Traffic Policy Rules per Policy**           | 5                   | 15                                            | 15 on the Basic plan, 25 for Advanced, and over 25 for Enterprise |


### PR DESCRIPTION
[](https://linear.app/ngrok/issue/DOC-63/update-tcp-addresses-available-on-free-tier)

The pricing table didnt include active tcp endpoint limits on free tier, just specified number of reservable addresses, 

Tested this, you can start up to 3 tcp endpoints with a randomly assigned URL