### PR TITLE
Make sidebar scroll to the page you're viewing

### DIFF
--- a/src/theme/DocSidebarItem/Link/index.tsx
+++ b/src/theme/DocSidebarItem/Link/index.tsx
@@ -1,0 +1,66 @@
+import Link from "@docusaurus/Link";
+import isInternalUrl from "@docusaurus/isInternalUrl";
+import { isActiveSidebarItem } from "@docusaurus/plugin-content-docs/client";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import type { Props } from "@theme/DocSidebarItem/Link";
+import IconExternalLink from "@theme/Icon/ExternalLink";
+import clsx from "clsx";
+import { type ReactNode, useEffect, useRef } from "react";
+
+import styles from "./styles.module.css";
+
+export default function DocSidebarItemLink({
+	item,
+	onItemClick,
+	activePath,
+	level,
+	index,
+	...props
+}: Props): ReactNode {
+	const { href, label, className, autoAddBaseUrl } = item;
+	const isActive = isActiveSidebarItem(item, activePath);
+	const isInternalLink = isInternalUrl(href);
+	const itemRef = useRef<HTMLLIElement | null>(null);
+
+	useEffect(() => {
+		if (isActive && itemRef.current) {
+			itemRef.current.scrollIntoView({
+				behavior: "smooth",
+				block: "center",
+				inline: "nearest",
+			});
+		}
+	}, [isActive]);
+	return (
+		<li
+			ref={itemRef}
+			className={clsx(
+				ThemeClassNames.docs.docSidebarItemLink,
+				ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+				"menu__list-item",
+				className,
+			)}
+			key={label}
+		>
+			<Link
+				className={clsx(
+					"menu__link",
+					!isInternalLink && styles.menuExternalLink,
+					{
+						"menu__link--active": isActive,
+					},
+				)}
+				autoAddBaseUrl={autoAddBaseUrl}
+				aria-current={isActive ? "page" : undefined}
+				to={href}
+				{...(isInternalLink && {
+					onClick: onItemClick ? () => onItemClick(item) : undefined,
+				})}
+				{...props}
+			>
+				{label}
+				{!isInternalLink && <IconExternalLink />}
+			</Link>
+		</li>
+	);
+}

--- a/src/theme/DocSidebarItem/Link/styles.module.css
+++ b/src/theme/DocSidebarItem/Link/styles.module.css
@@ -1,0 +1,3 @@
+.menuExternalLink {
+	align-items: center;
+}


### PR DESCRIPTION
Currently the sidebar doesn't show the page you're viewing, which forces you to scroll to where it is yourself. Very frustrating. This fixes that.

## Test steps

1. Open a page like the [TCP addresses docs](https://ngrok-docs-git-shaquil-doc-30-make-the-sidebar-27006a-ngrok-dev.vercel.app/docs/universal-gateway/tcp-addresses/#api)
2. Click a link, like the one that says "/reserved_addrs API Resource" in the first bullet point
3. Observe that the sidebar scrolls when you navigate to the page





