### PR TITLE
fix a minor typo in the reverse tunnel docs

### DIFF
--- a/docs/agent/ssh-reverse-tunnel-agent.mdx
+++ b/docs/agent/ssh-reverse-tunnel-agent.mdx
@@ -18,7 +18,7 @@ import RandomTlsSshExample from "/examples/ssh/tls-terminate-at-upstream.mdx";
 
 ## Overview
 
-SSH reverse tunneling (`ssh -R`) is an alternative mechanism deliver services
+SSH reverse tunneling (`ssh -R`) is an alternative mechanism to deliver services
 via ngrok without running an [ngrok agent](/agent/) or [Agent
 SDK](/agent-sdks/).
 


### PR DESCRIPTION
This is super dinky, but I happened across it and figured I might as well fix it