### PR TITLE
New structure to K8s Operator/ingress getting started

### DIFF
--- a/docs/getting-started/kubernetes.mdx
+++ b/docs/getting-started/kubernetes.mdx
@@ -1,10 +1,32 @@
 ---
-title: Kubernetes Operator
+title: Kubernetes ingress
 pagination_next: k8s/guides/quickstart
 ---
 
-This guide will walk you through installing the ngrok Kubernetes Operator.
+This getting started guide will walk you through installing the ngrok Kubernetes
+Operator onto your cluster and configuring ingress to a Kubernetes service so
+that anyone can access it. We'll include an example deployment, but you could
+also use a Kubernetes service you already have running.
 
-import InstallPage from "../k8s/installation/install.mdx";
+import Installation from "../k8s/installation/_installation.mdx";
 
-<InstallPage />
+<Installation />
+
+import Quickstart from "../k8s/guides/quickstart.mdx";
+
+<Quickstart />
+
+## What's next?
+
+Once you have ingress to Kubernetes handled, there's still so much more you can
+do with ngrok.
+
+- Understand ngrok's core [endpoint](/docs/universal-gateway/endpoints/)
+	concepts, along with features that make our Kubernetes ingress unique, like [DDoS protection](/docs/universal-gateway/ddos-protection/) and a [global load balancer](/docs/universal-gateway/global-load-balancer/).
+- Explore the rest of our [Kubernetes ingress docs](/docs/k8s/).
+- Learn about [Traffic Policy](/docs/traffic-policy), our engine for filtering,
+	managing, and orchestrating traffic.
+- Follow comprehensive tutorials on configuring ngrok as [your next API
+	gateway](/docs/guides/api-gateway/kubernetes) or [multicloud API
+	gateway](/docs/guides/api-gateway/multicloud).
+

--- a/docs/getting-started/kubernetes.mdx
+++ b/docs/getting-started/kubernetes.mdx
@@ -3,6 +3,9 @@ title: Kubernetes ingress
 pagination_next: k8s/guides/quickstart
 ---
 
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
 This getting started guide will walk you through installing the ngrok Kubernetes
 Operator onto your cluster and configuring ingress to a Kubernetes service so
 that anyone can access it. We'll include an example deployment, but you could
@@ -15,6 +18,206 @@ import Installation from "../k8s/installation/_installation.mdx";
 import Quickstart from "../k8s/guides/quickstart.mdx";
 
 <Quickstart />
+
+You should now be able to access your service at `$NGROK_DOMAIN`!
+
+## Manage your Kubernetes ingress with Traffic Policy
+
+Our [Traffic Policy engine](/docs/traffic-policy) lets you filter traffic based
+on its properties and take action as it passes through ngrok's global network,
+into your cluster, and to your services.
+
+Let's use a popular example, the
+[`rate-limit`](/docs/traffic-policy/actions/rate-limit/) to illustrate where and
+how you can add Traffic Policy to your Kubernetes ingress. Reapply one of the
+following options, using the same ingress resource as before.
+
+<Tabs groupId="k8s" queryString="k8s">
+	<TabItem value="AgentEndpoint" label="Agent Endpoint" default>
+	```bash
+		kubectl apply -f -<<EOF
+		apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+		kind: AgentEndpoint
+		metadata:
+			name: game-2048
+			namespace: default
+		spec:
+			bindings:
+			- public
+			upstream:
+				url: http://game-2048.default:80
+			url: https://$NGROK_DOMAIN
+			trafficPolicy:
+				inline:
+					on_http_request:
+					  - actions:
+						    - type: rate-limit
+									config:
+										name: Only allow 30 requests per minute
+										algorithm: sliding_window
+										capacity: 30
+										rate: 60s
+										bucket_key:
+											- conn.client_ip
+		EOF
+	```
+	</TabItem>
+	<TabItem value="CloudEndpoint" label="Cloud and Agent Endpoint" default>
+	```bash
+	kubectl apply -f -<<EOF
+	apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+	kind: CloudEndpoint
+	metadata:
+		name: game-2048
+		namespace: default
+	spec:
+		url: https://$NGROK_DOMAIN
+		trafficPolicy:
+			policy:
+				on_http_request:
+				- name: game-2048
+					actions:
+					- type: forward-internal
+						config:
+							url: https://game-2048.internal
+					- type: rate-limit
+						config:
+							name: Only allow 30 requests per minute
+							algorithm: sliding_window
+							capacity: 30
+							rate: 60s
+							bucket_key:
+								- conn.client_ip
+	---
+	apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+	kind: AgentEndpoint
+	metadata:
+		name: game-2048
+		namespace: default
+	spec:
+		bindings:
+		- public
+		url: https://game-2048.internal
+		upstream:
+			url: http://game-2048.internal:80
+	EOF
+	```
+	</TabItem>
+	<TabItem value="Ingress" label="Ingress" default>
+	```bash
+	kubectl apply -f -<<EOF
+	apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+	kind: NgrokTrafficPolicy
+	metadata:
+		name: rate-limiting-policy
+		namespace: default
+	spec:
+		policy:
+			on_http_request:
+				- actions:
+					- type: rate-limit
+						config:
+							name: Only allow 30 requests per minute
+							algorithm: sliding_window
+							capacity: 30
+							rate: 60s
+							bucket_key:
+								- conn.client_ip
+	---
+	apiVersion: networking.k8s.io/v1
+	kind: Ingress
+	metadata:
+		name: game-2048-ingress
+		namespace: default
+		annotations:
+			k8s.ngrok.com/traffic-policy: rate-limting-policy
+	spec:
+		ingressClassName: ngrok
+		rules:
+			- host: $NGROK_DOMAIN
+				http:
+					paths:
+						- path: /
+							pathType: Prefix
+							backend:
+								service:
+									name: game-2048
+									port:
+										number: 80
+	EOF
+	```
+	</TabItem>
+	<TabItem value="GWAPI" label="Gateway API" default>
+	```bash
+	kubectl apply -f -<<EOF
+	apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+	kind: NgrokTrafficPolicy
+	metadata:
+		name: rate-limiting-policy
+		namespace: default
+	spec:
+		policy:
+			on_http_request:
+				- actions:
+					- type: rate-limit
+						config:
+							name: Only allow 30 requests per minute
+							algorithm: sliding_window
+							capacity: 30
+							rate: 60s
+							bucket_key:
+								- conn.client_ip
+	---
+	apiVersion: gateway.networking.k8s.io/v1
+	kind: Gateway
+	metadata:
+		name: ngrok-gateway
+		namespace: default
+		nnotations:
+			k8s.ngrok.com/traffic-policy: rate-limiting-policy
+	spec:
+		gatewayClassName: ngrok
+		listeners:
+			- name: http
+				protocol: HTTP
+				port: 80
+				hostname: "$NGROK_DOMAIN"
+				allowedRoutes:
+					namespaces:
+						from: Same
+	---
+	apiVersion: gateway.networking.k8s.io/v1
+	kind: HTTPRoute
+	metadata:
+		name: game-2048-route
+		namespace: default
+	spec:
+		parentRefs:
+		- group: gateway.networking.k8s.io
+			kind: Gateway
+			name: ngrok-gateway
+			namespace: default
+		hostnames:
+		- "$NGROK_DOMAIN"
+		rules:
+		- matches:
+			- path:
+					type: PathPrefix
+					value: /
+			backendRefs:
+			- name: game-2048
+				port: 80
+	EOF
+	```
+	</TabItem>
+</Tabs>
+
+You can test your rate limiting with a looping `curl` command, which should
+quickly result in `429` errors.
+
+```bash
+for i in `seq 1 50`; do curl -X GET -w '%{http_code}' https://<YOUR_NGROK_DOMAIN>/abc ; done
+```
 
 ## What's next?
 

--- a/docs/k8s/guides/quickstart.mdx
+++ b/docs/k8s/guides/quickstart.mdx
@@ -68,6 +68,21 @@ export NGROK_DOMAIN=my-domain.ngrok.io
 
 ## Configure traffic to your new `Service` with one of the following options
 
+The ngrok Kubernetes Operator supports multiple ingress resources, including
+those you may already have on your cluster:
+
+- A `AgentEndpoint` CRD that forward traffic from a public domain to a single
+	Kubernetes service.
+- A combination of `AgentEndpoint` and `CloudEndpoint` resources that forward
+	traffic from a public domain to many Kubernetes services.
+- [Ingress](/docs/k8s/guides/using-ingresses/) or [Gateway
+	API](/docs/k8s/guides/using-gwapi/) resources that the Operator automatically
+	translates into ngrok resources with the appropriate routing.
+
+For the easiest starting point, we recommend ngrok CRDs, but if you already have
+a cluster and are migrating to ngrok from a different ingress controller, you
+may find it easier to adapt an existing Ingress or Gateway API implementation.
+
 <Tabs groupId="k8s" queryString="k8s">
 	<TabItem value="AgentEndpoint" label="Agent Endpoint" default>
 	```bash

--- a/docs/k8s/guides/quickstart.mdx
+++ b/docs/k8s/guides/quickstart.mdx
@@ -1,17 +1,16 @@
 ---
-title: Quickstart
+title: ngrok Kubernetes Operator Quickstart
+sidebar_label: Quickstart
 pagination_next: k8s/guides/using-crds
 ---
 
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
-# ngrok Kubernetes Operator Quickstart
-
 The following guide will help you get started with the ngrok Kubernetes operator using a sample Deployment.
 If you've not already installed the operator yet, you can head to [the installation guide](/k8s/installation/install) first.
 
-### 1. Create a Deployment
+## Create a Deployment
 
 You can use the following `Deployment` of the 2048 game to test getting started with the ngrok Kubernetes operator if you don't already
 have one to test with.
@@ -42,7 +41,7 @@ spec:
 EOF
 ```
 
-### 2. Create a `Service` for the `Deployment`
+## Create a `Service` for the `Deployment`
 
 ```bash
 kubectl apply -f -<<EOF
@@ -61,13 +60,13 @@ spec:
 EOF
 ```
 
-### 3. Choose a domain
+## Choose a domain
 
 ```bash
 export NGROK_DOMAIN=my-domain.ngrok.io
 ```
 
-### 4. Configure traffic to your new `Service` with one of the following options.
+## Configure traffic to your new `Service` with one of the following options
 
 <Tabs groupId="k8s" queryString="k8s">
 	<TabItem value="AgentEndpoint" label="Agent Endpoint" default>

--- a/docs/k8s/installation/_installation.mdx
+++ b/docs/k8s/installation/_installation.mdx
@@ -3,10 +3,12 @@ import Tabs from "@theme/Tabs";
 
 ## What you'll need
 
-- A K8s cluster with kubectl access - We recommend using a recent version of K8s and will specify and test past versions as a part of [this GitHub issue](https://github.com/ngrok/ngrok-operator/issues/154)
+- A K8s cluster with kubectl access - We recommend using a recent version of K8s
+	and will specify and test past versions as a part of [this GitHub
+	issue](https://github.com/ngrok/ngrok-operator/issues/154). Need a quick
+	cluster for testing/development? Check out the [local cluster
+	guide](/k8s/guides/local-cluster)!
 - [helm](https://helm.sh/docs/intro/install/) - 3.0.0 or later.
-
-**Need a quick cluster for testing/development? Check out the [local cluster guide](/k8s/guides/local-cluster) first!**
 
 ## Add the ngrok Helm chart
 
@@ -48,17 +50,15 @@ export NAMESPACE=ngrok-operator
 
 ## Install Gateway API CRDs (optional)
 
-If you plan on using the Gateway API CRDs with the ngrok Kubernetes operator, install them before the operator.
+If you plan on using the [Gateway API CRDs](https://gateway-api.sigs.k8s.io/guides/) with the ngrok Kubernetes operator, install them before the operator.
 When the operator starts up it will enable support for Gateway API if the Gateway API CRDs are detected in your cluster.
 If you do not plan on using the Gateway API, then you can ignore this optional step.
 The Gateway API CRDs can be installed at a later point, but you will need to restart the operator after installing the Gateway API CRDs
 for the Gateway API support to be enabled.
 
-You can select either the standard or experimental set of Gateway API CRDs depending on your preference. Either version will work with the ngrok Kubernetes operator.
+You can select either the [standard](https://gateway-api.sigs.k8s.io/guides/#install-standard-channel) or [experimental](https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel) set of Gateway API CRDs depending on your preference. Either version will work with the ngrok Kubernetes Operator—click the links to get the latest versions of these CRDs.
 
-https://gateway-api.sigs.k8s.io/guides/
-
-After installing the Gateway API CRDs, create the following `GatewayClass` so that you can mark which Gateway API resources that the ngrok operator should handle
+After installing the Gateway API CRDs, create the following `GatewayClass` so that you can mark which Gateway API resources that the ngrok Operator should handle.
 
 ```bash
 kubectl apply -f -<<EOF

--- a/docs/k8s/installation/_installation.mdx
+++ b/docs/k8s/installation/_installation.mdx
@@ -1,0 +1,123 @@
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
+## What you'll need
+
+- A K8s cluster with kubectl access - We recommend using a recent version of K8s and will specify and test past versions as a part of [this GitHub issue](https://github.com/ngrok/ngrok-operator/issues/154)
+- [helm](https://helm.sh/docs/intro/install/) - 3.0.0 or later.
+
+**Need a quick cluster for testing/development? Check out the [local cluster guide](/k8s/guides/local-cluster) first!**
+
+## Add the ngrok Helm chart
+
+```bash
+helm repo add ngrok https://charts.ngrok.com
+helm repo update
+```
+
+:::note
+Whenever you want to update the operator or install a new version, you must run `helm repo update` to fetch the latest charts.
+:::
+
+## Get your ngrok API key and authtoken
+
+In order to use the ngrok Kubernetes Operator, you will need an ngrok account.
+Once you have an account, you will need to log into the [ngrok dashboard](https://dashboard.ngrok.com) to gather the necessary credentials.
+
+You will need two things from the dashboard:
+
+- Your auth token, which can be found [here](https://dashboard.ngrok.com/get-started/your-authtoken)
+- An API key, which can be generated [here](https://dashboard.ngrok.com/api)
+
+These credentials will be created as a Kubernetes secret, which the controller will have access to.
+The auth token is used to create tunnels, and the API key is used to manage resources via the ngrok API.
+
+```bash
+export NGROK_AUTHTOKEN=your copied auth token goes here
+export NGROK_API_KEY=your copied api key goes here
+```
+
+## Select your namespace
+
+Set the following variable to whatever you would like the installation namespace to be.
+We recommend using the default `ngrok-operator` namespace unless you need to change that.
+
+```bash
+export NAMESPACE=ngrok-operator
+```
+
+## Install Gateway API CRDs (optional)
+
+If you plan on using the Gateway API CRDs with the ngrok Kubernetes operator, install them before the operator.
+When the operator starts up it will enable support for Gateway API if the Gateway API CRDs are detected in your cluster.
+If you do not plan on using the Gateway API, then you can ignore this optional step.
+The Gateway API CRDs can be installed at a later point, but you will need to restart the operator after installing the Gateway API CRDs
+for the Gateway API support to be enabled.
+
+You can select either the standard or experimental set of Gateway API CRDs depending on your preference. Either version will work with the ngrok Kubernetes operator.
+
+https://gateway-api.sigs.k8s.io/guides/
+
+After installing the Gateway API CRDs, create the following `GatewayClass` so that you can mark which Gateway API resources that the ngrok operator should handle
+
+```bash
+kubectl apply -f -<<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+	name: ngrok
+spec:
+	controllerName: ngrok.com/gateway-controller
+EOF
+```
+
+## Install the Operator
+
+While you can pass the credential values directly via helm values like the below simple example shows, we do not recommend this for production scenarios.
+Instead, we recommend creating a Kubernetes secret and passing the secret name to the helm chart.
+This allows for easier infrastructure as code and prevents users with access to the cluster from viewing the API key and auth token using commands like `helm get values`.
+Select one of the below options based on which method you are comfortable with.
+
+<Tabs groupId="k8s" queryString="k8s-install">
+	<TabItem value="simple" label="Simple Method" default>
+		```bash
+		helm install ngrok-operator ngrok/ngrok-operator \
+		--namespace $NAMESPACE \
+		--create-namespace \
+		--set credentials.apiKey=$NGROK_API_KEY \
+		--set credentials.authtoken=$NGROK_AUTHTOKEN
+		```
+	</TabItem>
+	<TabItem value="secure" label="More Secure Method">
+		First, prepare the Secret for your credentials
+
+		```bash
+		export ENCODED_NGROK_AUTHTOKEN=$(echo -n "$NGROK_AUTHTOKEN" | base64)
+		export ENCODED_NGROK_API_KEY=$(echo -n "$NGROK_API_KEY" | base64)
+		kubectl apply -f -<<EOF
+		apiVersion: v1
+		kind: Secret
+		metadata:
+			name: ngrok-operator-credentials
+			namespace: $NAMESPACE
+		data:
+			API_KEY: "$ENCODED_NGROK_API_KEY"
+			AUTHTOKEN: "$ENCODED_NGROK_AUTHTOKEN"
+		EOF
+		```
+
+		Next, install the operator
+
+		```bash
+		helm install ngrok-operator ngrok/ngrok-operator \
+		--namespace $NAMESPACE \
+		--create-namespace \
+		--set credentials.secret.name=ngrok-operator-credentials \
+		```
+		</TabItem>
+
+</Tabs>
+
+## What's next?
+
+

--- a/docs/k8s/installation/_installation.mdx
+++ b/docs/k8s/installation/_installation.mdx
@@ -118,6 +118,3 @@ Select one of the below options based on which method you are comfortable with.
 
 </Tabs>
 
-## What's next?
-
-

--- a/docs/k8s/installation/install.mdx
+++ b/docs/k8s/installation/install.mdx
@@ -4,83 +4,11 @@ sidebar_label: Install
 pagination_next: k8s/guides/quickstart
 ---
 
-import TabItem from "@theme/TabItem";
-import Tabs from "@theme/Tabs";
+import Installation from "./_installation.mdx";
 
+<Installation />
 
-## Prerequisites
-
-- A K8s cluster with kubectl access - We recommend using a recent version of K8s and will specify and test past versions as a part of [this GitHub issue](https://github.com/ngrok/ngrok-operator/issues/154)
-- [helm](https://helm.sh/docs/intro/install/) - 3.0.0 or later.
-
-**Need a quick cluster for testing/development? Check out the [local cluster guide](/k8s/guides/local-cluster) first!**
-
-## Installation
-
-### 1. Add the ngrok Helm chart
-
-```bash
-helm repo add ngrok https://charts.ngrok.com
-helm repo update
-```
-
-:::note
-Whenever you want to update the operator or install a new version, you must run `helm repo update` to fetch the latest charts.
-:::
-
-### 2. Get your ngrok API Key and Auth Token
-
-In order to use the ngrok Kubernetes Operator, you will need an ngrok account.
-Once you have an account, you will need to log into the [ngrok dashboard](https://dashboard.ngrok.com) to gather the necessary credentials.
-
-You will need two things from the dashboard:
-
-- Your auth token, which can be found [here](https://dashboard.ngrok.com/get-started/your-authtoken)
-- An API key, which can be generated [here](https://dashboard.ngrok.com/api)
-
-These credentials will be created as a Kubernetes secret, which the controller will have access to.
-The auth token is used to create tunnels, and the API key is used to manage resources via the ngrok API.
-
-```bash
-export NGROK_AUTHTOKEN=your copied auth token goes here
-export NGROK_API_KEY=your copied api key goes here
-```
-
-### 3. Select your Namespace
-
-Set the following variable to whatever you would like the installation namespace to be.
-We recommend using the default `ngrok-operator` namespace unless you need to change that.
-
-```bash
-export NAMESPACE=ngrok-operator
-```
-
-### 4. (Optional) Install Gateway API CRDs
-
-If you plan on using the Gateway API CRDs with the ngrok Kubernetes operator, install them before the operator.
-When the operator starts up it will enable support for Gateway API if the Gateway API CRDs are detected in your cluster.
-If you do not plan on using the Gateway API, then you can ignore this optional step.
-The Gateway API CRDs can be installed at a later point, but you will need to restart the operator after installing the Gateway API CRDs
-for the Gateway API support to be enabled.
-
-You can select either the standard or experimental set of Gateway API CRDs depending on your preference. Either version will work with the ngrok Kubernetes operator.
-
-https://gateway-api.sigs.k8s.io/guides/
-
-After installing the Gateway API CRDs, create the following `GatewayClass` so that you can mark which Gateway API resources that the ngrok operator should handle
-
-```bash
-kubectl apply -f -<<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-	name: ngrok
-spec:
-	controllerName: ngrok.com/gateway-controller
-EOF
-```
-
-### 5. (optional) Find a Specific Version
+## (optional) Find a Specific Version
 
 The following command will print out a list of all the available versions of the ngrok Kubernetes operator chart including development releases.
 
@@ -95,53 +23,6 @@ and may contain features that have not been fully implemented or bugs that have 
 ```bash
 helm search repo ngrok/ngrok-operator --versions --devel
 ```
-
-### 6. Install the Operator
-
-While you can pass the credential values directly via helm values like the below simple example shows, we do not recommend this for production scenarios.
-Instead, we recommend creating a Kubernetes secret and passing the secret name to the helm chart.
-This allows for easier infrastructure as code and prevents users with access to the cluster from viewing the API key and auth token using commands like `helm get values`.
-Select one of the below options based on which method you are comfortable with.
-
-<Tabs groupId="k8s" queryString="k8s-install">
-	<TabItem value="simple" label="Simple Method" default>
-		```bash
-		helm install ngrok-operator ngrok/ngrok-operator \
-		--namespace $NAMESPACE \
-		--create-namespace \
-		--set credentials.apiKey=$NGROK_API_KEY \
-		--set credentials.authtoken=$NGROK_AUTHTOKEN
-		```
-	</TabItem>
-	<TabItem value="secure" label="More Secure Method">
-		First, prepare the Secret for your credentials
-
-		```bash
-		export ENCODED_NGROK_AUTHTOKEN=$(echo -n "$NGROK_AUTHTOKEN" | base64)
-		export ENCODED_NGROK_API_KEY=$(echo -n "$NGROK_API_KEY" | base64)
-		kubectl apply -f -<<EOF
-		apiVersion: v1
-		kind: Secret
-		metadata:
-			name: ngrok-operator-credentials
-			namespace: $NAMESPACE
-		data:
-			API_KEY: "$ENCODED_NGROK_API_KEY"
-			AUTHTOKEN: "$ENCODED_NGROK_AUTHTOKEN"
-		EOF
-		```
-
-		Next, install the operator
-
-		```bash
-		helm install ngrok-operator ngrok/ngrok-operator \
-		--namespace $NAMESPACE \
-		--create-namespace \
-		--set credentials.secret.name=ngrok-operator-credentials \
-		```
-		</TabItem>
-
-</Tabs>
 
 ## Next Steps
 


### PR DESCRIPTION
As mentioned in various places last week, I'm working on a different arrangement of existing docs content to tell a more complete story of getting started with K8s ingress with ngrok. Read about the idea on [Notion](https://www.notion.so/ngrok/K8s-Operator-getting-started-How-to-use-ngrok-as-your-Kubernetes-ingress-1d1d19ffb65480f5912cd78a0a806f45).

A few implementation details:

- I moved the installation instructions to a partial (`_installation.mdx) so it could be even more modular, and separate it from the post-installation instructions on the current [installation page](https://ngrok.com/docs/k8s/installation/install/#next-steps).
- Removed the numbering on the installation partial to make them fit better when imported into other content.
- Moved the optional **Find a specific version** step out of the installation partial because we don't need to import it everywhere.