### PR TITLE
fix: updating all the webhook guides to use policy files

### DIFF
--- a/docs/integrations/aftership/webhooks.mdx
+++ b/docs/integrations/aftership/webhooks.mdx
@@ -141,10 +141,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhooks** page, copy the value of the **Webhook secret**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and AfterShip.](#setup-webhook)):
+1. Create a traffic policy file named `aftership_policy.yml`, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and AfterShip.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: aftership
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook aftership --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file aftership_policy.yml
    ```
 
 1. Access [AfterShip](https://www.aftership.com/) and create a new shipment.

--- a/docs/integrations/airship/webhooks.mdx
+++ b/docs/integrations/airship/webhooks.mdx
@@ -149,10 +149,21 @@ This is a quick step to add extra protection to your application.
 
 1. Select **Signature** in the **Authentication** field, enter `12345` in the **Secret Key** field, and then click **Update**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value of the **Secret Key** field:
+1. Create a traffic policy file named `airship_policy.yml`, replacing `{your webhook secret}` with the value of the **Secret Key** field:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: airship
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook airship --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file airship_policy.yml
    ```
 
 1. Access your [Airship](https://www.airship.com) application and create a new message.

--- a/docs/integrations/alchemy/webhooks.mdx
+++ b/docs/integrations/alchemy/webhooks.mdx
@@ -151,10 +151,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the pop-up, copy the value of the **Signing key** field and click **Close**.
 
-1. Restart your ngrok agent by running the command, replacing `{your signing key}` with the value you have copied before:
+1. Create a traffic policy file named `alchemy_policy.yml`, replacing `{your signing key}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: alchemy
+             secret: "{your signing key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook alchemy --verify-webhook-secret {your signing key}
+   ngrok http 3000 --traffic-policy-file alchemy_policy.yml
    ```
 
 **Note**: After restarting the ngrok agent, the address of the agent will be modified.

--- a/docs/integrations/amazon-sns/webhooks.mdx
+++ b/docs/integrations/amazon-sns/webhooks.mdx
@@ -150,10 +150,21 @@ This is a quick step to add extra protection to your application.
 
 1. Click **Topics** on the left menu, click your topic and copy the value of the **Topic owner** field.
 
-1. Restart your ngrok agent by running the command, replacing `{Topic owner}` with the value you copied before:
+1. Create a traffic policy file named `amazon_sns_policy.yml`, replacing `{Topic owner}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: sns
+             secret: "{Topic owner}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook sns --verify-webhook-secret {Topic owner}
+   ngrok http 3000 --traffic-policy-file amazon_sns_policy.yml
    ```
 
 1. Access [Amazon Cloud Service](https://aws.amazon.com/), sign in using your Amazon account, access the Amazon SNS **Dashboard** page, and publish a new message to your topic.

--- a/docs/integrations/autodesk/webhooks.mdx
+++ b/docs/integrations/autodesk/webhooks.mdx
@@ -194,10 +194,21 @@ This is a quick step to add extra protection to your application.
 
 1. Make sure the response from the above command is `HTTP/1.1 200`.
 
-1. Restart your ngrok agent by running the command, replacing `{your client secret}` with the value you copied before:
+1. Create a traffic policy file named `autodesk_policy.yml`, replacing `{your client secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: autodesk
+             secret: "{your client secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook autodesk --verify-webhook-secret {your client secret}
+   ngrok http 3000 --traffic-policy-file autodesk_policy.yml
    ```
 
 1. Access the folder you assigned to your webhook, upload a text file, and confirm your localhost app receives a notification and logs both headers and body in the terminal.

--- a/docs/integrations/bitbucket/webhooks.mdx
+++ b/docs/integrations/bitbucket/webhooks.mdx
@@ -166,10 +166,21 @@ THe following are quick steps to add extra protection to your application.
 
   1. In the **Authentication** section, select **Secret token** as the method, and then enter a value for the secret token.
 
-  1. Restart your ngrok agent by running the command, replacing `{your secret token}` with the value you entered before:
+  1. Create a traffic policy file named `bitbucket_policy.yml` replacing `{your secret token}` with the value you entered before:
+
+  ```yaml
+  - on_http_request:
+    - actions:
+      - type: verify-webhook
+        config:
+          provider: bitbucket
+          secret: "{your secret token}"
+  ```
+
+  1. Restart your ngrok agent by running the command:
 
   ```bash
-  ngrok http 3000 --verify-webhook bitbucket --verify-webhook-secret {your secret token}
+  ngrok http 3000 --traffic-policy-file bitbucket_policy.yml
   ```
 
   1. Access your repository, add a new file and then commit the file.

--- a/docs/integrations/box/webhooks.mdx
+++ b/docs/integrations/box/webhooks.mdx
@@ -146,10 +146,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Manage Signature Keys** page, click **Generate Key** in the **Primary Key** section and then click **COPY** to copy the value of the generated primary key.
 
-1. Restart your ngrok agent by running the command, replacing `{your primary key}` with the value you have copied before:
+1. Create a traffic policy file named `box_policy.yml`, replacing `{your primary key}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: box
+             secret: "{your primary key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook BOX --verify-webhook-secret {your primary key}
+   ngrok http 3000 --traffic-policy-file box_policy.yml
    ```
 
 1. Access [Box](https://box.com/), sign in using your Box account, and then upload a file from your desktop to the folder you selected during the webhook registration. See [Integrate Box](#setup-webhook).

--- a/docs/integrations/brex/webhooks.mdx
+++ b/docs/integrations/brex/webhooks.mdx
@@ -153,10 +153,23 @@ This is a quick step to add extra protection to your application.
 
 1. Brex API responds with HTTP status 200 and a JSON containing the `"secret": "<webhook_secret>"` attribute/value pair.
 
-1. Restart your ngrok agent by running the command, replacing `{webhook_secret}` with the value of the **secret** attribute you received before:
+1. Create a traffic policy file named `brex_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: brex
+             secret: {webhook_secret}
+   ```
+
+   **Note**: Replace `{webhook_secret}` with the value of the **secret** attribute you received before.
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook BREX --verify-webhook-secret {webhook_secret}
+   ngrok http 3000 --traffic-policy-file brex_policy.yml
    ```
 
 1. Access the [Brex Dashboard](https://dashboard.brex.com), sign in using your Brex account, and create a new user. See [Run Webhooks with Brex and ngrok](#run-webhooks-with-brex-and-ngrok).

--- a/docs/integrations/buildkite/webhooks.mdx
+++ b/docs/integrations/buildkite/webhooks.mdx
@@ -147,10 +147,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Notification Services** page, click the **My LocalHost App** webhook tile, copy the value of the **Token** field, select **Send an HMAC signature**, and then click **Save Webhook Settings**.
 
-1. Restart your ngrok agent by running the command, replacing `{your token}` with the value you have copied before:
+1. Create a traffic policy file named `buildkite_policy.yml`, replacing `{your token}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: buildkite
+             secret: "{your token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook buildkite --verify-webhook-secret {your token}
+   ngrok http 3000 --traffic-policy-file buildkite_policy.yml
    ```
 
 1. Click **Pipelines** on the top menu, select one of your pipelines and create a new build.

--- a/docs/integrations/calendly/webhooks.mdx
+++ b/docs/integrations/calendly/webhooks.mdx
@@ -184,10 +184,21 @@ This is a quick step to add extra protection to your application.
 1. On the **Your personal access tokens** page, scroll down and click **Copy Key** in the **API Key** section.
    **Tip**: This is the same value you used to register your webhook. See [Integrate Calendly] (#setup-webhook).
 
-1. Restart your ngrok agent by running the command, replacing `{your key}` with the value you have copied before:
+1. Create a traffic policy file named `calendly_policy.yml`, replacing `{your key}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: calendly
+             secret: "{your key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook CALENDLY --verify-webhook-secret {your key}
+   ngrok http 3000 --traffic-policy-file calendly_policy.yml
    ```
 
 1. Access your Calendly link, click **30 Minutes Meeting**, select a date, and then click **Confirm**.

--- a/docs/integrations/castle/webhooks.mdx
+++ b/docs/integrations/castle/webhooks.mdx
@@ -142,10 +142,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Application** page, copy the value of the **API SECRET** field.
 
-1. Restart your ngrok agent by running the command, replacing `{your api secret}` with the value you have copied before:
+1. Create a traffic policy file named `castle_policy.yml`, replacing `{your api secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: castle
+             secret: "{your api secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook castle --verify-webhook-secret {your api secret}
+   ngrok http 3000 --traffic-policy-file castle_policy.yml
    ```
 
 1. Access the [Castle dashboard](https://dashboard.castle.io/) and test the webhook endpoint or create an event by using the Castle SDK.

--- a/docs/integrations/chargify/webhooks.mdx
+++ b/docs/integrations/chargify/webhooks.mdx
@@ -148,10 +148,23 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Site** page, copy the value of the **Site Shared Key**.
 
-1. Restart your ngrok agent by running the command, replacing `{your site shared key}` with the value you have copied before:
+1. Create a traffic policy file named `chargify_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: chargify
+             secret: {your site shared key}
+   ```
+
+   **Note**: Replace `{your site shared key}` with the value you copied before.
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook chargify --verify-webhook-secret {your site shared key}
+   ngrok http 3000 --traffic-policy-file chargify_policy.yml
    ```
 
 1. Access the **Webhook Testing** page and send a new test notification to your webhook.

--- a/docs/integrations/circleci/webhooks.mdx
+++ b/docs/integrations/circleci/webhooks.mdx
@@ -140,10 +140,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your secret token}` with the value you have provided to the **Secret token** field during your webhook registration (See [Integrate ngrok and CircleCI](#setup-webhook)):
+1. Create a traffic policy file named `circleci_policy.yml`, replacing `{your secret token}` with the value you have provided to the **Secret token** field during your webhook registration (See [Integrate ngrok and CircleCI](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: circleci
+             secret: "{your secret token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook circleci --verify-webhook-secret {your secret token}
+   ngrok http 3000 --traffic-policy-file circleci_policy.yml
    ```
 
 1. Access [CircleCI](https://www.circleci.com/) and Rerun your workflow from start.

--- a/docs/integrations/clearbit/webhooks.mdx
+++ b/docs/integrations/clearbit/webhooks.mdx
@@ -145,10 +145,21 @@ This is a quick step to add extra protection to your application.
 1. Copy the value of the **Secret API Key** field that appears on the screen.
    **Note**: Usually the secret key value starts with `sk_`.
 
-1. Restart your ngrok agent by running the command, replacing `{your api key}` with the value you copied before:
+1. Create a traffic policy file named `clearbit_policy.yml`, replacing `{your api key}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: clearbit
+             secret: "{your api key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook clearbit --verify-webhook-secret {your api key}
+   ngrok http 3000 --traffic-policy-file clearbit_policy.yml
    ```
 
 1. Repeat the command to gather information about your account.

--- a/docs/integrations/clerk/webhooks.mdx
+++ b/docs/integrations/clerk/webhooks.mdx
@@ -149,10 +149,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Endpoint** page, click the eye icon under **Signing Secret** and copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{endpoint signing secret}` with the value you copied before:
+1. Create a traffic policy file named `clerk_policy.yml`, replacing `{endpoint signing secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: clerk
+             secret: "{endpoint signing secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook clerk --verify-webhook-secret {endpoint signing secret}
+   ngrok http 3000 --traffic-policy-file clerk_policy.yml
    ```
 
 1. Click **Users** on the left menu and then create a new user.

--- a/docs/integrations/coinbase/webhooks.mdx
+++ b/docs/integrations/coinbase/webhooks.mdx
@@ -135,10 +135,23 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by replacing `{your api secret}` with the value you copied during the webhook registration and running the following command:
+1. Create a traffic policy file named `coinbase_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: coinbase
+             secret: {your api secret}
+   ```
+
+   **Note**: Replace `{your api secret}` with the value you copied during the webhook registration.
+
+1. Restart your ngrok agent by running the following command:
 
    ```bash
-   ngrok http 3000 --verify-webhook coinbase --verify-webhook-secret {your api secret}
+   ngrok http 3000 --traffic-policy-file coinbase_policy.yml
    ```
 
 1. Access [Coinbase](https://www.coinbase.com/) and buy an asset.

--- a/docs/integrations/contentful/webhooks.mdx
+++ b/docs/integrations/contentful/webhooks.mdx
@@ -18,7 +18,7 @@ By integrating ngrok with Contentful, you can:
 - **Develop and test Contentful webhooks locally**, eliminating the time in deploying your development code to a public environment and setting it up in HTTPS.
 - **Inspect and troubleshoot requests from Contentful** in real-time via the inspection UI and API.
 - **Modify and Replay Contentful webhook requests** with a single click and without spending time reproducing events manually in your Contentful account.
-- **Verify signed Contentful webhook requests** at the edge using ngrok's webhook verification options: `--verify-webhook=contentful --verify-webhook-secret=<webhook signing secret>`
+- **Verify signed Contentful webhook requests** at the edge using ngrok's traffic policy with webhook verification
 
 ## **Step 1**: Start your app {#start-your-app}
 
@@ -62,9 +62,22 @@ Once your app is running successfully on localhost, let's get it on the internet
 
    Or with Contentful [Webhook Request Verification](https://www.contentful.com/developers/docs/webhooks/request-verification/) enabled:
 
-   ```bash
-   ngrok http 3000 --verify-webhook=contentful --verify-webhook-secret=<webhook signing secret>
-   ```
+   1. Create a traffic policy file named `contentful_policy.yml`:
+
+      ```yaml
+      on_http_request:
+        - actions:
+            - type: verify-webhook
+              config:
+                provider: contentful
+                secret: "<webhook signing secret>"
+      ```
+
+   1. Start ngrok with traffic policy:
+
+      ```bash
+      ngrok http 3000 --traffic-policy-file contentful_policy.yml
+      ```
 
 1. ngrok will display a URL where your localhost application is exposed to the internet (copy this URL for use with Contentful).
    ![ngrok agent running](/img/integrations/launch_ngrok_tunnel.png)
@@ -137,5 +150,5 @@ The ngrok Request Inspector provides a replay function that you can use to test 
 Verify that your local application receives the request and logs the corresponding information to the terminal.
 
 :::info NOTE
-If Contentful [Webhook Request Verification](https://www.contentful.com/developers/docs/webhooks/request-verification/) is enabled and you are verifying signed Contentful webhook requests at the edge using ngrok's webhook verification options: `--verify-webhook=contentful --verify-webhook-secret=<webhook signing secret>` replaying requests will not work outside of the 3 minute TTL.
+If Contentful [Webhook Request Verification](https://www.contentful.com/developers/docs/webhooks/request-verification/) is enabled and you are verifying signed Contentful webhook requests at the edge using ngrok's traffic policy with webhook verification, replaying requests will not work outside of the 3 minute TTL.
 :::

--- a/docs/integrations/docusign/webhooks.mdx
+++ b/docs/integrations/docusign/webhooks.mdx
@@ -151,10 +151,21 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Connect** page, click the **APPLICATIONS** tab, click your webhook, and then in the **Integration and Security Settings** section click **Include HMAC Signature**.
 
-1. Restart your ngrok agent by running the command, replacing `{your connect key}` with the value you copied before:
+1. Create a traffic policy file named `docusign_policy.yml`, replacing `{your connect key}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: docusign
+             secret: "{your connect key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook docusign --verify-webhook-secret {your connect key}
+   ngrok http 3000 --traffic-policy-file docusign_policy.yml
    ```
 
 1. Access [DocuSign](https://app.docusign.com/home) and create a new envelope.

--- a/docs/integrations/dropbox/webhooks.mdx
+++ b/docs/integrations/dropbox/webhooks.mdx
@@ -143,10 +143,21 @@ This is a quick step to add extra protection to your application.
 
 1. Access the [Dropbox developer site](https://www.dropbox.com/developers/apps), click the name of the app you created in the [Integrate Dropbox](#setup-webhook) step, click **Show** for the **App secret** field of the **Settings** tab, and then copy the value that appears on the page.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the value you have copied before:
+1. Create a traffic policy file named `dropbox_policy.yml`, replacing `{your app secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: dropbox
+             secret: "{your app secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook dropbox --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file dropbox_policy.yml
    ```
 
 1. Access the [Dropbox site](https://dropbox.com/), sign in using your Dropbox account, and then upload a new file to the app folder.

--- a/docs/integrations/facebook-messenger/webhooks.mdx
+++ b/docs/integrations/facebook-messenger/webhooks.mdx
@@ -188,10 +188,22 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic Settings** page, click **Show** to reveal the **App secret** value and copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the value you have copied before:
+1. Create a traffic policy file named `messenger_policy.yml`, replacing `{your app secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - name: "Facebook Messenger Webhooks"
+       actions:
+         - type: "webhook-validation"
+           config:
+             provider: "facebook_messenger"
+             secret: "{your app secret}"
+   ```
+
+2. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --url myexample.ngrok.app --verify-webhook facebook_messenger --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file messenger_policy.yml
    ```
 
 1. Access the Facebook page you have assigned to your webhook and send a message to another Facebook user.

--- a/docs/integrations/facebook/webhooks.mdx
+++ b/docs/integrations/facebook/webhooks.mdx
@@ -166,10 +166,22 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic Settings** page, click **Show** to reveal the **App secret** value and copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the value you have copied before:
+1. Create a traffic policy file named `facebook_policy.yml`, replacing `{your app secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - name: "Facebook Webhooks"
+       actions:
+         - type: "webhook-validation"
+           config:
+             provider: "facebook_graph_api"
+             secret: "{your app secret}"
+   ```
+
+2. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --url myexample.ngrok.app --verify-webhook facebook_graph_api --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file facebook_policy.yml
    ```
 
 1. Access the Facebook page you have assigned to your webhook and send a message to another Facebook user.

--- a/docs/integrations/frameio/webhooks.mdx
+++ b/docs/integrations/frameio/webhooks.mdx
@@ -152,10 +152,22 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhooks** page, click **Copy** to copy the **Secret** value.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and Frame.io.](#setup-webhook)):
+1. Create a traffic policy file named `frameio_policy.yml`, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and Frame.io.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - name: "Verify Frame.io requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "frameio"
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook frameio --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file frameio_policy.yml
    ```
 
 1. Access [Frame.io](https://frame.io/) and create a new project.

--- a/docs/integrations/github/webhooks.mdx
+++ b/docs/integrations/github/webhooks.mdx
@@ -151,12 +151,24 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. In the **Add webhook** page, provide a value to the **Secret** field.
+1. Create a traffic policy file named `github_policy.yml`, replacing `{your secret}` with your **Secret** from GitHub:
 
-1. Restart your ngrok agent by running the command, replacing `{your secret}` with your **Secret** from GitHub:
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: github
+             secret: "{your secret}"
+   ```
+
+
+
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook github --verify-webhook-secret {your secret}
+   ngrok http 3000 --traffic-policy-file github_policy.yml
    ```
 
 1. Resend one of the messages from your GitHub webhook.

--- a/docs/integrations/gitlab/webhooks.mdx
+++ b/docs/integrations/gitlab/webhooks.mdx
@@ -162,10 +162,21 @@ This is a quick step to add extra protection to your application.
 
 1. Enter a text for the **Secret token** field and click **Save changes**.
 
-1. Restart your ngrok agent by running the command, replacing `{your secret token}` with the value you have provided to the **Secret token** field (See [Integrate GitLab](#setup-webhook)):
+1. Create a traffic policy file named `gitlab_policy.yml`, replacing `{your secret token}` with the value you have provided to the **Secret token** field (See [Integrate GitLab](#setup-webhook)):
+
+   ```yaml
+   - on_http_request:
+       - actions:
+           - type: verify-webhook
+         config:
+           provider: gitlab
+           secret: "{your secret token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook gitlab --verify-webhook-secret {your secret token}
+   ngrok http 3000 --traffic-policy-file gitlab_policy.yml
    ```
 
 1. In the **Project Hooks** section, click **Test** for your webhook, and then click **Push events**. Alternatively, push content to your repository.

--- a/docs/integrations/heroku/webhooks.mdx
+++ b/docs/integrations/heroku/webhooks.mdx
@@ -140,10 +140,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have entered in the **Secret** field during the webhook registration (See [Integrate ngrok and Heroku.](#setup-webhook)):
+1. Create a traffic policy file named `heroku_policy.yml`, replacing `{your webhook secret}` with the value you have entered in the **Secret** field during the webhook registration (See [Integrate ngrok and Heroku.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: heroku
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook HEROKU --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file heroku_policy.yml
    ```
 
 1. Access [Heroku](https://heroku.com/), sign in using your Heroku account, access your app, and then execute a new build.

--- a/docs/integrations/hostedhooks/webhooks.mdx
+++ b/docs/integrations/hostedhooks/webhooks.mdx
@@ -177,10 +177,22 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Endpoint** page, click **Reveal** in the **Signing Secret** field and copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{app sign secret}` with the value you copied before:
+1. Create a traffic policy file named `hostedhooks_policy.yml`, replacing `{app sign secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - name: "Verify HostedHooks requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "hostedhooks"
+             secret: "{app sign secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook hostedhooks --verify-webhook-secret {app sign secret}
+   ngrok http 3000 --traffic-policy-file hostedhooks_policy.yml
    ```
 
 1. Post a new message to the message endpoint of HostedHooks by following the same procedure as the [Run Webhooks with HostedHooks and ngrok](#run-webhook) section.

--- a/docs/integrations/hubspot/webhooks.mdx
+++ b/docs/integrations/hubspot/webhooks.mdx
@@ -172,10 +172,21 @@ This is a quick step to add extra protection to your application.
 
 1. On your app page, click the **Auth** tab, click **Show** in the **Client secret** section, and then click **Copy**.
 
-1. Restart your ngrok agent by running the command, replacing `{your client secret}` with the value you copied before:
+1. Create a traffic policy file named `hubspot_policy.yml`, replacing `{your client secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: hubspot
+             secret: "{your client secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook hubspot --verify-webhook-secret {your client secret}
+   ngrok http 3000 --traffic-policy-file hubspot_policy.yml
    ```
 
 1. Access your [HubSpot](https://hubspot.com) account and create a new contact (don't forget to Select your user as the **Contact owner**).

--- a/docs/integrations/hygraph/webhooks.mdx
+++ b/docs/integrations/hygraph/webhooks.mdx
@@ -142,10 +142,22 @@ This is a quick step to add extra protection to your application.
 
 1. On the popup, enter a secret key that is at least 32 characters long in the **Secret key** field, and then click **Update** at the top of the popup screen.
 
-1. Restart your ngrok agent by running the command, replacing `{your secret key}` with the value you used in the **Secret key** field:
+1. Create a traffic policy file named `hygraph_policy.yml`, replacing `{your secret key}` with the value you used in the **Secret key** field:
+
+   ```yaml
+   on_http_request:
+     - name: "Verify Hygraph requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "graphcms"
+             secret: "{your secret key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook graphcms --verify-webhook-secret {your secret key}
+   ngrok http 3000 --traffic-policy-file hygraph_policy.yml
    ```
 
 1. On the Hygraph home page, create a new asset.

--- a/docs/integrations/instagram/webhooks.mdx
+++ b/docs/integrations/instagram/webhooks.mdx
@@ -174,10 +174,22 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic Settings** page, click **Show** to reveal the **App secret** value and copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the value you have copied before:
+1. Create a traffic policy file named `instagram_policy.yml`, replacing `{your app secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - name: "Instagram Webhooks"
+       actions:
+         - type: "webhook-validation"
+           config:
+             provider: facebook_graph_api
+             secret: "{your app secret}"
+   ```
+
+2. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --url myexample.ngrok.app --verify-webhook FACEBOOK_GRAPH_API --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file instagram_policy.yml
    ```
 
 1. Access the Instagram page you have assigned to your webhook and send a message to another Instagram user.

--- a/docs/integrations/intercom/webhooks.mdx
+++ b/docs/integrations/intercom/webhooks.mdx
@@ -153,10 +153,21 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic information** page, copy the **Client secret** value.
 
-1. Restart your ngrok agent by running the command, replacing `{your client secret}` with the value you copied before:
+1. Create a traffic policy file named `intercom_policy.yml`, replacing `{your client secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: intercom
+             secret: "{your client secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook intercom --verify-webhook-secret {your client secret}
+   ngrok http 3000 --traffic-policy-file intercom_policy.yml
    ```
 
 1. Access the [Intercom Home](https://app.intercom.com/) page and create a new contact.

--- a/docs/integrations/launchdarkly/webhooks.mdx
+++ b/docs/integrations/launchdarkly/webhooks.mdx
@@ -138,10 +138,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and LaunchDarkly.](#setup-webhook)):
+1. Create a traffic policy file named `launchdarkly_policy.yml`, replacing `{your webhook secret}` with the value you have copied before (See [Integrate ngrok and LaunchDarkly.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: launch_darkly
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook LAUNCH_DARKLY --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file launchdarkly_policy.yml
    ```
 
 1. Access the [LaunchDarkly App](https://app.launchdarkly.com/) and create a new segment.

--- a/docs/integrations/mailgun/webhooks.mdx
+++ b/docs/integrations/mailgun/webhooks.mdx
@@ -163,10 +163,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhooks** page, click the eye icon near the **HTTP webhook signing key** text and copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{webhook signing key}` with the value you have copied before:
+1. Create a traffic policy file named `mailgun_policy.yml`, replacing `{webhook signing key}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: mailgun
+             secret: "{webhook signing key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook mailgun --verify-webhook-secret {webhook signing key}
+   ngrok http 3000 --traffic-policy-file mailgun_policy.yml
    ```
 
 1. Access [Mailgun](https://app.mailgun.com/) and send a new email to an authorized recipient.

--- a/docs/integrations/modern-treasury/webhooks.mdx
+++ b/docs/integrations/modern-treasury/webhooks.mdx
@@ -155,10 +155,22 @@ This is a quick step to add extra protection to your application.
 
 1. On your webhook page, copy the value of the **Webhook Key** field.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook key}` with the value you have copied before (See [Integrate ngrok and Modern Treasury.](#setup-webhook)):
+1. Create a traffic policy file named `modern_treasury_policy.yml`, replacing `{your webhook key}` with the value you have copied before (See [Integrate ngrok and Modern Treasury.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - name: "Verify Modern Treasury requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: modern_treasury
+             secret: "{your webhook key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook MODERN_TREASURY --verify-webhook-secret {your webhook key}
+   ngrok http 3000 --traffic-policy-file modern_treasury_policy.yml
    ```
 
 1. Access the [Modern Treasury site](https://app.moderntreasury.com/) and create a new payment order.

--- a/docs/integrations/mongodb/webhooks.mdx
+++ b/docs/integrations/mongodb/webhooks.mdx
@@ -138,10 +138,22 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value of the **Webhook Secret** field you copied during the webhook registration (See [Integrate ngrok and MongoDB.](#setup-webhook)):
+1. Create a traffic policy file named `mongodb_policy.yml`, replacing `{your webhook secret}` with the value of the **Webhook Secret** field you copied during the webhook registration (See [Integrate ngrok and MongoDB.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - name: "Verify MongoDB requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "mongodb"
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook mongodb --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file mongodb_policy.yml
    ```
 
 1. Access your project home page and invite a new person to your project.

--- a/docs/integrations/mux/webhooks.mdx
+++ b/docs/integrations/mux/webhooks.mdx
@@ -139,10 +139,22 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhooks** tab of the **Settings** page, click **Show Signing Secret** for your webhook and copy the value of the signing secret.
 
-1. Restart our ngrok agent by running the command, replacing `{your signing secret}` with the value you have copied before (See [Integrate ngrok and Mux.](#setup-webhook)):
+1. Create a traffic policy file named `mux_policy.yml`, replacing `{your signing secret}` with the value you have copied before (See [Integrate ngrok and Mux.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - name: "Verify Mux requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "mux"
+             secret: "{your signing secret}"
+   ```
+
+1. Restart our ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook mux --verify-webhook-secret {your signing secret}
+   ngrok http 3000 --traffic-policy-file mux_policy.yml
    ```
 
 1. Access [Mux](https://www.mux.com/), sign in, and create a new asset.

--- a/docs/integrations/orbit/webhooks.mdx
+++ b/docs/integrations/orbit/webhooks.mdx
@@ -142,10 +142,22 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Update Webhook** page, enter `12345` in the **Webhook Secret** field and click **Save Changes**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value from the previous step:
+1. Create a traffic policy file named `orbit_policy.yml`, replacing `{your webhook secret}` with the value from the previous step:
+
+   ```yaml
+   on_http_request:
+     - name: "Verify Orbit requests"
+       actions:
+         - type: verify-webhook
+           config:
+             provider: "orbit"
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook orbit --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file orbit_policy.yml
    ```
 
 1. Access [Orbit Home](https://app.orbit.love/) page, sign in, and add a new activity to a member.

--- a/docs/integrations/pagerduty/webhooks.mdx
+++ b/docs/integrations/pagerduty/webhooks.mdx
@@ -146,10 +146,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook payload signing}` with the value you copied before (See [Integrate ngrok and PagerDuty.](#setup-webhook)):
+1. Create a traffic policy file named `pagerduty_policy.yml`, replacing `{your webhook payload signing}` with the value you copied before (See [Integrate ngrok and PagerDuty.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: pagerduty
+             secret: "{your webhook payload signing}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook pagerduty --verify-webhook-secret {your webhook payload signing}
+   ngrok http 3000 --traffic-policy-file pagerduty_policy.yml
    ```
 
 1. Access PagerDuty (`https://{tenant}.pagerduty.com/incidents`) and create a new incident.

--- a/docs/integrations/pinwheel/webhooks.mdx
+++ b/docs/integrations/pinwheel/webhooks.mdx
@@ -150,10 +150,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your api secret}` with the value of the API Secret you copied before (See [Integrate Pinwheel](#setup-webhook)):
+1. Create a traffic policy file named `pinwheel_policy.yml`, replacing `{your api secret}` with the value of the API Secret you copied before (See [Integrate Pinwheel](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: pinwheel
+             secret: "{your api secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook pinwheel --verify-webhook-secret {your api secret}
+   ngrok http 3000 --traffic-policy-file pinwheel_policy.yml
    ```
 
 1. Request users to log into their payroll account by using Pinwheel API.

--- a/docs/integrations/plivo/webhooks.mdx
+++ b/docs/integrations/plivo/webhooks.mdx
@@ -153,10 +153,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Overview** page, click the eye icon next to **Auth Token** and then copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{your auth token}` with the value you copied before:
+1. Create a traffic policy file named `plivo_policy.yml`, replacing `{your auth token}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: plivo
+             secret: "{your auth token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook plivo --verify-webhook-secret {your auth token}
+   ngrok http 3000 --traffic-policy-file plivo_policy.yml
    ```
 
 1. Send a new SMS to your Plivo phone number.

--- a/docs/integrations/pusher/webhooks.mdx
+++ b/docs/integrations/pusher/webhooks.mdx
@@ -142,10 +142,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the [Pusher dashboard](https://dashboard.pusher.com/), click **App keys** on the left menu, and then copy the value of the **secret** field that appears on the screen.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have copied before:
+1. Create a traffic policy file named `pusher_policy.yml`, replacing `{your webhook secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: pusher
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook pusher --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file pusher_policy.yml
    ```
 
 1. Repeat the steps described in the [Run Webhooks with Pusher and ngrok](#run-webhook) section.

--- a/docs/integrations/sendgrid/webhooks.mdx
+++ b/docs/integrations/sendgrid/webhooks.mdx
@@ -159,10 +159,21 @@ This is a quick step to add extra protection to your application.
 1. In the **Signed Event Webhook Requests** popup window, click **Generate Verification Key**, copy the value of the key that appears in the page, and then click **Close**.
    **Tip**: Make sure the **Signed Event Webhook Request Status** is **ENABLED**.
 
-1. Restart your ngrok agent by running the command, replacing `{your verification key}` with the value you copied before:
+1. Create a traffic policy file named `sendgrid_policy.yml`, replacing `{your verification key}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: sendgrid
+             secret: "{your verification key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook sendgrid --verify-webhook-secret {your verification key}
+   ngrok http 3000 --traffic-policy-file sendgrid_policy.yml
    ```
 
 1. Reproduce the steps to send an email through your SendGrid account.

--- a/docs/integrations/sentry/webhooks.mdx
+++ b/docs/integrations/sentry/webhooks.mdx
@@ -146,10 +146,21 @@ This is a quick step to add extra protection to your application.
 
 1. On your Sentry organization page, click **Settings** on the left menu, click **Developer Settings** on the Organization sub-menu, click **My Local App Webhook**, and then copy the value of the **Client Secret** field under the **CREDENTIALS** section.
 
-1. Restart your ngrok agent by running the command, replacing `{your client secret}` with the value you have copied before (See [Integrate ngrok and Sentry.](#setup-webhook)):
+1. Create a traffic policy file named `sentry_policy.yml`, replacing `{your client secret}` with the value you have copied before (See [Integrate ngrok and Sentry.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: sentry
+             secret: "{your client secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook sentry --verify-webhook-secret {your client secret}
+   ngrok http 3000 --traffic-policy-file sentry_policy.yml
    ```
 
 1. Repeat the steps in the [Run Webhooks with Sentry and ngrok](#run-webhook) section to create and resolve an issue.

--- a/docs/integrations/shopify/webhooks.mdx
+++ b/docs/integrations/shopify/webhooks.mdx
@@ -150,10 +150,21 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Webhooks** section of the **Notifications** page, Shopify shows a value after the **All your webhooks will be signed with** message. Copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your signing secret}` with the value you copied before:
+1. Create a traffic policy file named `shopify_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: shopify
+             secret: "{your signing secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook shopify --verify-webhook-secret {your signing secret}
+   ngrok http 3000 --traffic-policy-file shopify_policy.yml
    ```
 
 1. Access your Shopify store admin page, click **Products** in the left menu, and then create a new product.

--- a/docs/integrations/signalsciences/webhooks.mdx
+++ b/docs/integrations/signalsciences/webhooks.mdx
@@ -135,10 +135,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhook** page, click the eye icon to reveal the **secret key** value and then copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you have copied before:
+1. Create a traffic policy file named `signalsciences_policy.yml`, replacing `{your webhook secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: signalsciences
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook signalsciences --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file signalsciences_policy.yml
    ```
 
 1. Access the [Signal Sciences Dashboard](https://dashboard.signalsciences.net/), sign in, and change your site display name.

--- a/docs/integrations/slack/webhooks.mdx
+++ b/docs/integrations/slack/webhooks.mdx
@@ -143,10 +143,21 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic Information** page for your Slack app, click **Show** for the **Signing Secret** and copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{your signing secret}` with your **Signing Secret** from Slack:
+1. Create a traffic policy file named `slack_policy.yml` with the following content, replacing `{your signing secret}` with your **Signing Secret** from Slack:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: slack
+             secret: "{your signing secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook slack --verify-webhook-secret {your signing secret}
+   ngrok http 3000 --traffic-policy-file slack_policy.yml
    ```
 
 1. In your Slack app, select the **Slackbot**, write `Hello Slack bot!` in the message field, and then send it.

--- a/docs/integrations/sonatype-nexus/webhooks.mdx
+++ b/docs/integrations/sonatype-nexus/webhooks.mdx
@@ -141,10 +141,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhook** page, click the **Settings** tab, and then enter `12345` in the **Secret Key** field.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value of the **Secret Key** field:
+1. Create a traffic policy file named `sonatype_nexus_policy.yml`, replacing `{your webhook secret}` with the value of the **Secret Key** field:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: sonatype_nexus
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook sonatype_nexus --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file sonatype_nexus_policy.yml
    ```
 
 1. On the **Sonatype Nexus Repository Manager** user interface, click **Repository** on the left menu and then click **Repositories**. In this example, click **apt (hosted)**.

--- a/docs/integrations/square/webhooks.mdx
+++ b/docs/integrations/square/webhooks.mdx
@@ -147,10 +147,23 @@ This is a quick step to add extra protection to your application.
 1. On your application page, scroll down until you find **Access token**, click **Show** for this field, and then copy the **Access token** value.
    **Tip**: Depending on the environment you choose the name of the field is either **Sandbox Access token** or **Production Access token**.
 
-1. Restart your ngrok agent by running the command, replacing `{your access token}` with the value you copied before:
+1. Create a traffic policy file named `square_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: square
+             secret: {your access token}
+   ```
+
+   **Note**: Replace `{your access token}` with the value you copied before.
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook square --verify-webhook-secret {your access token}
+   ngrok http 3000 --traffic-policy-file square_policy.yml
    ```
 
 1. Access the [Square Dashboard](https://squareup.com/dashboard/) page and create a new item.

--- a/docs/integrations/stripe/webhooks.mdx
+++ b/docs/integrations/stripe/webhooks.mdx
@@ -148,10 +148,21 @@ This is a quick step to add extra protection to your application.
 
 1. In the Webhook page for your webhook, click **Reveal** under **Signing secret**, and copy the value that appears.
 
-1. Restart your ngrok agent by running the command, replacing `{your signing secret}` with your **Signing secret** from Stripe:
+1. Create a traffic policy file named `stripe_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: stripe
+             secret: "{your signing secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook stripe --verify-webhook-secret {your signing secret}
+   ngrok http 3000 --traffic-policy-file stripe_policy.yml
    ```
 
 1. In your Stripe dashboard, click **Products** in the top menu and then create a new product.

--- a/docs/integrations/svix/webhooks.mdx
+++ b/docs/integrations/svix/webhooks.mdx
@@ -147,10 +147,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the left menu, click **Incoming Webhooks**, click the URL of your webhook, click the eye icon under the **Signing Secret** section, and then copy the value of the signing secret.
 
-1. Restart your ngrok agent by replacing `{your webhook secret}` with the value you copied before and running the following command:
+1. Create a traffic policy file named `svix_policy.yml`, replacing `{your webhook secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: svix
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the following command:
 
    ```bash
-   ngrok http 3000 --verify-webhook svix --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file svix_policy.yml
    ```
 
 1. Access the [Svix Dashboard](https://dashboard.svix.com/) and create a new endpoint.

--- a/docs/integrations/teams/webhooks.mdx
+++ b/docs/integrations/teams/webhooks.mdx
@@ -148,10 +148,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the **Security token** value you copied before (See [Integrate Microsoft Teams](#setup-webhook)):
+1. Create a traffic policy file named `teams_policy.yml` with the Microsoft Teams webhook verification configuration, replacing `{your app secret}` with the **Security token** value you copied before (See [Integrate Microsoft Teams](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: microsoft_teams
+             secret: "{your app secret}"
+   ```
+
+1. Restart your ngrok agent by running the command with the traffic policy:
 
    ```bash
-   ngrok http 3000 --url myexample.ngrok.app --verify-webhook microsoft_teams --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file teams_policy.yml
    ```
 
 1. Access the Microsoft Teams page you have assigned to your webhook and send a message to another Microsoft Teams user.

--- a/docs/integrations/terraform/webhooks.mdx
+++ b/docs/integrations/terraform/webhooks.mdx
@@ -143,10 +143,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **ngrok** notification page, enter `'12345` in the **Token** field and then click **Update notification**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook token}` with the value you have copied before (See [Integrate ngrok and Terraform Cloud.](#setup-webhook)):
+1. Create a traffic policy file named `terraform_policy.yml`, replacing `{your webhook token}` with the value you have copied before (See [Integrate ngrok and Terraform Cloud.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: terraform
+             secret: "{your webhook token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook terraform --verify-webhook-secret {your webhook token}
+   ngrok http 3000 --traffic-policy-file terraform_policy.yml
    ```
 
 1. On the top of the page, click **Actions** and then click **Start new run**.

--- a/docs/integrations/tiktok/webhooks.mdx
+++ b/docs/integrations/tiktok/webhooks.mdx
@@ -151,10 +151,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Manage apps** page, click your app tile, click the eye icon to reveal the **Client secret** value, and then copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you copied before:
+1. Create a traffic policy file named `tiktok_policy.yml`, replacing `{your webhook secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: tiktok
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook tiktok --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file tiktok_policy.yml
    ```
 
 1. Access your [TikTok](https://www.tiktok.com/) account and use the app. See [Run Webhooks with TikTok and ngrok](#run-webhook).

--- a/docs/integrations/trendmicro/webhooks.mdx
+++ b/docs/integrations/trendmicro/webhooks.mdx
@@ -144,10 +144,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Send notification to** popup, enter `12345` in the **Webhook Security Token** field and then click **Save**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook token}` with the value of the **Webhook Security Token** field:
+1. Create a traffic policy file named `trendmicro_policy.yml`, replacing `{your webhook token}` with the value of the **Webhook Security Token** field:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: trendmicro_conformity
+             secret: "{your webhook token}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook trendmicro_conformity --verify-webhook-secret {your webhook token}
+   ngrok http 3000 --traffic-policy-file trendmicro_policy.yml
    ```
 
 1. Access the [Trend Micro Cloud One home](https://cloudone.trendmicro.com/home) page, click the **Conformity** tile, and then run the Conformity bot again.

--- a/docs/integrations/twilio/webhooks.mdx
+++ b/docs/integrations/twilio/webhooks.mdx
@@ -91,10 +91,21 @@ The webhook verification module allows ngrok to assert requests to your endpoint
 
 1. Login to [Twilio Console](https://console.twilio.com/) and copy your Auth Token value.<br />
    **Note:** ngrok Webhook Verification ensures traffic from your Twilio account is the **only traffic allowed** to make calls to your app. Because Twilio signs all Webhooks using the Primary Auth Token, ngrok can verifies the signature of every request and only authorizing requests originating from your Twilio account.
-2. Restart ngrok by running the command, replacing \{your auth token\} with your Twilio Auth Token:
+2. Create a traffic policy file named `twilio_policy.yml`:
+
+```yaml
+on_http_request:
+  - actions:
+      - type: verify-webhook
+        config:
+          provider: twilio
+          secret: "{your auth token}"
+```
+
+3. Restart ngrok by running the command:
 
 ```bash
-   ngrok http 3000 --verify-webhook twilio --verify-webhook-secret {your auth token}
+   ngrok http 3000 --traffic-policy-file twilio_policy.yml
 ```
 
 ### Inspecting requests

--- a/docs/integrations/twitter/webhooks.mdx
+++ b/docs/integrations/twitter/webhooks.mdx
@@ -174,10 +174,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Webhooks** page, click **Copy** to copy the **Secret** value.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value you copied before:
+1. Create a traffic policy file named `twitter_policy.yml`, replacing `{your webhook secret}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: twitter
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook twitter --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file twitter_policy.yml
    ```
 
 1. Access [X](https://www.twitter.com/) and post a new tweet.

--- a/docs/integrations/typeform/webhooks.mdx
+++ b/docs/integrations/typeform/webhooks.mdx
@@ -142,10 +142,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value of the **secret** attribute you provided in the webhook registration (See [Integrate ngrok and Typeform.](#setup-webhook)):
+1. Create a traffic policy file named `typeform_policy.yml`, replacing `{your webhook secret}` with the value of the **secret** attribute you provided in the webhook registration (See [Integrate ngrok and Typeform.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: typeform
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook typeform --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file typeform_policy.yml
    ```
 
 1. Access your form URL, answer the questions of your typeform, and then click **Submit** at the end of the form flow.

--- a/docs/integrations/vmware/webhooks.mdx
+++ b/docs/integrations/vmware/webhooks.mdx
@@ -157,10 +157,21 @@ This is a quick step to add extra protection to your application.
 
 1. On the **Edit Event Notification** page, enter a username in the **Username** field, enter a password in the **Password**, enter the same password in the **Confirm Password** field, and then click **SAVE**.
 
-1. Restart your ngrok agent by running the command, replacing `{username}` and `{password}` with the corresponding values you provided before:
+1. Create a traffic policy file named `vmware_policy.yml`, replacing `{username}` and `{password}` with the corresponding values you provided before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: vmware_workspace
+             secret: "{username}::{password}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook vmware_workspace --verify-webhook-secret {username}::{password}
+   ngrok http 3000 --traffic-policy-file vmware_policy.yml
    ```
 
 1. Access [VMware Workspace ONE](https://console.cloud.vmware.com/), register a new user to your device, and ask the user to enroll the device.

--- a/docs/integrations/webex/webhooks.mdx
+++ b/docs/integrations/webex/webhooks.mdx
@@ -146,10 +146,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` the **SECRET_KEY** value you provided during the webhook registration (See [Integrate ngrok and Cisco Webex.](#setup-webhook)):
+1. Create a traffic policy file named `webex_policy.yml`, replacing `{your webhook secret}` with the **SECRET_KEY** value you provided during the webhook registration (See [Integrate ngrok and Cisco Webex.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: webex
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook webex --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file webex_policy.yml
    ```
 
 1. Access [Cisco Webex](https://www.webex.com), sign in, and then click **Start a meeting**.

--- a/docs/integrations/whatsapp/webhooks.mdx
+++ b/docs/integrations/whatsapp/webhooks.mdx
@@ -170,10 +170,22 @@ This is a quick step to add extra protection to your application.
 
 1. In the **Basic Settings** page, click **Show** to reveal the **App secret** value and copy this value.
 
-1. Restart your ngrok agent by running the command, replacing `{your app secret}` with the value you have copied before:
+1. Create a traffic policy file named `whatsapp_policy.yml`, replacing `{your app secret}` with the value you have copied before:
+
+   ```yaml
+   on_http_request:
+     - name: "WhatsApp Webhooks"
+       actions:
+         - type: "webhook-validation"
+           config:
+             provider: facebook_graph_api
+             secret: "{your app secret}"
+   ```
+
+2. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --url myexample.ngrok.app --verify-webhook FACEBOOK_GRAPH_API --verify-webhook-secret {your app secret}
+   ngrok http 3000 --traffic-policy-file whatsapp_policy.yml
    ```
 
 1. Access the WhatsApp page you have assigned to your webhook and send a message to another WhatsApp user.

--- a/docs/integrations/worldline/webhooks.mdx
+++ b/docs/integrations/worldline/webhooks.mdx
@@ -135,10 +135,21 @@ The ngrok signature webhook verification feature allows ngrok to assert that req
 
 This is a quick step to add extra protection to your application.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook secret}` with the value of the **Secret Webhook Key** (See [Integrate ngrok and Worldline.](#setup-webhook)):
+1. Create a traffic policy file named `worldline_policy.yml`, replacing `{your webhook secret}` with the value of the **Secret Webhook Key** (See [Integrate ngrok and Worldline.](#setup-webhook)):
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: worldline
+             secret: "{your webhook secret}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook worldline --verify-webhook-secret {your webhook secret}
+   ngrok http 3000 --traffic-policy-file worldline_policy.yml
    ```
 
 1. Access [Worldline](https://www.worldline.com/), sign in, create a new payment link, open the link in a new browser tab, and select **Bancontact** as the payment method.

--- a/docs/integrations/xero/webhooks.mdx
+++ b/docs/integrations/xero/webhooks.mdx
@@ -164,10 +164,23 @@ This is a quick step to add extra protection to your application.
 
 1. Copy the value of the **Webhooks key**.
 
-1. Restart your ngrok agent by running the command, replacing `{your webhook key}` with the value you have copied before:
+1. Create a traffic policy file named `xero_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: xero
+             secret: {your webhook key}
+   ```
+
+   **Note**: Replace `{your webhook key}` with the value you copied before.
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook xero --verify-webhook-secret {your webhook key}
+   ngrok http 3000 --traffic-policy-file xero_policy.yml
    ```
 
 1. Access the [Xero dashboard](https://go.xero.com/) and create a new contact.

--- a/docs/integrations/zendesk/webhooks.mdx
+++ b/docs/integrations/zendesk/webhooks.mdx
@@ -170,10 +170,21 @@ This is a quick step to add extra protection to your application.
 
 1. In your webhook page, click **Reveal secret** and click **Copy** to copy the **Secret key** value.
 
-1. Restart your ngrok agent by running the command, replacing `{your secret key}` with the value you copied before:
+1. Create a traffic policy file named `zendesk_policy.yml`, replacing `{your secret key}` with the value you copied before:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: zendesk
+             secret: "{your secret key}"
+   ```
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook zendesk --verify-webhook-secret {your secret key}
+   ngrok http 3000 --traffic-policy-file zendesk_policy.yml
    ```
 
 1. Execute the procedures in the [Run Webhooks with Zendesk and ngrok](#run-webhooks-with-zendesk-and-ngrok-) section to create a new ticket.

--- a/docs/integrations/zoom/webhooks.mdx
+++ b/docs/integrations/zoom/webhooks.mdx
@@ -159,10 +159,23 @@ This is a quick step to add extra protection to your application.
 
 1. Make sure you have copied the **Secret Token** value when you were configuring your Webhook app in Zoom.
 
-1. Restart your ngrok agent by running the command, replacing `{your secret token}` with your **Secret Token** from Zoom:
+1. Create a traffic policy file named `zoom_policy.yml`:
+
+   ```yaml
+   on_http_request:
+     - actions:
+         - type: verify-webhook
+           config:
+             provider: zoom
+             secret: "{your secret token}"
+   ```
+
+   **Note**: Replace `{your secret token}` with your **Secret Token** from Zoom.
+
+1. Restart your ngrok agent by running the command:
 
    ```bash
-   ngrok http 3000 --verify-webhook zoom --verify-webhook-secret {your secret token}
+   ngrok http 3000 --traffic-policy-file zoom_policy.yml
    ```
 
 1. In your Zoom dashboard, start a new meeting, and after a few seconds end the meeting.


### PR DESCRIPTION
generated with the help of Amp.

this updates all the examples in the webhook guides to use policy instead of the command line flags.