### PR TITLE
Remove outdated reference to endpoint regions

### DIFF
--- a/docs/api/resources/endpoints.mdx
+++ b/docs/api/resources/endpoints.mdx
@@ -44,7 +44,6 @@ Returns a 201 response on success
 | Name                | Type               | Description                                                                                                                                               |
 | ------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                | string             | unique endpoint resource identifier                                                                                                                       |
-| `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
 | `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
@@ -107,7 +106,6 @@ Returns a 200 response on success
 | Name                | Type               | Description                                                                                                                                               |
 | ------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                | string             | unique endpoint resource identifier                                                                                                                       |
-| `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
 | `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
@@ -162,7 +160,6 @@ Returns a 200 response on success
 | Name                | Type               | Description                                                                                                                                               |
 | ------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                | string             | unique endpoint resource identifier                                                                                                                       |
-| `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
 | `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
@@ -229,7 +226,6 @@ Returns a 200 response on success
 | Name                | Type               | Description                                                                                                                                               |
 | ------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                | string             | unique endpoint resource identifier                                                                                                                       |
-| `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
 | `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |

--- a/docs/universal-gateway/points-of-presence.mdx
+++ b/docs/universal-gateway/points-of-presence.mdx
@@ -40,7 +40,6 @@ Region codes are used by the following features:
 
 They are correspondingly used in the following APIs:
 
-- [Endpoint `region` property](/api/resources/endpoints/#response-2)
 - [Domain `region` property](/api/resources/reserved-domains/#response-2)
 - [TCP Address `region` property](/api/resources/reserved-addrs/#response-2)
 - [Tunnel Sessions `region` propety](/api/resources/tunnel-sessions/#response-1)


### PR DESCRIPTION
We still have documentation that refers to Region on the Endpoint eventhough that field no longer exists on the Endpoint and Endpoints are now global.