### PR TITLE
Fix up Ollama guide based on Aaishika's experience

### DIFF
--- a/docs/using-ngrok-with/ollama.mdx
+++ b/docs/using-ngrok-with/ollama.mdx
@@ -49,7 +49,7 @@ This URL now provides public access to your local Ollama instance.
 
 ## 4. Use your Ollama instance from anywhere
 
-You can now send requests to your Ollama server from anywhere using the ngrok URL. 
+You can now send requests to your Ollama server from anywhere using the ngrok URL.
 For example, run the `curl` command below, replacing `abcd1234.ngrok.app` with your domain name and `gemma3` with a model you've pulled, to prompt your LLM.
 
 ```bash


### PR DESCRIPTION
@aaishikasb was building a demo around Ollama and ran into a few issues in this guide.

1. Ollama requires you to rewrite the host header to `localhost`
2. The base64 encoding wasn't correct
3. The example response from Ollama was incorrect 

This PR fixes those issues, and then I added in some general cleanup to make the steps clearer.