### PR TITLE
fix: oauth example syntax

### DIFF
--- a/docs/traffic-policy/examples/oauth-protection.mdx
+++ b/docs/traffic-policy/examples/oauth-protection.mdx
@@ -121,9 +121,7 @@ This section includes two examples of how to apply these additional auth lifecyc
 	config={{
 	"on_http_request": [
 		{
-			"match": {
-				"path": "/ngrok/logout"
-			},
+			"expressions": ["req.url.path == '/ngrok/logout'"],
 			"actions": [
 				{
 					"type": "redirect",


### PR DESCRIPTION
this was using the wrong syntax