### PR TITLE
Remove congratulations and fix header structures

### DIFF
--- a/docs/guides/other-guides/dashboard-sso-okta-setup.md
+++ b/docs/guides/other-guides/dashboard-sso-okta-setup.md
@@ -9,7 +9,7 @@ This should not be confused with configuring an ngrok endpoint so [application u
 - Admin access to edit your ngrok account settings
 - An [ngrok Enterprise](https://ngrok.com/pricing) account
 
-## Create a new SAML App Integration in Okta
+## 1. Create a new SAML App Integration in Okta
 
 1. From the "Applications" menu, click the blue "Create App Integration" button.
    ![](/img/howto/dash-sso/okta-create-app.png)
@@ -21,7 +21,7 @@ This should not be confused with configuring an ngrok endpoint so [application u
    ![](/img/howto/dash-sso/okta-nameid-format.png)
 1. Select "This is an internal app that we have created" and click "Finish".
 
-## Download your SAML App metadata XML
+## 2. Download your SAML App metadata XML
 
 1. Navigate to the "Sign On" Tab on the new app and click on "Actions" under the Active SHA-2 certificate
 1. Click "View IdP metadata".
@@ -29,7 +29,7 @@ This should not be confused with configuring an ngrok endpoint so [application u
 1. In that new window, Select "Save As" from the File menu to save your metadata.xml file for uploading into ngrok in a later step.  
    ![](/img/howto/dash-sso/okta-save-as-xml.png)
 
-## Configure Single Sign-On (SSO) for your ngrok account
+## 3. Configure Single Sign-On (SSO) for your ngrok account
 
 1. Log into your ngrok dashboard and navigate to the ["Settings > Account"](https://dashboard.ngrok.com/settings) section in the left navigation menu.
    ![](/img/howto/dash-sso/okta-ngrok-account-settings.png)
@@ -40,7 +40,7 @@ This should not be confused with configuring an ngrok endpoint so [application u
 1. Click "Save". Clicking Save will create the integration and generate the required URLs for your Okta Application.
    ![](/img/howto/dash-sso/okta-ngrok-required-urls.png)
 
-## Add the ngrok generated URLs to your Okta SAML application
+## 4. Add the ngrok generated URLs to your Okta SAML application
 
 1. Back in your Okta account, on the "General" tab of your Okta app, click on "Edit" under "SAML Settings"
    ![](/img/howto/dash-sso/okta-edit-app.png)

--- a/docs/guides/other-guides/dashboard-sso-okta-setup.md
+++ b/docs/guides/other-guides/dashboard-sso-okta-setup.md
@@ -3,7 +3,7 @@
 This guide walks you through configuring the ngrok dashboard to use Okta as an identity provider and enable single sign-on for your ngrok account.
 This should not be confused with configuring an ngrok endpoint so [application users can log in using Okta](/integrations/okta/sso-oidc).
 
-The requirements for completing this guide are:
+## What you'll need
 
 - Admin access to create new applications in Okta
 - Admin access to edit your ngrok account settings
@@ -49,6 +49,6 @@ The requirements for completing this guide are:
    ![](/img/howto/dash-sso/okta-temp-urls.png)
 1. Click "Next". Click "Finish".
 
-Congratulations, you should now be configured property to log into your ngrok account using Okta!
+You should now be configured to log into your ngrok account using Okta.
 
 By default, your ngrok account will still allow users to log in with their existing credentials as well as through Okta ("Mixed Mode"). Once you verify that everything is working properly with your integration, you can enable "SSO Enforced" in the ngrok Dashboard which will require all new users to log in through Okta for their ngrok account.

--- a/docs/integrations/auth0/dashboard-sso.mdx
+++ b/docs/integrations/auth0/dashboard-sso.mdx
@@ -53,6 +53,6 @@ The requirements for completing this guide are:
       }
       ```
 
-Congratulations, you should now be configured to log into your ngrok account using Auth0!
+You should now be configured to log into your ngrok account using Auth0.
 
 By default, your ngrok account will still allow users to log in with their existing credentials as well as through Auth0 ("Mixed Mode"). Once you verify that everything is working properly with your integration, you can enable "SSO Enforced" in the ngrok Dashboard which will require all new users to log in through Auth0 for their ngrok account.

--- a/docs/integrations/auth0/dashboard-sso.mdx
+++ b/docs/integrations/auth0/dashboard-sso.mdx
@@ -3,17 +3,16 @@ title: Configure Auth0 Single Sign-On with SAML
 description: Configure Single Sign-On for your ngrok dashboard using Auth0 as the Identity Provider
 ---
 
-# Configuring Auth0 Single Sign-On (SSO) with SAML
+This guide walks you through configuring the ngrok dashboard to use Auth0 as an identity provider and enable single sign-on within SAML for your ngrok account. 
+This should not be confused with configuring an ngrok endpoint to allow your application users to log in using Auth0.
 
-This guide will walk you through configuring the ngrok dashboard to use Auth0 as an identity provider and enable single sign-on within SAML for your ngrok account. This should not be confused with configuring an ngrok endpoint to allow your application users to log in using Auth0.
-
-The requirements for completing this guide are:
+## What you'll need
 
 - Admin access to create new applications in Auth0
 - Admin access to edit your ngrok account settings
 - An ngrok Enterprise account
 
-## Create an Application in Auth0
+## 1. Create an Application in Auth0
 
 1. From the "Applications" menu, click the blue "Create Application" button.
    ![Create Application](img/auth0app.png)
@@ -25,7 +24,7 @@ The requirements for completing this guide are:
 
 4. In the popup window on the Usage tab download the Identity Provider Metadata from the provided link.
 
-## Configure Single Sign-On (SSO) for your ngrok account
+## 2. Configure Single Sign-On (SSO) for your ngrok account
 
 1. Log into your ngrok dashboard and navigate to the "Settings > Account" section in the left navigation menu.
 2. Select "+ New Identity Provider" button to add a new SAML identity provider.
@@ -36,7 +35,7 @@ The requirements for completing this guide are:
 5. Click "Save". Clicking Save will create the integration and generate the required URLs for your Auth0 Application.
    ![Enter SP Information](img/save_saml.png)
 
-## Add the ngrok generated URLs to your Auth0 SAML application
+## 3. Add the ngrok generated URLs to your Auth0 SAML application
 
 1. Back in your Auth0 account, select your Application and click on the Addons tab. Again select the SAML2 Web App. In the popup window select the Settings tab.
    1. Paste in the Application Callback URL (ACS) obtained from the ngrok IdP settings - SAML Provider/Service Provider - ACS URL as seen above.
@@ -55,4 +54,5 @@ The requirements for completing this guide are:
 
 You should now be configured to log into your ngrok account using Auth0.
 
-By default, your ngrok account will still allow users to log in with their existing credentials as well as through Auth0 ("Mixed Mode"). Once you verify that everything is working properly with your integration, you can enable "SSO Enforced" in the ngrok Dashboard which will require all new users to log in through Auth0 for their ngrok account.
+By default, your ngrok account will still allow users to log in with their existing credentials as well as through Auth0 ("Mixed Mode"). 
+Once you verify that everything is working properly with your integration, you can enable "SSO Enforced" in the ngrok Dashboard which will require all new users to log in through Auth0 for their ngrok account.

--- a/docs/integrations/auth0/dashboard-sso.mdx
+++ b/docs/integrations/auth0/dashboard-sso.mdx
@@ -3,7 +3,7 @@ title: Configure Auth0 Single Sign-On with SAML
 description: Configure Single Sign-On for your ngrok dashboard using Auth0 as the Identity Provider
 ---
 
-This guide walks you through configuring the ngrok dashboard to use Auth0 as an identity provider and enable single sign-on within SAML for your ngrok account. 
+This guide walks you through configuring the ngrok dashboard to use Auth0 as an identity provider and enable single sign-on within SAML for your ngrok account.
 This should not be confused with configuring an ngrok endpoint to allow your application users to log in using Auth0.
 
 ## What you'll need
@@ -54,5 +54,5 @@ This should not be confused with configuring an ngrok endpoint to allow your app
 
 You should now be configured to log into your ngrok account using Auth0.
 
-By default, your ngrok account will still allow users to log in with their existing credentials as well as through Auth0 ("Mixed Mode"). 
+By default, your ngrok account will still allow users to log in with their existing credentials as well as through Auth0 ("Mixed Mode").
 Once you verify that everything is working properly with your integration, you can enable "SSO Enforced" in the ngrok Dashboard which will require all new users to log in through Auth0 for their ngrok account.

--- a/docs/integrations/salesforce/ssowithendpoints.mdx
+++ b/docs/integrations/salesforce/ssowithendpoints.mdx
@@ -88,7 +88,7 @@ traffic_policy:
 ```
 
 6. Replace `<your-salesforce-issuer-url>`, `<your-salesforce-client-id>`, and `<your-salesforce-client-secret>` with the values you obtained from Salesforce in the previous steps. The issuer URL will follow the format: `https://[yourdomain]-dev-ed.develop.my.salesforce.com`
-7. Click save. 
+7. Click save.
 
 You have now successfully created a cloud endpoint with OIDC traffic policy action using Salesforce as an IdP.
 

--- a/docs/integrations/salesforce/ssowithendpoints.mdx
+++ b/docs/integrations/salesforce/ssowithendpoints.mdx
@@ -88,7 +88,9 @@ traffic_policy:
 ```
 
 6. Replace `<your-salesforce-issuer-url>`, `<your-salesforce-client-id>`, and `<your-salesforce-client-secret>` with the values you obtained from Salesforce in the previous steps. The issuer URL will follow the format: `https://[yourdomain]-dev-ed.develop.my.salesforce.com`
-7. Hit save and congratulations! You have successfully created a cloud endpoint with OIDC traffic policy action using Salesforce as an IdP.
+7. Click save. 
+
+You have now successfully created a cloud endpoint with OIDC traffic policy action using Salesforce as an IdP.
 
 ### (Optional) Configure an Agent Endpoint with Salesforce OAuth from the CLI
 

--- a/docs/integrations/salesforce/ssowithendpoints.mdx
+++ b/docs/integrations/salesforce/ssowithendpoints.mdx
@@ -3,40 +3,40 @@ title: Secure ngrok Endpoints using Salesforce OpenID Connect
 description: Use Salesforce's managed applications to add SSO for your ngrok resources
 ---
 
-In this guide you will use Salesforce as:
+In this guide shows you how to use Salesforce as:
 
 - An OAuth provider along with the ngrok OIDC traffic policy action to secure your ngrok resources.
 - The primary IdP for your endpoints. The OIDC traffic policy action will supplement an ID token that will be used to identify users that log in to your endpoint.
 
-Since Salesforce is currently not a supported OAuth provider by ngrok, this will allow you to leverage its OAuth capabilities and add an extra layer of authorization to your endpoints.
+Since Salesforce is currently not a supported OAuth provider by ngrok, this allows you to leverage its OAuth capabilities and add an extra layer of authorization to your endpoints.
 
-### Why Should I Use OIDC to Secure My Endpoints?
+## Why use OIDC to secure your endpoints
 
 The OIDC traffic policy action allows you to control access to your upstream services and also configure routing based on the information that ngrok stores about user’s authentication/authorization status.
 
-### Why Am I Using Salesforce as an IdP?
+## Why use Salesforce as an IdP
 
 Using salesforce OAuth enables you to give users of your application, API, Database, SSO without needed separate credentials. Ngrok also handles that authentication transparently. Your organization’s personnel in charge of security and administration can also manage all external application integrations from one place.
 
-## What you'll need:
+## What you'll need
 
 - a Salesforce developer account with administrative rights to create apps
 - An ngrok Enterprise Account with an authtoken or admin access to configure an endpoint with Traffic Policy and OpenID Connect.
 
-### 1. Create a Salesforce External Client App
+## 1. Create a Salesforce External Client App
 
 1. Navigate to the **App Manager** in Salesforce.
 2. Click on **New External Client App**.
 
 ![Salesforce Setup](img/external_client_create.png)
 
-### 2. Configure the External Client App
+## 2. Configure the External Client App
 
 1. Go to the **Policies** tab in your Salesforce dashboard
 2. Go to **App Policies**
 3. Set the start page to OAuth
 
-### 3. Configure OAuth Settings
+## 3. Configure OAuth Settings
 
 1. In the Basic Information Section
    - Set the external client app name to `ngrok` or whatever you would like
@@ -55,17 +55,17 @@ Using salesforce OAuth enables you to give users of your application, API, Datab
      - Require secret for Refresh Token Flow
      - Make sure Require Proof Key for Code Exchange (PKCE) is not enabled, as this will throw an error when you log in to your endpoint
 
-### 4. Verify your Salesforce External Client Application Configuration
+## 4. Verify your Salesforce External Client Application Configuration
 
 ![Final OAuth Config](img/oauthconfig.png)
 
-### 5. Obtain the Client ID and Client Secret
+## 5. Obtain the Client ID and Client Secret
 
 1. After saving your external client app, go to **Settings** and then under **OAuth Settings** click on the following button to see your Client ID and Client Secret:
 
 ![Client ID and Client Secret](img/keyandsecret.png)
 
-### 6. Create a Cloud Endpoint and Configure OIDC Traffic Policy Action
+## 6. Create a Cloud Endpoint and Configure OIDC Traffic Policy Action
 
 1. Log in to your ngrok dashboard and navigate to the **Endpoints** section.
 2. Click on **Create Endpoint**.
@@ -92,7 +92,7 @@ traffic_policy:
 
 You have now successfully created a cloud endpoint with OIDC traffic policy action using Salesforce as an IdP.
 
-### (Optional) Configure an Agent Endpoint with Salesforce OAuth from the CLI
+## (Optional) Configure an Agent Endpoint with Salesforce OAuth from the CLI
 
 You can also use the following command to start an agent endpoint with the same credentials you used in your traffic policy. To learn more about when
 to use Agent vs Cloud endpoints, check out our [documentation on endpoints](https://ngrok.com/docs/universal-gateway/endpoints/).

--- a/docs/integrations/teams/webhooks.mdx
+++ b/docs/integrations/teams/webhooks.mdx
@@ -28,7 +28,7 @@ By integrating ngrok with Microsoft Teams, you can:
 - **Modify and Replay Microsoft Teams Webhook requests** with a single click and without spending time reproducing events manually in your Microsoft Teams account.
 - **Secure your app with Microsoft Teams validation provided by ngrok**. Invalid requests are blocked by ngrok before reaching your app.
 
-## **Step 1**: Start your app {#start-your-app}
+## 1. Start your app {#start-your-app}
 
 For this tutorial, we'll use the [sample NodeJS app available on GitHub](https://github.com/ngrok/ngrok-webhook-nodejs-sample).
 
@@ -40,7 +40,7 @@ cd ngrok-webhook-nodejs-sample
 npm install
 ```
 
-This will get the project installed locally.
+This installs the project locally.
 
 Now you can launch the app by running the following command:
 
@@ -48,17 +48,19 @@ Now you can launch the app by running the following command:
 npm start
 ```
 
-The app runs by default on port 3000.
+The app runs on port 3000 by default.
 
 You can validate that the app is up and running by visiting http://localhost:3000. The application logs request headers and body in the terminal and responds with a message in the browser.
 
-## **Step 2**: Launch ngrok {#start-ngrok}
+## 2. Launch ngrok {#start-ngrok}
 
-Once your app is running successfully on localhost, let's get it on the internet securely using ngrok!
+Now that your app is running locally, you can put it on the internet securely with ngrok.
 
-**Note:** This integration requires an ngrok Pro or Enterprise license because Microsoft Teams validates your ngrok domain and certificate.
+:::info
+This integration requires an ngrok Pro or Enterprise license because Microsoft Teams validates your ngrok domain and certificate.
+:::
 
-1. If you're not an ngrok user yet, just [sign up for ngrok for free](https://ngrok.com/signup).
+1. If you're not an ngrok user yet, [sign up for ngrok for free](https://ngrok.com/signup).
 
 1. [Download the ngrok agent](https://download.ngrok.com).
 
@@ -85,7 +87,7 @@ Once your app is running successfully on localhost, let's get it on the internet
 1. ngrok will display a URL where your localhost application is exposed to the internet (copy this URL for use with Microsoft Teams).
    ![ngrok agent running](/img/integrations/launch_ngrok_tunnel_domain.png)
 
-## **Step 3**: Integrate Microsoft Teams {#setup-webhook}
+## 3. Integrate Microsoft Teams {#setup-webhook}
 
 To register a webhook on your Microsoft Teams account follow the instructions below:
 
@@ -104,7 +106,7 @@ To register a webhook on your Microsoft Teams account follow the instructions be
 
 1. On the **Congratulations** popup, make note of the **Security token** value and then click **Close**.
 
-### Run Webhooks with Microsoft Teams and ngrok
+## Run Webhooks with Microsoft Teams and ngrok
 
 Microsoft teams Outgoing Webhook acts as a bot sending any text you type using `@mention`. It sends notifications to your local application through ngrok.
 
@@ -119,6 +121,7 @@ Confirm your localhost app receives a notification call and logs both headers an
 <InspectingRequests />
 
 <ReplayingRequests />
+
 ## Secure webhook requests {#security}
 
 The ngrok signature webhook verification feature allows ngrok to assert that requests from your Microsoft Teams webhook are the only traffic allowed to make calls to your localhost app.

--- a/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
@@ -6,14 +6,12 @@ pagination_next: traffic-policy/getting-started/agent-endpoints/config-file
 
 import { GettingStarted } from "/traffic-policy/getting-started/GettingStarted";
 
-# Getting Started with Agent Endpoints and Traffic Policy via CLI Flags
+## What you'll need
 
-## Prerequisites
+- An [ngrok account](https://dashboard.ngrok.com/).
+- The [ngrok Agent CLI](https://ngrok.com/download) installed.
 
-1. **ngrok Account** - Ensure you have an active [ngrok](https://dashboard.ngrok.com/) account.
-2. **ngrok Agent** - Download and install the [ngrok agent](https://ngrok.com/download) for your operating system.
-
-## Step 1: Create a Traffic Policy
+## 1. Create a Traffic Policy
 
 Create a custom traffic policy file with the following contents:
 
@@ -21,7 +19,7 @@ Create a custom traffic policy file with the following contents:
 
 This policy will respond to each HTTP request with a simple “Hello, World!” message.
 
-## Step 2: Apply Your Traffic Policy
+## 2. Apply your Traffic Policy
 
 Run the agent, applying the traffic policy you saved in the previous step with the `--traffic-policy-file` flag:
 
@@ -31,12 +29,12 @@ $ ngrok http 80 --traffic-policy-file policy.yml
 
 This command starts an HTTP tunnel for port `80`, using the specified `policy.yml` traffic policy to manage traffic.
 
-## Step 3: Test it out
+## 3. Test it out
 
 After running the ngrok command in the previous step you should now see a URL in the forwarding section. Open the URL
 in your web browser. You should see the "Hello, World!" message displayed in your browser.
 
-# What's next?
+## What's next?
 
 You've now successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent.
 

--- a/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/cli.mdx
@@ -36,11 +36,9 @@ This command starts an HTTP tunnel for port `80`, using the specified `policy.ym
 After running the ngrok command in the previous step you should now see a URL in the forwarding section. Open the URL
 in your web browser. You should see the "Hello, World!" message displayed in your browser.
 
-# Next Steps
+# What's next?
 
-**🎉 Congratulations!**
-
-You've successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent.
+You've now successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent.
 
 To learn more about ngrok's Traffic Policy and its capabilities, check out the following resources:
 

--- a/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
@@ -3,16 +3,14 @@ title: Getting Started with Agent Endpoints and Traffic Policy via Configuration
 sidebar_label: via Configuration File
 ---
 
-# Getting Started with Agent Endpoints and Traffic Policy via Configuration File
-
 The following getting started guide will take you through starting an Agent Endpoint with a Traffic Policy applied via the [Agent Configuration File](/agent/config/). Note, this guide requires that your agent configuration file is set to [v3](/agent/config/v3).
 
-## Prerequisites
+## What you'll need
 
-1. **ngrok Account** - Ensure you have an active [ngrok](https://dashboard.ngrok.com/) account.
-2. **ngrok Agent** - Download and install the [ngrok agent](https://ngrok.com/download) for your operating system.
+- An [ngrok account](https://dashboard.ngrok.com/).
+- The [ngrok Agent CLI](https://ngrok.com/download) installed.
 
-## Step 1: Edit your ngrok Configuration File
+## 1. Edit your ngrok configuration file
 
 Enter the following command into your terminal:
 
@@ -45,7 +43,7 @@ Your configuration file `version` must be set to `3`.
 
 :::
 
-## Step 2: Start your Agent Endpoint
+## 2. Start your Agent Endpoint
 
 Start your Agent Endpoint by running the following command:
 
@@ -55,11 +53,11 @@ ngrok start my-agent-endpoint
 
 This command will start an HTTP tunnel for port `80`, using the specified traffic policy in the config file to manage traffic.
 
-## Step 3: Test it out
+## 3. Test it out
 
 After running the ngrok command in the previous step you should now see a URL in the forwarding section. Open the URL in your web browser. You should see the "Hello, World!" message displayed in your browser.
 
-# What's next?
+## What's next?
 
 You've now successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent configuration file.
 

--- a/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
+++ b/docs/traffic-policy/getting-started/agent-endpoints/config-file.mdx
@@ -59,11 +59,9 @@ This command will start an HTTP tunnel for port `80`, using the specified traffi
 
 After running the ngrok command in the previous step you should now see a URL in the forwarding section. Open the URL in your web browser. You should see the "Hello, World!" message displayed in your browser.
 
-# Next Steps
+# What's next?
 
-**🎉 Congratulations!**
-
-You've successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent configuration file.
+You've now successfully set up your first Agent Endpoint with a custom Traffic Policy using the ngrok agent configuration file.
 
 To learn more about ngrok's Traffic Policy and its capabilities, check out the following resources:
 

--- a/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
+++ b/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
@@ -50,11 +50,9 @@ ngrok api endpoints create \
 Once you have created your Cloud Endpoint you can now open the URL
 in your web browser. You should see the "Hello, World!" message displayed in your browser.
 
-# Next Steps
+# What's next?
 
-**🎉 Congratulations!**
-
-You've successfully set up your first Cloud Endpoint with a custom Traffic Policy via the API.
+You've now successfully set up your first Cloud Endpoint with a custom Traffic Policy via the API.
 
 To learn more about ngrok's Traffic Policy and its capabilities, check out the following resources:
 

--- a/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
+++ b/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
@@ -46,7 +46,7 @@ ngrok api endpoints create \
 ## 4. Test it out
 
 Once you have created your Cloud Endpoint you can now open the URL
-in your web browser. 
+in your web browser.
 You should see the "Hello, World!" message displayed in your browser.
 
 ## What's next?

--- a/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
+++ b/docs/traffic-policy/getting-started/cloud-endpoints/api.mdx
@@ -3,16 +3,14 @@ title: Getting Started with Cloud Endpoints and Traffic Policy via API
 sidebar_label: via API
 ---
 
-# Getting Started with Cloud Endpoints and Traffic Policy via API
+## What you'll need
 
-## Prerequisites
+- An [ngrok account](https://dashboard.ngrok.com/).
+- The [ngrok Agent CLI](https://ngrok.com/download) installed.
+- Your [ngrok API key](https://dashboard.ngrok.com/api-keys).
+- A [reserved domain](https://dashboard.ngrok.com/domains).
 
-1. **ngrok Account** - Ensure you have an active [ngrok](https://dashboard.ngrok.com/) account.
-2. **ngrok Agent** - Download and install the [ngrok agent](https://ngrok.com/download) for your operating system.
-3. **ngrok API Key** - Create an [API key](https://dashboard.ngrok.com/api-keys) via the dashboard.
-4. **A Reserved Domain** - You'll need to [reserve a domain](https://dashboard.ngrok.com/domains) via the dashboard.
-
-## Step 1: Add your API key to the Agent
+## 1. Add your API key to the Agent
 
 Create an [API key on your ngrok dashboard](https://dashboard.ngrok.com/api-keys) and then run the following in your terminal:
 
@@ -20,7 +18,7 @@ Create an [API key on your ngrok dashboard](https://dashboard.ngrok.com/api-keys
 ngrok config add-api-key <your-api-key>
 ```
 
-## Step 2: Create your Traffic Policy file
+## 2. Create your Traffic Policy file
 
 Create a file named `policy.yml` with the following contents:
 
@@ -35,7 +33,7 @@ on_http_request:
 
 This will be the Traffic Policy used on your Cloud Endpoint to respond to each HTTP request with a simple “Hello, World!” message.
 
-## Step 3: Create your Cloud Endpoint via API
+## 3. Create your Cloud Endpoint via the API
 
 Create your Cloud Endpoint via the API by running the following in your terminal (make sure to replace `<your-reserve-domain>` with your reserved domain):
 
@@ -45,12 +43,13 @@ ngrok api endpoints create \
   --traffic-policy "$(<policy.yml)"
 ```
 
-## Step 4: Test it out
+## 4. Test it out
 
 Once you have created your Cloud Endpoint you can now open the URL
-in your web browser. You should see the "Hello, World!" message displayed in your browser.
+in your web browser. 
+You should see the "Hello, World!" message displayed in your browser.
 
-# What's next?
+## What's next?
 
 You've now successfully set up your first Cloud Endpoint with a custom Traffic Policy via the API.
 

--- a/docs/universal-gateway/kubernetes-endpoints.mdx
+++ b/docs/universal-gateway/kubernetes-endpoints.mdx
@@ -1,7 +1,5 @@
 # Kubernetes Endpoints
 
-## Overview
-
 Kubernetes endpoints are secure, private endpoints that are only addressable
 inside of Kubernetes clusters where you install the [Kubernetes
 operator](/k8s/). They enable you to connect to ngrok endpoints without making
@@ -15,7 +13,7 @@ Kubernetes endpoints have a
 Create a Kubernetes endpoint by specifying binding of `kubernetes` when you
 create an endpoint.
 
-#### Step 1: Install the ngrok Kubernetes Operator
+### 1. Install the ngrok Kubernetes Operator
 
 ```bash
 helm install ngrok-operator ngrok/ngrok-operator \
@@ -27,13 +25,13 @@ helm install ngrok-operator ngrok/ngrok-operator \
   --set credentials.authtoken=$NGROK_AUTHTOKEN
 ```
 
-#### Step 2: Create a new namespace
+### 2. Create a new namespace
 
 ```bash
 kubectl create ns prod
 ```
 
-#### Step 3: Create an ngrok endpoint
+### 3. Create an ngrok endpoint
 
 Run the following command in the same ngrok account to create the kubernetes
 bound endpoint. After the command completes, the ngrok operator will [create
@@ -44,7 +42,7 @@ endpoint's URL.
 ngrok http 80 --url http://customer-2.prod --binding kubernetes
 ```
 
-#### Step 4: Connect to the endpoint
+### 4. Connect to the endpoint
 
 Other pods in the Kubernetes cluster where the ngrok operator is running can
 connect to the bound endpoint.
@@ -74,7 +72,7 @@ The following restrictions are enforced:
   http://api.internal). Those endpoints will not conflict or
   [pool](/universal-gateway/endpoint-pooling).
 
-#### Examples
+### URL examples
 
 - `http://app.example`
 - `http://app.example:12345`
@@ -85,21 +83,21 @@ The following restrictions are enforced:
 - `http://app.foo.bar` - invalid hostname, must have only two parts
 - `tcp://app.example` - tcp endpoint must specify port number
 
-## Type and Pooling
+## Types and pooling
 
 - Kubernetes endpoints support all [Endpoint
   Types](/universal-gateway/types) (`agent` and `cloud`).
 - Kubernetes endpoints support [Endpoint
   Pooling](/universal-gateway/endpoint-pooling).
 
-## `Service` Creation
+## Service creation
 
 After a kubernetes-bound endpoint is created, the ngrok cloud service notifies
 Kubernetes Operators that a new kubernetes-bound endpoint exists. Kubernetes
 Operators create `v1.Service` objects in their Kubernetes clusters which
 forward traffic they receive to the operators' pods.
 
-#### `ClusterIP` Service
+### Cluster IP service
 
 A Cluster IP service is created in the operator's namespace.
 
@@ -118,9 +116,9 @@ spec:
       targetPort: <randomly-assigned> # assigned by operator to target the ngrok-operator-forwarder container
 ```
 
-#### `ExternalName` Service
+### External Name service
 
-An ExternalName service is created in the namespace targeted by the second part
+An External Name service is created in the namespace targeted by the second part
 of the URL's hostname.
 
 ```yaml
@@ -135,7 +133,7 @@ spec:
   externalName: <endpoint-id>.ngrok-operator.svc.cluster.local
 ```
 
-## How do I update endpoint selectors?
+## How to update endpoint selectors
 
 If you don't want all kubernetes endpoints in your account to appear inside of
 a cluster, you may specify an Endpoint Selector which filters which Kubernetes
@@ -146,15 +144,15 @@ account. The operator will only projects endpoints that the selector returns
 
 See [the docs on enabling bindings](/docs/k8s/guides/bindings/#enable-bindings-for-the-operator) to learn more.
 
-## How do I enable or disable Kubernetes endpoints on an existing installation?
+## How to enable or disable Kubernetes endpoints on an existing installation
 
 By default, if you don't change the default endpoint selector, all endpoints with a Kubernetes binding will be bound to the cluster the Operator is installed on. Changing the binding allows you to restrict which endpoints that operator will handle.
 
 See [the docs on enabling bindings](/docs/k8s/guides/bindings/#enable-bindings-for-the-operator) to learn more.
 
-## Coming Soon
+## Coming soon
 
-This feature is in developer preview, more documentation is coming soon.
+This feature is in developer preview—more documentation is coming soon.
 
 ## API
 

--- a/docs/universal-gateway/kubernetes-endpoints.mdx
+++ b/docs/universal-gateway/kubernetes-endpoints.mdx
@@ -54,8 +54,7 @@ $ kubectl run -i --tty --rm debug --restart=Never --image=appropriate/curl -- /b
 # curl http://customer-2.prod
 ```
 
-Congraulations, you just connected to your application via a private kubernetes
-endpoint!
+Now your application is connected via a private Kubernetes endpoint.
 
 ## URLs
 


### PR DESCRIPTION
remove "congratulations" - doesn't suit the style and tone of technical documentation. Also took the opportunity to do some light copyediting and fix inconsistent header structures on the affected pages.