### PR TITLE
Add a `<Definition>` component

### DIFF
--- a/docs/iam/users.mdx
+++ b/docs/iam/users.mdx
@@ -1,3 +1,5 @@
+import { Definition } from "/src/components/Definition/";
+
 # Users
 
 Users are members of your Account that may log into the dashboard, start
@@ -48,7 +50,7 @@ additional details on configuring it.
 
 In addition to the normal authentication factors required to log into the ngrok
 dashboard, you may also configure your ngrok account to further restrict
-dashboard access to a set of IP CIDR blocks.
+dashboard access to a set of <Definition>IP CIDR</Definition> blocks.
 
 Dashboard IP Restrictions should always be used in a warning mode first to test
 that you won't accidentally lock yourself out of your account if you restrict
@@ -105,7 +107,7 @@ Settings page](https://dashboard.ngrok.com/settings). By default, you provision
 new users by inviting them to join your Account with Invitations.
 
 If you have configured [SSO](#single-sign-on), you may also add users to your
-account via SCIM or JIT provisioning.
+account via <Definition>SCIM</Definition> or <Definition>JIT provisioning</Definition>.
 
 ### Invitations
 

--- a/docs/iam/users.mdx
+++ b/docs/iam/users.mdx
@@ -107,7 +107,7 @@ Settings page](https://dashboard.ngrok.com/settings). By default, you provision
 new users by inviting them to join your Account with Invitations.
 
 If you have configured [SSO](#single-sign-on), you may also add users to your
-account via <Definition>SCIM</Definition> or <Definition>JIT provisioning</Definition>.
+account via the <Definition>SCIM</Definition> or <Definition>JIT provisioning</Definition> methods.
 
 ### Invitations
 

--- a/src/components/Definition/data.ts
+++ b/src/components/Definition/data.ts
@@ -1,0 +1,26 @@
+export type Term = {
+	titles: string[];
+	meaning: string;
+	link?: string;
+};
+
+export const terms: Term[] = [
+	{
+		titles: ["CIDR", "IP CIDR"],
+		meaning:
+			"Classless Inter-Domain Routing is a method used to allocate IP addresses more efficiently and route IP packets more flexibly than the older class-based system.",
+		link: "https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing",
+	},
+	{
+		titles: ["SCIM", "SCIM provisioning"],
+		meaning:
+			"SSO SCIM Provisioning refers to the combination of two identity management technologies: Single Sign-On (SSO) and System for Cross-domain Identity Management (SCIM). Together, they automate user account creation, updates, and removal across different systems.",
+		link: "https://en.wikipedia.org/wiki/System_for_Cross-domain_Identity_Management",
+	},
+	{
+		titles: ["JIT", "JIT provisioning"],
+		meaning:
+			"Just-In-Time Single Sign-On Provisioning is a user account provisioning method that automatically creates (or updates) user accounts at the time of login via Single Sign-On, rather than pre-creating all user accounts in advance.",
+		link: "https://en.wikipedia.org/wiki/System_for_Cross-domain_Identity_Management",
+	},
+];

--- a/src/components/Definition/index.tsx
+++ b/src/components/Definition/index.tsx
@@ -1,0 +1,65 @@
+import type React from "react";
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@ngrok/mantle/hover-card";
+import { QuestionMark } from "@phosphor-icons/react";
+import { Button } from "@ngrok/mantle/button";
+import { terms } from "./data";
+import Link from "@docusaurus/Link";
+
+type DefinitionProps = {
+	children: React.ReactNode;
+	meaning?: string;
+};
+
+export function Definition({
+	children,
+	meaning,
+}: DefinitionProps): React.ReactElement {
+	if (!children) throw new Error("<Definition/> requires children");
+	const getMatchingTerm = () => {
+		const match = terms.find((term) =>
+			term.titles.includes(children.toString())
+		);
+		if (!match)
+			throw new Error(
+				"<Definition/> requires the meaning prop if no corresponding term is found."
+			);
+		return (
+			<div>
+				<p>{match.meaning}</p>
+				<p>
+					{match.link && (
+						<Link className="mb-0" href={match.link}>
+							Learn More
+						</Link>
+					)}
+				</p>
+			</div>
+		);
+	};
+
+	return (
+		<HoverCard>
+			<HoverCardTrigger className="m-0" asChild>
+				<Button
+					className="mx-[-4px]"
+					type="button"
+					priority="neutral"
+					appearance="link"
+				>
+					<>
+						<span className=" mr-[-5px]">{children}</span>
+
+						<QuestionMark size={8} className="mb-2" />
+					</>
+				</Button>
+			</HoverCardTrigger>
+			<HoverCardContent className="pb-0 w-80">
+				<span>{meaning || getMatchingTerm()}</span>
+			</HoverCardContent>
+		</HoverCard>
+	);
+}


### PR DESCRIPTION
This component adds a hovercard over technical terms. The hovercard tells the reader what the term means so they don't have to navigate away from the page to look it up.

## Examples:

- You can hover IP CIDR on [this page](https://ngrok-docs-git-shaquil-doc-246-add-a-learn-mor-9d9f8d-ngrok-dev.vercel.app/docs/iam/users#ip-restrictions)
- And you can hover over JIT provisioning and SCIM [on this page](https://ngrok-docs-git-shaquil-doc-246-add-a-learn-mor-9d9f8d-ngrok-dev.vercel.app/docs/iam/users#provisioning)


https://github.com/user-attachments/assets/597c04dc-2208-49c3-92d9-3ecce16f72aa

