### PR TITLE
Redirect top level guides path

### DIFF
--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -1046,6 +1046,8 @@ const redirects = [
 		fromIncludes("/docs/guides/other-guides/dashboard-sso-okta-setup/"),
 		"/docs/integrations/okta/dashboard-sso-okta-setup",
 	],
+	// Just a redirect so the top-level guides path goes somewhere (there's no guides/index)
+	[fromIncludes("/docs/guides/"), "/docs/guides/api-gateway/get-started/"],
 ];
 
 // get current href from window


### PR DESCRIPTION
This was missed in this PR:
- https://github.com/ngrok/ngrok-docs/pull/1381/files#diff-ff69966805a57bad378b3a583c5ec56f4882cf83deb4a7f31f372aff8705163c