### PR TITLE
Create examples gallery directly from .mdx files, not YAML

### DIFF
--- a/docs/universal-gateway/examples.mdx
+++ b/docs/universal-gateway/examples.mdx
@@ -12,5 +12,4 @@ import ExampleGallery from '@site/src/components/ExampleGallery';
 
 <p className="text-lg">Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.</p>
 
-
 <ExampleGallery />

--- a/docs/universal-gateway/examples.mdx
+++ b/docs/universal-gateway/examples.mdx
@@ -4,75 +4,13 @@ title: Examples
 pagination_label: Examples Overview
 pagination_next: universal-gateway/examples/front-door-pattern
 sidebar_label: Overview
-
-categories:
-  - id: fundamentals
-    name: Fundamentals
-    color: yellow
-
-  - id: use-ngrok-with
-    name: Use ngrok with...
-    color: cyan
-
-  - id: traffic-control
-    name: Traffic Control
-    color: green
-
-  - id: authn-authz
-    name: "Authentication & Authorization"
-    color: rose
-
-examples:
-  - slug: front-door-pattern
-    name: "Implement the 'Front Door' Pattern"
-    description: "By using a Cloud Endpoint and internal Agent Endpoints together, you loosely couple your gateway and services for extra flexibility."
-    categories:
-      - fundamentals
-      - traffic-control
-
-  - slug: route-by-geography
-    name: "Route to Endpoints by Geography"
-    description: "Show users content based on their region, comply with regulations, or ensure traffic hits the nearest endpoint for the lowest latency."
-    categories:
-      - traffic-control
-
-  - slug: wordpress
-    name: "Accelerate and Secure Your Wordpress Installation"
-    description: "Improve your existing Wordpress installation with automatic TLS certificates, CDN acceleration/DDoS protection, and options to protect your admin dashboard."
-    categories:
-      - use-ngrok-with
-
-  - slug: offload-analytics
-    name: "Offload Analytics to a Secondary Service"
-    description: Capture observability data from your gateway and send it to a self-hosted analytics service securely and without instrumenting your code.
-    categories:
-      - use-ngrok-with
-
-  - slug: lock-admin-dashboards
-    name: "Lock Down Your Admin Dashboards"
-    description: "Add multiple layers of protection and authentication to your dashboards to prevent threat actors from even attempting attacks."
-    categories:
-      - authn-authz
-      - traffic-control
-
-  - slug: maintenance-mode 
-    name: "Deploy a Zero-Code Maintenance Mode for Your Services"
-    description: "Deploy a consistent maintenance message for your services without having to spin up new services or make changes to your network."
-    categories:
-      - traffic-control
-
-  - slug: route-api-app-traffic-user-agent
-    name: "Authenticate and Route API vs. App Traffic Based on User Agent"
-    description: "Automatically enforce the right type of AuthN and route requests to the appropriate upstream service from the same hostname and path."
-    categories:
-      - authn-authz
-      - traffic-control
 ---
 
-import ExampleHub from "@site/src/components/ExampleHub";
+import ExampleGallery from '@site/src/components/ExampleGallery';
 
 # Examples
 
 <p className="text-lg">Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.</p>
 
-<ExampleHub examples={frontMatter.examples} categories={frontMatter.categories} />
+
+<ExampleGallery />

--- a/docs/universal-gateway/examples/front-door-pattern.mdx
+++ b/docs/universal-gateway/examples/front-door-pattern.mdx
@@ -2,6 +2,9 @@
 title: "Implement the 'Front Door' Pattern"
 description: By using Cloud Endpoint and internal Agent Endpoints together, you loosely double your gateway and services for extra flexibility.
 sidebar_label: "The Front Door Pattern"
+categories:
+  - fundamentals
+  - traffic-control
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/lock-admin-dashboards.mdx
+++ b/docs/universal-gateway/examples/lock-admin-dashboards.mdx
@@ -2,6 +2,9 @@
 title: "Lock Down Your Admin Dashboards"
 description: "Add multiple layers of protection and authentication to your dashboards to prevent threat actors from even attempting attacks."
 sidebar_label: "Secure Admin Dashboards"
+categories:
+  - authn-authz
+  - traffic-control
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/maintenance-mode.mdx
+++ b/docs/universal-gateway/examples/maintenance-mode.mdx
@@ -2,6 +2,8 @@
 title: "Deploy a Zero-Code Maintenance Mode for Your Services"
 sidebar_label: Maintenence Mode
 description: Learn how to use Traffic Policy to immediately deploy a consistent maintenance message without needing to spin up a new backend service or change DNS records.
+categories:
+  - traffic-control
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/offload-analytics.mdx
+++ b/docs/universal-gateway/examples/offload-analytics.mdx
@@ -2,6 +2,8 @@
 title: "Offload Analytics to a Secondary Service"
 description: "With http-request, you can capture observability data from your gateway and send it to a self-hosted analytics service securely and without instrumenting your code."
 sidebar_label: "Offload Analytics"
+categories:
+  - use-ngrok-with
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/route-api-app-traffic-user-agent.mdx
+++ b/docs/universal-gateway/examples/route-api-app-traffic-user-agent.mdx
@@ -1,7 +1,10 @@
 ---
 title: "Authenticate and Route API vs. App Traffic Based on User Agent"
 description: "Automatically enforce the right type of AuthN and route requests to the appropriate upstream service from the same hostname and path."
-sidebar_label: Route by User Agent
+sidebar_label: "Route by User Agent"
+categories:
+  - authn-authz
+  - traffic-control
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/route-by-geography.mdx
+++ b/docs/universal-gateway/examples/route-by-geography.mdx
@@ -2,6 +2,8 @@
 title: "Route to Endpoints by Geography"
 description: "Show users content based on their region, comply with regulations, or ensure traffic hits the nearest endpoint for the best latency."
 sidebar_label: "Route to Endpoints by Geography"
+categories:
+  - traffic-control
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/docs/universal-gateway/examples/wordpress.mdx
+++ b/docs/universal-gateway/examples/wordpress.mdx
@@ -2,6 +2,8 @@
 title: "Accelerate and Secure your Wordpress Installation"
 description: "ngrok improves your existing Wordpress installation by managing your TLS certificates, accelerating your blog on our CDN, and protecting it from DDoS attacks."
 sidebar_label: "Secure Wordpress Installations"
+categories:
+  - use-ngrok-with
 ---
 
 import ReserveDomain from "./snippets/_reserve-domain.mdx";

--- a/src/components/ExampleGallery.tsx
+++ b/src/components/ExampleGallery.tsx
@@ -1,42 +1,43 @@
-import React, { useEffect, useState } from 'react';
-import { loadExamples, categoryConfig, ExampleMeta } from './loadExamples';
-import ExampleHub from './ExampleHub';
+import React, { useEffect, useState } from "react";
+import ExampleHub from "./ExampleHub";
+import { type ExampleMeta, categoryConfig, loadExamples } from "./loadExamples";
 
 export default function ExampleGallery() {
-  const [examples, setExamples] = useState<ExampleMeta[]>([]);
+	const [examples, setExamples] = useState<ExampleMeta[]>([]);
 
-  useEffect(() => {
-    const loaded = loadExamples();
-    setExamples(loaded);
-  }, []);
+	useEffect(() => {
+		const loaded = loadExamples();
+		setExamples(loaded);
+	}, []);
 
-  if (!examples.length) {
-    return <p>Loading examples...</p>;
-  }
+	if (!examples.length) {
+		return <p>Loading examples...</p>;
+	}
 
-  return <ExampleHub examples={examples} categories={extractCategories(examples)} />;
+	return (
+		<ExampleHub examples={examples} categories={extractCategories(examples)} />
+	);
 }
 
 function extractCategories(examples: ExampleMeta[]) {
-  const map = new Map<string, { id: string; name: string; color: string }>();
+	const map = new Map<string, { id: string; name: string; color: string }>();
 
-  for (const ex of examples) {
-    for (const cat of ex.categories) {
-      if (!map.has(cat)) {
-        const config = categoryConfig[cat];
-        map.set(cat, {
-          id: cat,
-          name: config?.name ?? toTitleCase(cat),
-          color: config?.color ?? 'gray',
-        });
-      }
-    }
-  }
+	for (const ex of examples) {
+		for (const cat of ex.categories) {
+			if (!map.has(cat)) {
+				const config = categoryConfig[cat];
+				map.set(cat, {
+					id: cat,
+					name: config?.name ?? toTitleCase(cat),
+					color: config?.color ?? "gray",
+				});
+			}
+		}
+	}
 
-  return Array.from(map.values());
+	return Array.from(map.values());
 }
 
 function toTitleCase(str: string) {
-  return str.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	return str.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
-

--- a/src/components/ExampleGallery.tsx
+++ b/src/components/ExampleGallery.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { loadExamples, categoryConfig, ExampleMeta } from './loadExamples';
+import ExampleHub from './ExampleHub';
+
+export default function ExampleGallery() {
+  const [examples, setExamples] = useState<ExampleMeta[]>([]);
+
+  useEffect(() => {
+    const loaded = loadExamples();
+    setExamples(loaded);
+  }, []);
+
+  if (!examples.length) {
+    return <p>Loading examples...</p>;
+  }
+
+  return <ExampleHub examples={examples} categories={extractCategories(examples)} />;
+}
+
+function extractCategories(examples: ExampleMeta[]) {
+  const map = new Map<string, { id: string; name: string; color: string }>();
+
+  for (const ex of examples) {
+    for (const cat of ex.categories) {
+      if (!map.has(cat)) {
+        const config = categoryConfig[cat];
+        map.set(cat, {
+          id: cat,
+          name: config?.name ?? toTitleCase(cat),
+          color: config?.color ?? 'gray',
+        });
+      }
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+function toTitleCase(str: string) {
+  return str.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+

--- a/src/components/ExampleHub.tsx
+++ b/src/components/ExampleHub.tsx
@@ -20,7 +20,7 @@ import {
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import { useState } from "react";
 
-import { usePluginData } from '@docusaurus/useGlobalData';
+import { usePluginData } from "@docusaurus/useGlobalData";
 
 const DefaultCategoryValue = "any";
 const DefaultPhaseValue = "any";

--- a/src/components/ExampleHub.tsx
+++ b/src/components/ExampleHub.tsx
@@ -20,10 +20,11 @@ import {
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import { useState } from "react";
 
+import { usePluginData } from '@docusaurus/useGlobalData';
+
 const DefaultCategoryValue = "any";
 const DefaultPhaseValue = "any";
 
-// Renamed from Action to Example for clearer domain context
 type Example = {
 	id?: string;
 	slug: string;
@@ -49,7 +50,6 @@ export default function ExampleHub({ examples, categories }: Props) {
 	const [categoryFilter, setCategoryFilter] = useState(DefaultCategoryValue);
 	const [exampleSearch, setExampleSearch] = useState("");
 
-	// Enhanced: Map category ID to display name and color from YAML
 	const categoryMap = Object.fromEntries(
 		categories.map((cat) => [
 			cat.id,
@@ -79,7 +79,6 @@ export default function ExampleHub({ examples, categories }: Props) {
 		);
 	}
 
-	// Added: Assign primary category for grouping
 	const examplesWithPrimary = filteredExamples.map((example) => ({
 		...example,
 		primaryCategoryId: example.categories[0],
@@ -141,7 +140,7 @@ export default function ExampleHub({ examples, categories }: Props) {
 								>
 									<Card className="flex h-full flex-col hover:bg-card-hover">
 										<CardHeader>
-											<CardTitle className="mb-0">{example.name}</CardTitle>
+											<CardTitle className="mb-0">{example.title}</CardTitle>
 										</CardHeader>
 										<CardBody className="flex-grow py-4 px-6">
 											<p className="m-0 p-0">{example.description}</p>

--- a/src/components/loadExamples.ts
+++ b/src/components/loadExamples.ts
@@ -1,0 +1,49 @@
+export type ExampleMeta = {
+  slug: string;
+  title: string;
+  description: string;
+  categories: string[];
+  phases?: string[];
+};
+
+export const categoryConfig: Record<string, { name: string; color: string }> = {
+  'use-ngrok-with': {
+    name: 'Use ngrok with...',
+    color: 'cyan',
+  },
+  'traffic-control': {
+    name: 'Traffic Control',
+    color: 'green',
+  },
+  'authn-authz': {
+    name: 'Authentication & Authorization',
+    color: 'rose',
+  },
+  fundamentals: {
+    name: 'Fundamentals',
+    color: 'yellow',
+  },
+};
+
+export function loadExamples(): ExampleMeta[] {
+  const context = require.context(
+    '../../docs/universal-gateway/examples',
+    false,
+    /\.mdx$/
+  );
+
+  return context.keys().map((key) => {
+    const mod = context(key);
+    const frontMatter = mod.frontMatter;
+
+		const slug = key.replace(/^\.\//, '').replace(/\.mdx$/, '');
+
+    return {
+      slug: slug,
+      title: frontMatter.title,
+      description: frontMatter.description,
+      categories: frontMatter.categories ?? [],
+      phases: frontMatter.phases ?? [],
+    } satisfies ExampleMeta;
+  });
+}

--- a/src/components/loadExamples.ts
+++ b/src/components/loadExamples.ts
@@ -1,49 +1,49 @@
 export type ExampleMeta = {
-  slug: string;
-  title: string;
-  description: string;
-  categories: string[];
-  phases?: string[];
+	slug: string;
+	title: string;
+	description: string;
+	categories: string[];
+	phases?: string[];
 };
 
 export const categoryConfig: Record<string, { name: string; color: string }> = {
-  'use-ngrok-with': {
-    name: 'Use ngrok with...',
-    color: 'cyan',
-  },
-  'traffic-control': {
-    name: 'Traffic Control',
-    color: 'green',
-  },
-  'authn-authz': {
-    name: 'Authentication & Authorization',
-    color: 'rose',
-  },
-  fundamentals: {
-    name: 'Fundamentals',
-    color: 'yellow',
-  },
+	"use-ngrok-with": {
+		name: "Use ngrok with...",
+		color: "cyan",
+	},
+	"traffic-control": {
+		name: "Traffic Control",
+		color: "green",
+	},
+	"authn-authz": {
+		name: "Authentication & Authorization",
+		color: "rose",
+	},
+	fundamentals: {
+		name: "Fundamentals",
+		color: "yellow",
+	},
 };
 
 export function loadExamples(): ExampleMeta[] {
-  const context = require.context(
-    '../../docs/universal-gateway/examples',
-    false,
-    /\.mdx$/
-  );
+	const context = require.context(
+		"../../docs/universal-gateway/examples",
+		false,
+		/\.mdx$/,
+	);
 
-  return context.keys().map((key) => {
-    const mod = context(key);
-    const frontMatter = mod.frontMatter;
+	return context.keys().map((key) => {
+		const mod = context(key);
+		const frontMatter = mod.frontMatter;
 
-		const slug = key.replace(/^\.\//, '').replace(/\.mdx$/, '');
+		const slug = key.replace(/^\.\//, "").replace(/\.mdx$/, "");
 
-    return {
-      slug: slug,
-      title: frontMatter.title,
-      description: frontMatter.description,
-      categories: frontMatter.categories ?? [],
-      phases: frontMatter.phases ?? [],
-    } satisfies ExampleMeta;
-  });
+		return {
+			slug: slug,
+			title: frontMatter.title,
+			description: frontMatter.description,
+			categories: frontMatter.categories ?? [],
+			phases: frontMatter.phases ?? [],
+		} satisfies ExampleMeta;
+	});
 }


### PR DESCRIPTION
This PR converts the examples gallery from loading via a handwritten YAML file to loading the frontmatter of the `.mdx` files directly, which means it should be easier for folks to contribute because all they have to do add the file in the `universal-gateway/examples` folder and specify one or more `categories` in the fronmatter.

But, this needs more testing and it looks like I have many type errors to fix before this goes live.