### PR TITLE
Remove "show more" from code blocks

### DIFF
--- a/src/components/LangSwitcher/index.tsx
+++ b/src/components/LangSwitcher/index.tsx
@@ -5,7 +5,6 @@ import {
 	CodeBlockBody,
 	CodeBlockCode,
 	CodeBlockCopyButton,
-	CodeBlockExpanderButton,
 	CodeBlockHeader,
 	CodeBlockTitle,
 	fmtCode,
@@ -45,8 +44,6 @@ export function LangSwitcher({ children, className, ...props }: any) {
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	const meta: { collapsible?: boolean; [key: string]: any } =
 		matchingBlock?.meta || {};
-	const collapsible =
-		meta.collapsible && matchingBlock?.content.split("\n").length > 10;
 
 	return (
 		<BrowserOnly
@@ -87,7 +84,6 @@ export function LangSwitcher({ children, className, ...props }: any) {
 							language={matchingBlock?.language || meta.language}
 							value={fmtCode`${matchingBlock?.content.toString()}`}
 						/>
-						{collapsible && <CodeBlockExpanderButton />}
 					</CodeBlockBody>
 				</CodeBlock>
 			)}

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -4,7 +4,6 @@ import {
 	CodeBlockBody,
 	CodeBlockCode,
 	CodeBlockCopyButton,
-	CodeBlockExpanderButton,
 	CodeBlockHeader,
 	CodeBlockIcon,
 	CodeBlockTitle,
@@ -77,8 +76,6 @@ function DocsCodeBlock({
 	const hasHeader = title || mode || _icon;
 	const indentation = _indentation ?? meta.indentation;
 
-	const collapsible = meta.collapsible && children.split("\n").length > 20;
-
 	return (
 		<CodeBlock className={className} {...props}>
 			{hasHeader && (
@@ -94,7 +91,6 @@ function DocsCodeBlock({
 					language={language}
 					value={fmtCode`${children}`}
 				/>
-				{collapsible && <CodeBlockExpanderButton />}
 			</CodeBlockBody>
 		</CodeBlock>
 	);


### PR DESCRIPTION
[Preview here](https://ngrok-docs-git-disable-show-more-in-code-blocks-ngrok-dev.vercel.app/docs/traffic-policy/actions/url-rewrite/#rewrite-using-regular-expressions)

We currently truncate code blocks and display a "Show more" button that allows users to expand the code if it's long:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/fda4fd5c-3a26-4a37-bde5-e7eece1cbed5" />

This PR removes that functionality, as users has gotten confused by this and missed the "Show more" while scanning pages:

(Same example untruncated)
<img width="750" alt="image" src="https://github.com/user-attachments/assets/1e8fd1fd-bac8-43e0-9f01-7bd9da589a0e" />
