### PR TITLE
feat: improve padding and sizing of code language tabs

### DIFF
--- a/src/components/LangSwitcher/index.tsx
+++ b/src/components/LangSwitcher/index.tsx
@@ -53,8 +53,8 @@ export function LangSwitcher({ children, className, ...props }: any) {
 		>
 			{() => (
 				<CodeBlock className={clsx(className, "mb-4")} {...props}>
-					<CodeBlockHeader className="flex-col overflow-x-auto p-1">
-						<div className="flex w-[100%] gap-1.5">
+					<CodeBlockHeader className="flex-col overflow-x-auto p-2">
+						<div className="flex w-[100%] gap-1">
 							{/* biome-ignore lint/suspicious/noExplicitAny: <explanation> */}
 							{codeBlocks.map((child: any) => (
 								<Button
@@ -62,10 +62,11 @@ export function LangSwitcher({ children, className, ...props }: any) {
 									onClick={() => updateTab(child.language)}
 									type="button"
 									priority="neutral"
+									className="text-xs h-6 px-1.5"
 									appearance={
 										matchingBlock?.language === child.language
 											? "filled"
-											: "outlined"
+											: "ghost"
 									}
 								>
 									{child.language.toUpperCase()}

--- a/src/components/LangSwitcher/index.tsx
+++ b/src/components/LangSwitcher/index.tsx
@@ -62,12 +62,13 @@ export function LangSwitcher({ children, className, ...props }: any) {
 									onClick={() => updateTab(child.language)}
 									type="button"
 									priority="neutral"
-									className="text-xs h-6 px-1.5"
-									appearance={
+									className={clsx(
+										"text-xs h-6 px-1.5",
 										matchingBlock?.language === child.language
-											? "filled"
-											: "ghost"
-									}
+											? "bg-neutral-500/10 text-neutral-800"
+											: "text-neutral-500",
+									)}
+									appearance="ghost"
 								>
 									{child.language.toUpperCase()}
 								</Button>


### PR DESCRIPTION
It's not perfect (we don't have size on mantle buttons, as far as I can tell, so I manually did it via tailwind classes).

Before:

![image](https://github.com/user-attachments/assets/91ce832d-ec2e-4145-9381-3298ba6b3914)


After:

![image](https://github.com/user-attachments/assets/d9e59149-d884-4dc0-b35b-ac14e628bd26)

Designs:

![image](https://github.com/user-attachments/assets/a39c2e39-1089-4766-a9de-3ac4d41023ab)

