### PR TITLE
update: edges sunset date

### DIFF
--- a/docs/universal-gateway/edges.mdx
+++ b/docs/universal-gateway/edges.mdx
@@ -3,15 +3,12 @@
 ## Deprecation
 
 ::::warning
-Edges, Routes, Modules, Backends and Labeled Tunnels are deprecated. See the [Migration Guide](#migration-guide).
+Edges, Routes, Modules, Backends and Labeled Tunnels are deprecated and will be sunset on December 31st, 2025. See the [Migration Guide](#migration-guide).
 ::::
 
 ### Sunset Date
 
-There is no planned date when Edges will be sunset and turned off.
-
-Edges are still supported and continue to work as-is. When a date is chosen, it
-will be communicated to all Edges users.
+Edges will be sunset and turned off on December 31st, 2025.
 
 ### Migration Guide
 


### PR DESCRIPTION
We have a date of December 31st, 2025 for when we will sunset edges, as such we need to update the documentation to communicate this date to users.