### PR TITLE
Fix definition wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "validate-codeblocks:warnings": "tsx src/validate-codeblocks/index.ts --warnings",
     "validate-codeblocks:quiet": "tsx src/validate-codeblocks/index.ts --quiet",
     "test": "vitest run",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "clear-cache": "rm -rf .docusaurus node_modules/.cache",
+    "clear-cache-win": "rmdir /s /q \".docusaurus\" && rmdir /s /q \"node_modules\\.cache\""
   },
   "dependencies": {
     "@algolia/autocomplete-core": "1.19.1",

--- a/src/components/Definition/data.ts
+++ b/src/components/Definition/data.ts
@@ -1,4 +1,9 @@
 /**
+ * Because of the nature of docusaurus, to test changes here you have to
+ * stop the dev server, run `pnpm clear-cache` or `pnpm clear-cache-win` depending on your OS,
+ * and then restart the dev server.
+ */
+/**
  * Tip: When adding titles, make sure the longest variation is first in the array.
  */
 export type Term = {

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -31,6 +31,7 @@ const toReplace = (to) => (path, from) => path.replace(from, to); // abc/x -> xy
 const redirects = [
 	[fromIncludes("/docs/1"), "/docs/"],
 	[fromIncludes("/docs/2"), "/docs/"],
+	[fromIncludes("/docs/overview"), "/docs/"],
 	[fromIncludes("/docs/ngrok-link"), "/docs/universal-gateway/overview/"],
 	[fromIncludes("/docs/api/api-clients"), "/docs/api/#client-libraries"],
 	[fromIncludes("/docs/api/client-libraries"), "/docs/api/#client-libraries"],


### PR DESCRIPTION
Addresses issues in this slack thread:
- https://ngrok.slack.com/archives/C03LRGNSG6A/p1752619859317469

Changes:
- Updates definition wrapper script to not toss out the rest of the text if a matching term appears twice in one paragraph
- Adds a pnpm clear-cache script so it's easier to work on custom plugins. Docusaurus caches plugin output, so changes to custom plugins like the definition wrapper require clearing the cache and deleting the build folder every time