### PR TITLE
Update secrets documentation for NE-322 (macro rename)

### DIFF
--- a/docs/traffic-policy/macros/index.mdx
+++ b/docs/traffic-policy/macros/index.mdx
@@ -653,7 +653,7 @@ The following is an example of using `rand.int` with custom values:
 
 ## Secrets
 
-### `secret(string, string) -> string`
+### `secrets.get(string, string) -> string`
 
 :::tip Early Access
 This feature is currently in Early Access. Log into the [ngrok dashboard](https://dashboard.ngrok.com/developer-preview) to request access.
@@ -672,7 +672,7 @@ Security Macros allow you to access sensitive information directly in your Traff
 ##### Example
 
 ```yaml
-secret("vault-name", "secret-name")
+secrets.get("vault-name", "secret-name")
 ```
 
 ## String


### PR DESCRIPTION
Follow-on docs update for https://linear.app/ngrok/issue/NE-322/rename-secret-macro-to-secretsget