### PR TITLE
Convert codeblock spaces to tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "client": "link:@docusaurus/plugin-content-docs/client",
     "clsx": "2.1.1",
     "concurrently": "9.1.2",
+    "convert-to-spaces": "^2.0.1",
     "cross-env": "7.0.3",
     "dotenv": "16.4.7",
     "internal": "link:@docusaurus/theme-common/internal",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       concurrently:
         specifier: 9.1.2
         version: 9.1.2
+      convert-to-spaces:
+        specifier: ^2.0.1
+        version: 2.0.1
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -2915,6 +2918,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -11040,6 +11047,8 @@ snapshots:
   convert-source-map@1.5.1: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.6: {}
 

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -13,6 +13,7 @@ import {
 	parseMetastring,
 } from "@ngrok/mantle/code-block";
 import type { WithStyleProps } from "@ngrok/mantle/types";
+import convertToSpaces from "convert-to-spaces";
 import type { ComponentProps, ReactNode } from "react";
 
 type Props = WithStyleProps & {
@@ -72,6 +73,8 @@ function DocsCodeBlock({
 
 	const collapsible = meta.collapsible && children.split("\n").length > 20;
 
+	const codeblockContent = convertToSpaces(fmtCode`${children}`);
+
 	return (
 		<CodeBlock className={className} {...props}>
 			{hasHeader && (
@@ -82,7 +85,7 @@ function DocsCodeBlock({
 			)}
 			<CodeBlockBody>
 				{!meta.disableCopy && <CodeBlockCopyButton />}
-				<CodeBlockCode language={language} value={fmtCode`${children}`} />
+				<CodeBlockCode language={language} value={codeblockContent} />
 				{collapsible && <CodeBlockExpanderButton />}
 			</CodeBlockBody>
 		</CodeBlock>


### PR DESCRIPTION
Uses tabs instead of spaces in our code snippets, which should make indentation more consistent and prevent issues with using tools that don't expect tabs in YAML.

See [this linear](https://linear.app/ngrok/issue/EPD-629/code-blocks-in-docs-contain-tabs-for-indentation-which-dont-work-with) issue for more info.

## Test steps

If you want to test this, you can ensure that code snippets in this PR's preview are rendering the exact same as those in prod, as swapping from tabs to spaces should cause no issues there. Some examples:
- K8s docs
  - [This PR](https://ngrok-docs-git-shaquil-doc-232-convert-tabs-to-87a271-ngrok-dev.vercel.app/docs/k8s/guides/how-to/rate-limiting/?kind=gateway-api#rate-limiting-examples)
  - [Prod](https://ngrok.com/docs/k8s/guides/how-to/rate-limiting/?kind=gateway-api#rate-limiting-examples)
- Traffic Policy examples
  - [This PR](https://ngrok-docs-git-shaquil-doc-232-convert-tabs-to-87a271-ngrok-dev.vercel.app/docs/traffic-policy/examples/add-and-remove-headers/#enrich-your-upstream-service)
  - [Prod](https://ngrok.com/docs/traffic-policy/examples/add-and-remove-headers/#enrich-your-upstream-service)