### PR TITLE
Fix broken link on homepage quickstarts

### DIFF
--- a/docs/overview/index.mdx
+++ b/docs/overview/index.mdx
@@ -80,7 +80,7 @@ Or instead of the ngrok agent, get started another way:
 			</div>
 		</div>
 	</Link>
-	<Link to={`/using-ngrok-with/node-js`}>
+	<Link to={`/docs/getting-started/javascript/`}>
 		<div className="ngrok--card ngrok--card-sm">
 			<div className="ngrok--card-heading jc-space-between">
 				<h4 className="fw-600">JavaScript SDK</h4>


### PR DESCRIPTION
I think the intention here is to link directly to the JS quickstart... I'm not even sure what the content of the old `/using-ngrok-with/node-js` page used to be!