### PR TITLE
Add Minecraft example

### DIFF
--- a/docs/universal-gateway/examples.mdx
+++ b/docs/universal-gateway/examples.mdx
@@ -106,6 +106,13 @@ examples:
     categories:
       - use-ngrok-with
       - authn-authz
+
+  - slug: minecraft
+    name: "Secure Your Public Minecraft Server"
+    description: "Unwanted players can quickly destroy your hard work, but you can restrict access by letting in a specific set of IP addresses."  
+    categories:
+      - use-ngrok-with
+      - authn-authz
 ---
 
 import ExampleHub from "@site/src/components/ExampleHub";

--- a/docs/universal-gateway/examples/minecraft.mdx
+++ b/docs/universal-gateway/examples/minecraft.mdx
@@ -1,0 +1,68 @@
+---
+title: "Secure Your Public Minecraft Server"
+description: "TK"
+sidebar_label: "Secure Minecraft Server"
+sidebar_position: 1
+---
+
+import ReserveDomain from "./snippets/_reserve-domain.mdx";
+import CloudEndpoint from "./snippets/_cloud-endpoint.mdx";
+import TryOut from "./snippets/_try-out.mdx";
+import Back from "./snippets/_back-to-examples.mdx";
+
+Unwanted players joining your Minecraft server can quickly destroy your hard work before you have a chance to kick them out.
+The good news is since you're using ngrok, it's quick and easy to restrict access to your Minecraft server by only letting in a specific set of IP addresses.
+
+This example is focused on securing your Minecraft server using Traffic Policy.
+For more general instructions on using ngrok with Minecraft, including limitations of our [free plan](/docs/pricing-limits/free-plan-limits/) and troubleshooting common issues, see our [using ngrok with Minecraft](/docs/using-ngrok-with/minecraft/) guide.
+
+## 1. Create a Traffic Policy file
+
+On the system where your Minecraft server runs, create a file named `minecraft.yaml` and paste in the policy below, replacing `$YOUR_IP` and `$FRIEND_IP` with public IPs.
+If you or your friends don't know theirs, ngrok has a simple [helper page](https://ipv4.ngrok.com/) that returns your public IP address.
+
+```yaml
+on_tcp_connect:
+  - actions:
+      - type: restrict-ips
+        config:
+          enforce: true
+          allow:
+            - $YOUR_IP/32
+            - $ANOTHER_FRIEND_IP/32
+```
+
+**What's happening here?** This policy checks whether every TCP connection originates from an IP address matching one on the `allow` list. If they match, the policy allows them connect to your ngrok agent and your Minecraft server, but if they don't, ngrok denies the request.
+
+## 2. Start your Minecraft endpoint
+
+On the same system where Minecraft runs, start your ngrok agent on port `25565`, which is the default for Minecraft, and include the `minecraft.yaml` file you just created.
+
+```bash
+ngrok tcp 25565 --traffic-policy-file minecraft.yaml
+```
+
+Once the agent starts, take note of the random public TCP address assigned to your Minecraft server, like `tcp://8.tcp.us-cal-1.ngrok.io:10891`.
+
+## 4. Try out your Minecraft endpoint
+
+You and others can now connect to your Minecraft server at the public TCP address.
+As long as your IPs match those in the `allow` list, you'll be able to connect.
+
+## Optional: Get a permanent TCP address
+
+With a production [pay-as-you-go account](/docs/pricing-limits/), you can reserve a permanent TCP addresss for your Minecraft server, which means you and others won't need to change the URL after restartng the server or its host machine.
+
+Navigate to the [**Domains** section](https://dashboard.ngrok.com/domains) of the ngrok dashboard and click **New +** to reserve the TCP address.
+Next, restart your agent, replacing `tcp://1.tcp.ngrok.io:12345` with the TCP address you reserved.
+
+```bash
+ngrok tcp 25565 --url tcp://1.tcp.ngrok.io:12345 --traffic-policy-file minecraft.yaml
+```
+
+## What's next?
+
+- Read our [Minecraft guide](/docs/using-ngrok-with/minecraft/) for details on free plan limitations and troubleshooting.
+- View your Minecraft traffic in [Traffic Inspector](https://dashboard.ngrok.com/traffic-inspector) to verify that your IP restrictions are working.
+- Track your monthly bandwidth and Traffic Policy executions on your [usage page](https://dashboard.ngrok.com/usage) to stay aware of any limitations you might reach, particularly on ngrok's [free plan](/docs/pricing-limits/free-plan-limits/).
+- Read more about [Traffic Policy](/docs/traffic-policy), [core concepts](/docs/traffic-policy/concepts), and [actions](/docs/traffic-policy/actions) you might want to implement next.

--- a/docs/universal-gateway/examples/minecraft.mdx
+++ b/docs/universal-gateway/examples/minecraft.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secure Your Public Minecraft Server"
-description: "TK"
+description: "Unwanted players can quickly destroy your hard work, but you can restrict access by letting in a specific set of IP addresses."
 sidebar_label: "Secure Minecraft Server"
 sidebar_position: 1
 ---
@@ -11,7 +11,7 @@ import TryOut from "./snippets/_try-out.mdx";
 import Back from "./snippets/_back-to-examples.mdx";
 
 Unwanted players joining your Minecraft server can quickly destroy your hard work before you have a chance to kick them out.
-The good news is since you're using ngrok, it's quick and easy to restrict access to your Minecraft server by only letting in a specific set of IP addresses.
+The good news is since you're using ngrok, you can restrict access to your Minecraft server by only letting in a specific set of IP addresses.
 
 This example is focused on securing your Minecraft server using Traffic Policy.
 For more general instructions on using ngrok with Minecraft, including limitations of our [free plan](/docs/pricing-limits/free-plan-limits/) and troubleshooting common issues, see our [using ngrok with Minecraft](/docs/using-ngrok-with/minecraft/) guide.

--- a/docs/universal-gateway/examples/minecraft.mdx
+++ b/docs/universal-gateway/examples/minecraft.mdx
@@ -13,8 +13,10 @@ import Back from "./snippets/_back-to-examples.mdx";
 Unwanted players joining your Minecraft server can quickly destroy your hard work before you have a chance to kick them out.
 The good news is since you're using ngrok, you can restrict access to your Minecraft server by only letting in a specific set of IP addresses.
 
+:::tip
 This example is focused on securing your Minecraft server using Traffic Policy.
 For more general instructions on using ngrok with Minecraft, including limitations of our [free plan](/docs/pricing-limits/free-plan-limits/) and troubleshooting common issues, see our [using ngrok with Minecraft](/docs/using-ngrok-with/minecraft/) guide.
+:::
 
 ## 1. Create a Traffic Policy file
 

--- a/docs/using-ngrok-with/minecraft.md
+++ b/docs/using-ngrok-with/minecraft.md
@@ -1,12 +1,21 @@
 ---
-title: Minecraft
+title: Using ngrok with Minecraft
+sidebar_label: Minecraft
 ---
 
-# Using ngrok with Minecraft
+Minecraft requires the use of an ngrok TCP tunnel to share your server with others. Use the [ngrok agent](/docs/agent/) to open a TCP tunnel on the default Minecraft port, `25565`.
 
-Minecraft requires the use of an ngrok TCP tunnel to share your server with others. Use `ngrok tcp 25565` to open a TCP tunnel on the default Minecraft port. You can then use the address provided to connect to your Minecraft server.
+```bash
+ngrok tcp 25565
+```
 
-The free version of ngrok has the following restrictions:
+You and others can then connect to your Minecraft server on the random TCP address provided in the ngrok CLI interface, like `tcp://1.tcp.ngrok.io:12345`.
+
+You can also follow our [secure Minecraft server example](/docs/universal-gateway/examples/minecraft/) for specific instructions on restricting access to your public Minecraft server based on public IP addresses.
+
+## Minecraft on ngrok's free plan
+
+The [free version](/docs/pricing-limits/free-plan-limits/) of ngrok has the following restrictions:
 
 - **A valid credit or debit card is required**
   - In an effort to combat abuse on our platform, we now require users to [add a valid credit or debit card to their account](https://dashboard.ngrok.com/settings#id-verification) before using TCP endpoints in the free tier. This card will not be charged.
@@ -14,10 +23,8 @@ The free version of ngrok has the following restrictions:
   - When you restart the agent, you will need to send a new TCP address to your players. Our paid accounts allow you to reserve a TCP Address for reuse. In this case, you would start the TCP tunnel using a command like `ngrok tcp --url tcp://1.tcp.ngrok.io:12345 25565`.
 - **Bandwidth Limits**
   - The free plan includes a limited amount of bandwidth per month which will prevent players from connecting to your server when exceeded.
-- **No IP Restrictions**
-  - Your Minecraft server will be available to anyone by default.
 
-Static/unchanging addresses, increased bandwidth limits, and IP Restrictions are all available with our [paid accounts](https://ngrok.com/pricing).
+Static/unchanging addresses and increased bandwidth limits are available with our [paid accounts](https://ngrok.com/pricing).
 
 ## Troubleshooting
 
@@ -26,9 +33,11 @@ Static/unchanging addresses, increased bandwidth limits, and IP Restrictions are
 If you exceed the bandwidth limit on your account players will no longer be able to connect to your server.
 
 Players attempting to connect to your server may see a "Disconnected" message in the Minecraft client.
+
 ![Minecraft Client Disconnected](/img/howto/minecraft/client_disconnected.png)
 
 Your server logs may indicate the client connecting and immediately disconnecting.
+
 ![Minecraft Server Logs](/img/howto/minecraft/server_disconnected.png)
 
 Check your [usage](https://dashboard.ngrok.com/usage) page to ensure you haven't exceeded your "Bandwidth Limit Out" limit.


### PR DESCRIPTION
I felt like it was better to retain the existing Minecraft guide, and cross-link between them, because the existing Minecraft guide has info about free plans and troubleshooting that don't necessarily make sense as part of this specific example.

I couldn't help myself but do a tiny bit of cleanup in the Minecraft guide while I was in there.