### PR TITLE
Fix quickstart OAuth rule

### DIFF
--- a/docs/getting-started/_secure-your-app.mdx
+++ b/docs/getting-started/_secure-your-app.mdx
@@ -27,7 +27,7 @@ This example uses ngrok's default managed google application to authenticate use
 			{
 				name: "bad email",
 				expressions: [
-					"!actions.ngrok.oauth.identity.email != 'alan@example.com",
+					"actions.ngrok.oauth.identity.email != 'alan@example.com'",
 				],
 				actions: [
 					{


### PR DESCRIPTION
This existing rule doesn't work:

1. There's no closing `'` around the email address
2. The double `!` operators doesn't make sense and the first one errors because you're trying to `NOT` a string.

This change creates a working policy that denies everyone _but_ `alan@example.com`. Tested it out in a new cloud endpoint.

```
on_http_request:
  - name: OAuth
    actions:
      - type: oauth
        config:
          auth_id: oauth
          provider: google
  - name: bad email
    expressions:
      - actions.ngrok.oauth.identity.email != 'alan@example.com'
    actions:
      - type: custom-response
        config:
          body: Hey, no auth for you ${actions.ngrok.oauth.identity.name}!
          status_code: 400
```

In theory you could write the expression like this, which is also valid, but I feel like that makes less sense:

```
  - name: bad email
    expressions:
      - "!(actions.ngrok.oauth.identity.email == 'alan@example.com')"
```