### PR TITLE
Re-add SSH guide and update SSH instructions

### DIFF
--- a/docs/universal-gateway/tcp.mdx
+++ b/docs/universal-gateway/tcp.mdx
@@ -14,6 +14,8 @@ import RandomPythonSdkExample from "/examples/python-sdk/tcp-random.mdx";
 import RandomRustSdkExample from "/examples/rust-sdk/tcp-random.mdx";
 import RandomSshExample from "/examples/ssh/tcp-random.mdx";
 
+import SSHinstructions from "/docs/using-ngrok-with/ssh.mdx";
+
 import FixedAgentCliExample from "/examples/agent-cli/tcp-fixed.mdx";
 import FixedAgentConfigExample from "/examples/agent-config/tcp-fixed.mdx";
 import FixedGoSdkExample from "/examples/go-sdk/tcp-fixed.mdx";
@@ -77,6 +79,9 @@ This example creates a TCP endpoint on a randomly-assigned URL - e.g.
 		<RandomAgentConfigExample />
 	</TabItem>
 	<TabItem value="ssh" label="SSH">
+		<SSHinstructions />
+	</TabItem>
+	<TabItem value="ssh-r" label="SSH -R">
 		<RandomSshExample />
 	</TabItem>
 	<TabItem value="go-sdk" label="Go">

--- a/docs/using-ngrok-with/ssh.mdx
+++ b/docs/using-ngrok-with/ssh.mdx
@@ -1,0 +1,20 @@
+---
+title: Using ngrok with SSH
+sidebar_label: SSH
+---
+
+ngrok's TCP tunnels are perfect for SSH traffic. Simply start a TCP tunnel to port 22 and you should be all set.
+
+```sh
+ngrok tcp 22
+```
+
+::::warning
+TCP endpoints are only available on a free plan after [adding a valid payment method](https://dashboard.ngrok.com/settings#id-verification) to your account.
+::::
+
+When connecting through the ngrok TCP address, make sure you specify the port separately.
+
+```sh
+ssh -p PORT user@NGROK_TCP_ADDRESS
+```

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -921,7 +921,6 @@ const redirects = [
 	[fromExact("/docs/using-ngrok-with/go/"), "/docs/getting-started/go/"],
 	[fromExact("/docs/using-ngrok-with/rust/"), "/docs/getting-started/rust/"],
 	[fromExact("/docs/using-ngrok-with/rdp/"), "/docs/guides/ssh-rdp"],
-	[fromExact("/docs/using-ngrok-with/ssh/"), "/docs/guides/ssh-rdp"],
 	//site-to-site redirects
 	[
 		fromExact("/docs/guides/site-to-site-connectivity/dbs/"),


### PR DESCRIPTION
This PR re-adds the SSH specific guide, and adds its instructions to the SSH tab in the TCP quickstart. It also renames the existing SSH tab to SSH -R so it's clear what's happening