### PR TITLE
Warn users that `tunnels` will be removed from v3 eventually

### DIFF
--- a/docs/agent/config/v3.mdx
+++ b/docs/agent/config/v3.mdx
@@ -619,6 +619,10 @@ endpoints:
 
 ## Tunnels (Deprecated)
 
+:::warning
+The `tunnels` configuration field is deprecated and will be removed by the end of 2025. Please use the `endpoints` configuration field instead.
+:::
+
 v3 still supports the `tunnels` configuration field. This is a key-value list of tunnel name to configurations.
 
 An example can be found below:


### PR DESCRIPTION
Addresses this issue:
- https://linear.app/ngrok/issue/SUP-113/whats-the-long-term-plan-for-tunnels-section-of-v3-config

We need to warn users that `tunnels` will not be available in the future.