### PR TITLE
Update custom domains guide

### DIFF
--- a/docs/k8s/guides/custom-domain.mdx
+++ b/docs/k8s/guides/custom-domain.mdx
@@ -1,5 +1,6 @@
 ---
-title: Custom Domains
+sidebar_label: Custom Domains
+title: Kubernetes Custom White Label Domains
 ---
 
 In the Kubernetes Ingress and Gateway API specs, ingresses and routes can have multiple rules with different hostnames. While standard ngrok domains are available for use immediately after reservation, custom white label domains may require a couple extra steps to get working. The following outlines 2 options for getting custom white label domains working with the ngrok Kubernetes Operator.

--- a/docs/universal-gateway/custom-domains.mdx
+++ b/docs/universal-gateway/custom-domains.mdx
@@ -46,13 +46,13 @@ To start an agent endpoint at your domain, run the following command in your ter
 
 ## Wildcard domains
 
-If you bring your own [wildcard domain](/universal-gateway/wildcard-domains), e.g. `*.example.com`, you will need to create a second `CNAME` record with your domain host for [wildcard TLS Certificate provisioning](/universal-gateway/tls-certificates/how-does-ngrok-handle-tls/#wildcard-domains).
+If you bring your own [wildcard domain](/universal-gateway/domains#wildcard-domains), e.g. `*.example.com`, you will need to create a second `CNAME` record with your domain host for [wildcard TLS Certificate provisioning](/universal-gateway/tls-certificates/#wildcard-domains).
 
 ## Apex domains
 
 Because it's not possible to create `CNAME` records for apex domains, if you want to use an apex domain, e.g. `example.com`, you must use a DNS provider that supports an `ALIAS` record or `CNAME` flattening.
 
-Because of how `ALIAS`/`CNAME` flattening is implemented, apex domains will not take advantage of the [Global Load Balancer](/universal-gateway/global-load-balancer/#domains). If you're trying to create your apex domain because you need to create endpoints for multiple subdomains, use a [wildcard domain](/universal-gateway/what-are-public-endpoints#wildcard-domains) instead.
+Because of how `ALIAS`/`CNAME` flattening is implemented, apex domains will not take advantage of the [Global Load Balancer](/universal-gateway/global-load-balancer/). If you're trying to create your apex domain because you need to create endpoints for multiple subdomains, use a [wildcard domain](#wildcard-domains) instead.
 
 ## Using custom domains with TCP endpoints
 

--- a/docs/universal-gateway/domains.mdx
+++ b/docs/universal-gateway/domains.mdx
@@ -86,30 +86,8 @@ For example, if you create a Domain with the name `foo.ngrok.app`:
 
 ## Bring your own domain {#branded-domains}
 
-You can use any domain name that you already own with ngrok, e.g.
-`app.your-domain.com`. To do so, you will create a CNAME record for that domain
-to point traffic from the domain to ngrok's cloud service. When you create a
-Domain, you will be presented with a target value for the CNAME record you need
-to create. If you [create the Domain via
-API](/api/resources/reserved-domains/), this value is the `cname_target` field.
-
-If you bring your own [wildcard domain](#wildcard-domains), you will need to
-create a second DNS CNAME record for [wildcard TLS Certificate
-provisioning](/universal-gateway/tls-certificates/#wildcard-domains).
-
-ngrok is not a domain registrar; you must already own a domain name to use it
-with ngrok.
-
-### Apex domains
-
-If you want to use an apex domain (e.g. `example.com`) with ngrok, you must use
-a DNS provider that supports an ALIAS record or CNAME flattening because the
-DNS RFC does not permit CNAME records for apex domains. Because of how
-ALIAS/CNAME flattening is implemented, apex domains will not take advantage of
-the [Global Load Balancer](#global-load-balancer). If you are trying to create
-your apex domain because you need to create endpoints for multiple subdomains,
-use a [wildcard domain](#wildcard-domains) instead.
-
+You can use any custom domain name that you already own with ngrok, e.g.
+`app.your-domain.com`. To do so, see [the docs on using custom domains](/universal-gateway/custom-domains).
 ## Global Load Balancer
 
 The [Global Load Balancer](/universal-gateway/global-load-balancer)

--- a/sidebars.js
+++ b/sidebars.js
@@ -55,7 +55,12 @@ const sidebars = {
 					label: "Concepts",
 					type: "category",
 					items: [
-						{ id: "universal-gateway/domains", type: "doc", label: "Domains" },
+						{
+							link: { type: "doc", id: "universal-gateway/domains" },
+							type: "category",
+							label: "Domains",
+							items: ["universal-gateway/custom-domains"],
+						},
 						{
 							id: "universal-gateway/tcp-addresses",
 							type: "doc",


### PR DESCRIPTION
- Moves it to a better location in the sidebar
- Updates guide instructions
- Renames kubernetes custom domain guide so it stops showing up at the top of search results