### PR TITLE
Update titles and sidebar labels to differentiate page titles for Overviews

### DIFF
--- a/docs/agent-sdks/index.mdx
+++ b/docs/agent-sdks/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
-title: Overview
+title: Agent SDKs
+sidebar_label: Overview
 pagination_next: k8s/index
 ---
 

--- a/docs/agent/index.mdx
+++ b/docs/agent/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: ngrok Agent
+sidebar_label: Overview
 pagination_next: agent/web-inspection-interface
 ---
 

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: The ngrok API
+sidebar_label: Overview
 pagination_next: api/reference
 ---
 

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Errors
+sidebar_label: Overview
 pagination_next: errors/reference
 ---
 

--- a/docs/iam/index.mdx
+++ b/docs/iam/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Identity and Access Management
+sidebar_label: Overview
 pagination_next: iam/users
 ---
 

--- a/docs/obs/index.mdx
+++ b/docs/obs/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Traffic Observability
+sidebar_label: Overview
 pagination_next: obs/traffic-inspection
 ---
 

--- a/docs/traffic-policy/index.mdx
+++ b/docs/traffic-policy/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Traffic Policy
+sidebar_label: Overview
 pagination_next: traffic-policy/getting-started/agent-endpoints/cli
 ---
 

--- a/docs/universal-gateway/overview.mdx
+++ b/docs/universal-gateway/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Universal Gateway
+sidebar_label: Overview
 pagination_next: universal-gateway/domains
 ---
 


### PR DESCRIPTION
I noticed this a long time ago, forgot about it, but then noticed it again today—the page titles for our **Overview** docs are all **Overview | ngrok Documentation**, which makes differentiating between them hard if you have multiple tabs open.

I decided to go ahead with this solution, but also open to suggestions on where/how we should specify on-page vs. sidebar vs. SEO titles. I think there's at least one other way we might do this.

Before:

![Screenshot 2025-05-01 at 11 21 35 AM](https://github.com/user-attachments/assets/1b93b4ee-bad3-452b-a76e-0483510b7383)

After:

![Screenshot 2025-05-01 at 11 39 01 AM](https://github.com/user-attachments/assets/e2e640fe-1aec-4991-b16e-6f29eb549a77)

Good news, and potential side quest opportunity—looks like Google ignores page titles on search results, so this hasn't been an issue when people are searching for our docs on Google. But how/why does Google just ignore our titles and make its own?

![image](https://github.com/user-attachments/assets/5eaef7ce-ef92-4444-a6eb-ad10f3a4783e)
![image](https://github.com/user-attachments/assets/95c5da12-3cb2-4860-9af1-3b4e627e71f4)