### PR TITLE
Improve mobile responsiveness in examples gallery

### DIFF
--- a/docs/universal-gateway/examples.mdx
+++ b/docs/universal-gateway/examples.mdx
@@ -122,12 +122,12 @@ import Link from '@docusaurus/Link';
 
 # Examples
 
-<p className="text-lg">Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.</p>
+<p className="lg:text-lg">Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.</p>
 
 <ExampleHub examples={frontMatter.examples} categories={frontMatter.categories} />
 <Separator className="my-8" semantic />
 
-<div className="ngrok--cards grid grid-cols-2 gap-4">
+<div className="ngrok--cards grid md:grid-cols-2 gap-4">
 	<Link to="https://ngrok.com/info/submit-examples-gallery">
 		<Card className="flex h-full flex-col bg-teal-500/20 text-teal-700 hover:bg-teal-500/10">
 			<CardHeader className="py-6">

--- a/docs/universal-gateway/examples/snippets/_back-to-examples.mdx
+++ b/docs/universal-gateway/examples/snippets/_back-to-examples.mdx
@@ -10,7 +10,7 @@ import { HorizontalSeparatorGroup, Separator } from "@ngrok/mantle/separator";
 import Link from '@docusaurus/Link';
 
 <Separator className="my-8" semantic />
-<div className="ngrok--cards grid grid-cols-2 gap-4">
+<div className="ngrok--cards grid md:grid-cols-2 gap-4">
 	<Link to="/docs/universal-gateway/examples">
 		<Card className="flex h-full flex-col hover:bg-card-hover">
 			<CardHeader className="py-6">

--- a/src/components/ExampleHub.tsx
+++ b/src/components/ExampleHub.tsx
@@ -132,7 +132,7 @@ export default function ExampleHub({ examples, categories }: Props) {
 				return (
 					<section key={cat.id} className="my-8">
 						<h2 className="text-xl font-bold mb-2">{cat.name}</h2>
-						<div className="ngrok--cards grid grid-cols-2 gap-4">
+						<div className="ngrok--cards grid md:grid-cols-2 gap-4">
 							{examplesInGroup.map((example) => (
 								<Link
 									key={example.name}


### PR DESCRIPTION
Noticed this because I looked at the newsletter while on vacation, tapped through to the examples gallery, and wasn't 100% happy with what I saw. Not sure how many folks actually look at our docs on mobile but this makes the experience not perfect, but far better.