### PR TITLE
Adds example of custom-response for internal endpoint downtime

### DIFF
--- a/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
+++ b/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
@@ -8,7 +8,7 @@ configuration demonstrates how to use the `custom-response` action to redirect t
 #### Example Traffic Policy Document
 
 <ConfigExample
-  hideAgentConfig
+	hideAgentConfig
 	config={{
 		on_http_request: [
 			{

--- a/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
+++ b/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
@@ -1,0 +1,35 @@
+import ConfigExample from "/src/components/ConfigExample.tsx";
+
+### Custom Response for Internal Endpoint Downtime
+
+The following [Traffic Policy](/docs/traffic-policy/)
+configuration demonstrates how to use the `custom-response` action to redirect to a URL if an internal endpoint is returning an error.
+
+#### Example Traffic Policy Document
+
+<ConfigExample
+	config={{
+		on_http_request: [
+			{
+				actions: [
+					{
+						type: "forward-internal",
+						config: {
+							url: "https://endpoint-1.internal",
+							on_error: "continue",
+						},
+					},
+					{
+						type: "custom-response",
+						config: {
+							status_code: 302,
+							headers: {
+								location: "https://www.example.com",
+							},
+						},
+					},
+				],
+			},
+		],
+	}}
+/>

--- a/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
+++ b/traffic-policy/actions/custom-response/examples/http-upstream-maintenance-page.mdx
@@ -8,6 +8,7 @@ configuration demonstrates how to use the `custom-response` action to redirect t
 #### Example Traffic Policy Document
 
 <ConfigExample
+  hideAgentConfig
 	config={{
 		on_http_request: [
 			{

--- a/traffic-policy/actions/custom-response/examples/index.mdx
+++ b/traffic-policy/actions/custom-response/examples/index.mdx
@@ -1,9 +1,11 @@
 import ExampleHtmlMaintenancePage from "./http-html-maintenance-page.mdx";
 import ExampleJsonSingleInterpolation from "./http-json-single-interpolation.mdx";
 import ExamplePlainTextMultipleInterpolation from "./http-plain-text-multiple-interpolation.mdx";
+import ExampleUpstreamMaintenancePage from "./http-upstream-maintenance-page.mdx";
 
 ## Examples
 
 <ExampleHtmlMaintenancePage />
+<ExampleUpstreamMaintenancePage />
 <ExampleJsonSingleInterpolation />
 <ExamplePlainTextMultipleInterpolation />


### PR DESCRIPTION
Preview: https://ngrok-docs-git-jen-add-example-ngrok-dev.vercel.app/docs/traffic-policy/actions/custom-response/#custom-response-for-internal-endpoint-downtime