### PR TITLE
fix(traffic-policy/oidc): rename config field 'scope' to 'scopes'

### DIFF
--- a/traffic-policy/actions/oidc/config.mdx
+++ b/traffic-policy/actions/oidc/config.mdx
@@ -31,7 +31,7 @@ reference for this action.
 	<ConfigItem title="client_secret" type="string" required={false}>
 		<p>Your OpenID Connect app's client secret.</p>
 	</ConfigItem>
-	<ConfigItem title="scope" type="array of strings" required={false}>
+	<ConfigItem title="scopes" type="array of strings" required={false}>
 		<p>
 			A list of additional scopes to request when users authenticate with the
 			identity provider.


### PR DESCRIPTION
While reviewing the docs, noticed that the OIDC traffic policy action listed `scope` instead of the correct `scopes` field (an array of strings).