### PR TITLE
Add new pooling video to K8s guides

### DIFF
--- a/docs/guides/other-guides/load-balancing-kubernetes-clusters.mdx
+++ b/docs/guides/other-guides/load-balancing-kubernetes-clusters.mdx
@@ -5,6 +5,7 @@ description: Use Endpoint Pooling to split traffic between any number of cluster
 
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
+import { YouTubeEmbed } from "@components/youtube-embed";
 
 Let's say you have three services, `foo`, `bar`, and `baz`, deployed in a single
 Kubernetes cluster, but eventually decide you need to extend to multiple
@@ -14,6 +15,8 @@ clusters for reasons like:
 - Load distribution and scalability
 - Hosting services close to your customers in different regions
 - Deploying some clusters on-premises and others with a cloud provider
+
+<YouTubeEmbed videoId="xD1hZ84uEJs" title="Multi-cluster (and multi-cloud!) ingress in 60 seconds with ngrok" />
 
 With ngrok, you don't need to provision new load balancers or other complex
 networking tools—[Endpoint

--- a/docs/guides/other-guides/load-balancing-kubernetes.mdx
+++ b/docs/guides/other-guides/load-balancing-kubernetes.mdx
@@ -5,6 +5,7 @@ description: Learn how to use Endpoint Pooling to share incoming traffic between
 
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
+import { YouTubeEmbed } from "@components/youtube-embed";
 
 A core benefit of Kubernetes is that it simplifies creating multiple replica
 pods for your apps or APIs and automatically load-balancing
@@ -14,6 +15,8 @@ horizontally scale, but Kubernetes can't help if you want to:
 - Share traffic between multiple clusters
 - Balance traffic between more than one cloud providers
 - Deploy canary versions or run A/B tests of your apps/APIs on a single cluster
+
+<YouTubeEmbed videoId="xD1hZ84uEJs" title="Multi-cluster (and multi-cloud!) ingress in 60 seconds with ngrok" />
 
 [Endpoint Pooling](/docs/universal-gateway/endpoint-pooling/) makes load
 balancing between Kubernetes services simple—you only need to create two

--- a/docs/universal-gateway/endpoint-pooling.mdx
+++ b/docs/universal-gateway/endpoint-pooling.mdx
@@ -184,7 +184,7 @@ the chosen endpoint.
 ### Default Strategy
 
 ngrok's default balancing strategy attempts to strike a balance between
-performance and faireness:
+performance and fairness:
 
 - First, it identifies all endpoints in the pool which are in the point of
   presence closest to where a connection is received.
@@ -195,7 +195,7 @@ For the purposes of the first step, [cloud
 endpoints](/universal-gateway/cloud-endpoints) are considered to be online in
 all points of presence.
 
-For example, if an endpoint pool consist of the following endpoints:
+For example, if an endpoint pool consists of the following endpoints:
 
 - Endpoint A: Agent Endpoint connected to `eu`
 - Endpoint B: Agent Endpoint connected `eu`

--- a/docs/what-is-ngrok.mdx
+++ b/docs/what-is-ngrok.mdx
@@ -51,7 +51,7 @@ delivery network, DDoS protection and more.
   Connect](/traffic-policy/actions/oidc/) actions to federate your
   app's authentication to an identity provider.
 - **Load Balancer**: Use [Endpoint
-	Pools](/docs/universal-gateway/endpoint-pooling/) to load-balance traffic for
+  Pools](/docs/universal-gateway/endpoint-pooling/) to load-balance traffic for
   scalability, failover, or to do blue/green and canary deployments.
 
 ### Remote Access

--- a/docs/what-is-ngrok.mdx
+++ b/docs/what-is-ngrok.mdx
@@ -50,8 +50,9 @@ delivery network, DDoS protection and more.
   [JWT Validation](/traffic-policy/actions/jwt-validation/), or [OpenID
   Connect](/traffic-policy/actions/oidc/) actions to federate your
   app's authentication to an identity provider.
-- Load Balancer: Use [Edges](/universal-gateway/edges/) to load balance traffic for
-  scalability and failover or to do blue/green and canary deployments.
+- **Load Balancer**: Use [Endpoint
+	Pools](/docs/universal-gateway/endpoint-pooling/) to load-balance traffic for
+  scalability, failover, or to do blue/green and canary deployments.
 
 ### Remote Access
 

--- a/src/components/youtube-embed.tsx
+++ b/src/components/youtube-embed.tsx
@@ -16,12 +16,12 @@ type Props = Omit<ComponentProps<"div">, "children"> & {
 
 function YouTubeEmbed({ className, title, videoId, ...props }: Props) {
 	return (
-		<div className={cx("relative aspect-video", className)} {...props}>
+		<div className={cx("relative aspect-video mb-3", className)} {...props}>
 			<iframe
 				src={`https://www.youtube.com/embed/${videoId}`}
 				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 				allowFullScreen
-				className="absolute inset-0 w-full h-full mb-3"
+				className="absolute inset-0 w-full h-full"
 				title={title}
 			/>
 		</div>

--- a/src/components/youtube-embed.tsx
+++ b/src/components/youtube-embed.tsx
@@ -21,12 +21,12 @@ function YouTubeEmbed({ className, title, videoId, ...props }: Props) {
 				src={`https://www.youtube.com/embed/${videoId}`}
 				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 				allowFullScreen
-				className="absolute inset-0 w-full h-full"
+				className="absolute inset-0 w-full h-full mb-3"
 				title={title}
 			/>
 		</div>
 	);
-}
+} 
 
 export {
 	//,


### PR DESCRIPTION
I pushed out a new K8s-specific pooling video today, so using the new `YouTubeEmbed` component to drop it in a few places. Plus, two other pools-related tweaks:

- Fixed typos in the pooling doc
- Changed the link for **Load Balancer** in _What is ngrok?_ to point to pools.