### PR TITLE
Iterate on Universal Gateway Overview description

### DIFF
--- a/docs/universal-gateway/overview.mdx
+++ b/docs/universal-gateway/overview.mdx
@@ -6,16 +6,13 @@ pagination_next: universal-gateway/domains
 
 # Universal Gateway
 
-ngrok's Universal Gateway is a globally distributed API Gateway. It secures,
-accelerates and protects and accelerates your applications. We call it a
-Universal Gateway because it also supports
-[TCP](/universal-gateway/tcp/) and
-[TLS](/universal-gateway/tls/) applications.
+ngrok's Universal Gateway is a suite of common tools for building API and device gateways, identity-aware proxies, and site-to-site connectivity.
+It secures, accelerates and protects and accelerates your applications. 
+We call it a Universal Gateway because it supports [TCP](/universal-gateway/tcp/) and [TLS](/universal-gateway/tls/) applications as well as [HTTP/S](/universal-gateway/http/).
 
 ## Concepts
 
-Dive into the different parts of the Universal Gateway like Endpoints,
-Bindings, Pools and Domains to understand how they work.
+Dive into the different parts of the Universal Gateway like Endpoints, Bindings, Pools and Domains to understand how they work.
 
 Learn more about Universal Gateway Concepts:
 
@@ -37,33 +34,28 @@ Learn more about Endpoints:
 
 ## Load Balancing
 
-Endpoints Pools make load balancing dead simple. When your create two endpoints
-with the same URL (and binding), those endpoints automatically "pool" together
-and traffic to their URL is balanced among them.
+Endpoints Pools make load balancing dead simple. 
+When your create two endpoints with the same URL (and binding), those endpoints automatically "pool" together and traffic to their URL is balanced among them.
 
 - [Learn more about Load Balancing with Endpoint Pools →](/universal-gateway/endpoint-pooling/)
 
 ## TLS
 
-ngrok automatically handles TLS (SSL) termination and certificate management
-for you. There is typically nothing to setup, configure or manage.
+ngrok automatically handles TLS (SSL) termination and certificate management for you. 
+There is typically nothing to setup, configure, or manage.
 
 - [Learn more about TLS Certificates →](/universal-gateway/tls-certificates/)
 - [Learn more about the TLS Termination →](/universal-gateway/tls-termination/)
 
 ## Global Load Balancer
 
-ngrok's Global Load Balancer automatically improves the performance and
-resiliency of your applications by distributing traffic to the nearest healthy
-point of presence, measured by latency, from the perspective of the connecting
-client.
+ngrok's Global Load Balancer automatically improves the performance and resiliency of your applications by distributing traffic to the nearest healthy point of presence, measured by latency, from the perspective of the connecting client.
 
 - [Learn more about the Global Load Balancer →](/universal-gateway/global-load-balancer/)
 - [See ngrok's Global Points of Presence →](/universal-gateway/points-of-presence)
 
 ## DDoS Protection
 
-ngrok automatically protects your applications with out-of-the-box protection
-from distributed denial of service (DDoS) attacks.
+ngrok automatically protects your applications with out-of-the-box protection from distributed denial-of-service (DDoS) attacks.
 
 - [Learn more about DDoS Protection →](/universal-gateway/ddos-protection)


### PR DESCRIPTION
Following internal discussions on Slack, I'm proposing an update to the introductory description of Universal Gateway on the Overview page. I believe this description is more accurate and easier for new users to understand.

While here, I also took a minute to enforce the one-sentence-per-line style rule and added an Oxford comma toward the bottom of the page.