### PR TITLE
Add ja4 fingerprint to traffic policy docs

### DIFF
--- a/traffic-policy/variables/conn.tls.mdx
+++ b/traffic-policy/variables/conn.tls.mdx
@@ -7,6 +7,7 @@ The following variables are available under the `conn.tls` namespace:
 | Name                                                  | Type     | Description                                                                                                    |
 | ----------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | [`conn.tls.cipher_suite`](#conntlscipher_suite)       | `string` | The cipher suite selected during the TLS handshake.                                                            |
+| [`conn.tls.ja4_fingerprint`](#conntlsja4_fingerprint) | `string` | The JA4 fingerprint of the TLS handshake.                                                                      |
 | [`conn.tls.negotiated_alpn`](#conntlsnegotiated_alpn) | `string` | TLS Application-Layer Protocol Negotiation (ALPN) Protocol ID of the protocol agreed upon in the TLS handshake |
 | [`conn.tls.session_resumed`](#conntlssession_resumed) | `bool`   | True if the TLS session was resumed. Currently always false                                                    |
 | [`conn.tls.sni`](#conntlssni)                         | `string` | The hostname included in the `ClientHello` message via the SNI extension.                                      |
@@ -19,6 +20,16 @@ The cipher suite selected during the TLS handshake.
 <ConfigExample
 	config={{
 		expressions: ["conn.tls.cipher_suite == 'TLS_AES_128_GCM_SHA256'"],
+	}}
+/>
+
+### `conn.tls.ja4_fingerprint`
+
+The JA4 fingerprint of the TLS handshake.
+
+<ConfigExample
+	config={{
+		expressions: ["conn.tls.ja4_fingerprint == 't13d1717h2_5b57614c22b0_f0fc7018f8e8'"],
 	}}
 />
 

--- a/traffic-policy/variables/conn.tls.mdx
+++ b/traffic-policy/variables/conn.tls.mdx
@@ -29,7 +29,9 @@ The JA4 fingerprint of the TLS handshake.
 
 <ConfigExample
 	config={{
-		expressions: ["conn.tls.ja4_fingerprint == 't13d1717h2_5b57614c22b0_f0fc7018f8e8'"],
+		expressions: [
+			"conn.tls.ja4_fingerprint == 't13d1717h2_5b57614c22b0_f0fc7018f8e8'",
+		],
 	}}
 />
 


### PR DESCRIPTION
A companion to https://github.com/ngrok-private/ngrok/pull/36488

This change adds "JA4 fingerprint" as one of the "vars" available for use in the Traffic Policy.