### PR TITLE
Add link to auth examples page from Oauth action docs

### DIFF
--- a/traffic-policy/actions/oauth/examples/index.mdx
+++ b/traffic-policy/actions/oauth/examples/index.mdx
@@ -4,4 +4,8 @@ import CustomProviders from "./custom-providers.mdx";
 ## Examples
 
 <BasicExample />
+
+### Restricting access to certain users
+See [here](/docs/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables) for an example of conditional access based on OAuth result variables.
+
 <CustomProviders />


### PR DESCRIPTION
When using the docs, I frequently found myself in the Oauth TP Action docs, looking for how to conditionally grant access to certain people, but that example lives elsewhere.  This just adds a cross-link.