### PR TITLE
fix: update rate limit bucket key description

### DIFF
--- a/static/schemas/traffic-policy.json
+++ b/static/schemas/traffic-policy.json
@@ -856,10 +856,10 @@
         },
         "bucket_key": {
           "type": "array",
-          "description": "CEL expressions defining the rate limit bucket key",
+          "description": "CEL expression that defines how to bucket and rate limit the request. Each bucket key is a CEL expression which supports all valid traffic policy variables and macros for the current phase. Example bucket keys: `req.host` - Rate limit based on the host of the request. `conn.client_ip` - Rate limit based on the client IP address. `getReqHeader('X-Example-Header-Name')` - Rate limit based on the value of the specified header key, if it exists. Up to ten bucket keys can be specified. For multiple buckets, the action will rate limit by each unique combination of buckets.",
           "items": {
             "type": "string",
-            "description": "CEL expression for bucket key"
+            "description": "CEL expression for bucket key. See bucket_key description for examples."
           },
           "minItems": 1,
           "maxItems": 10


### PR DESCRIPTION
Updates the bucket key description on the rate limit action to be more descriptive and helpful when defining how to bucket traffic. It adds some examples.