### PR TITLE
Add a "View As Markdown" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@ngrok/mantle": "0.27.2",
     "@phosphor-icons/react": "2.1.7",
     "@stackql/docusaurus-plugin-hubspot": "1.1.0",
+    "@types/turndown": "^5.0.5",
     "algoliasearch": "5.24.0",
     "clsx": "2.1.1",
     "concurrently": "9.1.2",
@@ -56,6 +57,7 @@
     "react-hubspot-form": "1.3.7",
     "react-markdown": "10.1.0",
     "react-player": "2.16.0",
+    "turndown": "^7.2.0",
     "yaml": "2.7.1",
     "zod": "3.24.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@stackql/docusaurus-plugin-hubspot':
         specifier: 1.1.0
         version: 1.1.0
+      '@types/turndown':
+        specifier: ^5.0.5
+        version: 5.0.5
       algoliasearch:
         specifier: 5.24.0
         version: 5.24.0
@@ -93,6 +96,9 @@ importers:
       react-player:
         specifier: 2.16.0
         version: 2.16.0(react@18.3.1)
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.0
       yaml:
         specifier: 2.7.1
         version: 2.7.1
@@ -1633,6 +1639,9 @@ packages:
   '@mermaid-js/parser@0.4.0':
     resolution: {integrity: sha512-wla8XOWvQAwuqy+gxiZqY+c7FokraOTHRWMsbB4AgRx9Sy7zKslNyejy7E+a77qHfey5GXw/ik3IXv/NHMJgaA==}
 
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
   '@ngrok/mantle@0.27.2':
     resolution: {integrity: sha512-CzWPBYHF2RknbBhuOMoFNen82zmLpWGptLlHceOtuAuieBnImXpw8G82ri64IZY/dd6glCL0yhuRb75rS4HvIg==}
     engines: {node: ^22.0.0}
@@ -2619,6 +2628,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/turndown@5.0.5':
+    resolution: {integrity: sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6573,6 +6585,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turndown@7.2.0:
+    resolution: {integrity: sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==}
+
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
@@ -9305,6 +9320,8 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
+  '@mixmark-io/domino@2.2.0': {}
+
   '@ngrok/mantle@0.27.2(@phosphor-icons/react@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.20))(@types/react@18.3.20)(date-fns@4.1.0)(postcss@8.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17)(zod@3.24.4)':
     dependencies:
       '@ariakit/react': 0.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10370,6 +10387,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/turndown@5.0.5': {}
 
   '@types/unist@2.0.11': {}
 
@@ -15032,6 +15051,10 @@ snapshots:
       get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  turndown@7.2.0:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   type-fest@0.21.3: {}
 

--- a/src/components/ViewAsMarkdown/index.tsx
+++ b/src/components/ViewAsMarkdown/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { exportPageAsMarkdown } from "./utils";
+
+export function ViewAsMarkDown() {
+	return (
+		<button
+			type="button"
+			onClick={exportPageAsMarkdown}
+			className="button button--outline text-4xl m-5"
+		>
+			View as Markdown
+		</button>
+	);
+}

--- a/src/components/ViewAsMarkdown/utils.ts
+++ b/src/components/ViewAsMarkdown/utils.ts
@@ -1,0 +1,19 @@
+import TurndownService from "turndown";
+
+export function exportPageAsMarkdown() {
+	const turndownService = new TurndownService();
+
+	// You can narrow the scope if needed (e.g., just main content)
+	const content = document.querySelector("main")?.innerHTML;
+	if (!content) {
+		alert("Unable to find page content to convert.");
+		return;
+	}
+
+	const markdown = turndownService.turndown(content);
+
+	// Create a blob and open in a new tab
+	const blob = new Blob([markdown], { type: "text/markdown" });
+	const url = URL.createObjectURL(blob);
+	window.open(url, "_blank");
+}

--- a/src/components/ViewAsMarkdown/utils.ts
+++ b/src/components/ViewAsMarkdown/utils.ts
@@ -4,7 +4,9 @@ export function exportPageAsMarkdown() {
 	const turndownService = new TurndownService();
 
 	// You can narrow the scope if needed (e.g., just main content)
-	const content = document.querySelector("main")?.innerHTML;
+	const content = document.querySelector(
+		'div[class^="theme-doc-markdown"]',
+	)?.innerHTML;
 	if (!content) {
 		alert("Unable to find page content to convert.");
 		return;

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -13,6 +13,7 @@ import type ContentType from "@theme/DocItem/Content";
 import { type ReactNode, useState } from "react";
 import TabListContext from "../../Tabs/TabListContext";
 import type { TabItem } from "../../Tabs/TabListContext";
+import { ViewAsMarkDown } from "@site/src/components/ViewAsMarkdown";
 
 type Props = WrapperProps<typeof ContentType>;
 
@@ -62,6 +63,7 @@ export default function ContentWrapper(props: Props): ReactNode {
 					updateSelectedLanguage,
 				}}
 			>
+				<ViewAsMarkDown />
 				<Content {...props} />
 			</LangSwitcherContext.Provider>
 		</TabListContext.Provider>

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -8,12 +8,12 @@ import {
 	langParamName,
 	tabParamName,
 } from "@site/src/components/LangSwitcher/utils";
+import { ViewAsMarkDown } from "@site/src/components/ViewAsMarkdown";
 import Content from "@theme-original/DocItem/Content";
 import type ContentType from "@theme/DocItem/Content";
 import { type ReactNode, useState } from "react";
 import TabListContext from "../../Tabs/TabListContext";
 import type { TabItem } from "../../Tabs/TabListContext";
-import { ViewAsMarkDown } from "@site/src/components/ViewAsMarkdown";
 
 type Props = WrapperProps<typeof ContentType>;
 


### PR DESCRIPTION
There's a "View as markdown" button above the H1 on every page in this preview. Click it for a new tab to open up, showing you the raw rendered markdown for that page.

- [Preview](https://ngrok-docs-git-download-markdown-button-ngrok-dev.vercel.app/)

The end goal would be an interface like this:
![image](https://github.com/user-attachments/assets/eaca84c8-6b06-4b69-a4cb-18dcdff4346d)


- [Relevant convo](https://ngrok.slack.com/archives/C03LRGNSG6A/p1749773236516219)