### PR TITLE
Suggest checking '@domain' for email checks, not just 'domain'

### DIFF
--- a/docs/guides/identity-aware-proxy/securing-with-oauth.md
+++ b/docs/guides/identity-aware-proxy/securing-with-oauth.md
@@ -47,7 +47,7 @@ on_http_request:
         config:
           provider: google
   - expressions:
-      - "!(actions.ngrok.oauth.identity.email.endsWith('acme.com') || actions.ngrok.oauth.identity.email.endsWith('doe.com'))"
+      - "!(actions.ngrok.oauth.identity.email.endsWith('@acme.com') || actions.ngrok.oauth.identity.email.endsWith('@doe.com'))"
     actions:
       - type: deny
 ```

--- a/docs/guides/migration/modules-to-traffic-policy-actions.mdx
+++ b/docs/guides/migration/modules-to-traffic-policy-actions.mdx
@@ -53,7 +53,7 @@ on_http_request:
           - allowed_emails:
               - user@example.com
           - allowed_email_domains:
-              - example.com
+              - "example.com"
 
   # Run OAuth action for authentication
   - actions:
@@ -76,7 +76,7 @@ on_http_request:
           # Check whether the email is in the list of allowed emails
           - is_email_allowed: "${vars.allowed_emails && !(vars.identity.email in vars.allowed_emails)}"
           # Check whether the email domain is in the list of allowed email domains
-          - is_email_domain_allowed: "${vars.allowed_email_domains && !vars.allowed_email_domains.exists_one(i, (vars.identity.email.contains(i))}"
+          - is_email_domain_allowed: "${vars.allowed_email_domains && !vars.allowed_email_domains.exists_one(i, (vars.identity.email.endsWith('@' + i))}"
 
   # Check whether the email was allowed or the domain was allowed
   # Feel free to customize this to your liking!

--- a/docs/integrations/amazon-eks/eks.mdx
+++ b/docs/integrations/amazon-eks/eks.mdx
@@ -210,7 +210,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
            config:
              provider: google
          - expressions:
-             - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+             - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
            actions:
              - type: custom-response
                config:

--- a/docs/integrations/azure-aks/k8s.mdx
+++ b/docs/integrations/azure-aks/k8s.mdx
@@ -432,7 +432,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
             config:
               provider: google
           - expressions:
-              - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+              - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
             actions:
               - type: custom-response
                 config:

--- a/docs/integrations/consul/k8s.mdx
+++ b/docs/integrations/consul/k8s.mdx
@@ -352,7 +352,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
             config:
               provider: google
           - expressions:
-              - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+              - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
             actions:
               - type: custom-response
                 config:

--- a/docs/integrations/digitalocean/k8s.mdx
+++ b/docs/integrations/digitalocean/k8s.mdx
@@ -240,7 +240,7 @@ To demonstrate how ingress configuration and [OAuth support](/traffic-policy/act
            config:
              provider: google
          - expressions:
-             - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+             - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
            actions:
              - type: custom-response
                config:

--- a/docs/integrations/google-gke/google-kubernetes-engine.mdx
+++ b/docs/integrations/google-gke/google-kubernetes-engine.mdx
@@ -226,7 +226,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
            config:
              provider: google
          - expressions:
-             - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+             - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
            actions:
              - type: custom-response
                config:

--- a/docs/integrations/vcluster/k8s.md
+++ b/docs/integrations/vcluster/k8s.md
@@ -278,7 +278,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
            config:
              provider: google
          - expressions:
-             - "!actions.ngrok.oauth.identity.email.endsWith('example.com')"
+             - "!actions.ngrok.oauth.identity.email.endsWith('@example.com')"
            actions:
              - type: custom-response
                config:

--- a/docs/traffic-policy/examples/add-authentication.mdx
+++ b/docs/traffic-policy/examples/add-authentication.mdx
@@ -80,7 +80,7 @@ See [the `rate-limit` Traffic Policy action docs](/traffic-policy/actions/rate-l
 
 This rule grants conditional access to a page using the following ngrok [OAuth action result variables](/traffic-policy/actions/oauth):
 
-1. `actions.ngrok.oauth.identity.email.endsWith('ngrok.com')`
+1. `actions.ngrok.oauth.identity.email.endsWith('@ngrok.com')`
    1. Checks the email address of the authorized user from the provider. In the example, if the email address's domain is `ngrok.com`, the user will be granted access to the page.
 
 - `actions.ngrok.oauth.identity.name`
@@ -104,7 +104,7 @@ This rule grants conditional access to a page using the following ngrok [OAuth a
 			{
 				name: "good email",
 				expressions: [
-					"actions.ngrok.oauth.identity.email.endsWith('ngrok.com')",
+					"actions.ngrok.oauth.identity.email.endsWith('@ngrok.com')",
 				],
 				actions: [
 					{
@@ -119,7 +119,7 @@ This rule grants conditional access to a page using the following ngrok [OAuth a
 			{
 				name: "bad email",
 				expressions: [
-					"!actions.ngrok.oauth.identity.email.endsWith('ngrok.com')",
+					"!actions.ngrok.oauth.identity.email.endsWith('@ngrok.com')",
 				],
 				actions: [
 					{

--- a/docs/universal-gateway/examples/route-api-app-traffic-user-agent.mdx
+++ b/docs/universal-gateway/examples/route-api-app-traffic-user-agent.mdx
@@ -92,7 +92,7 @@ on_http_request:
   - expressions:
       # Check again whether the client's user agent contains 'Mozilla,' then also check whether the email they used in the OAuth flow matches <YOUR_DOMAIN>, and if both are `true`, then forward to your
       - "req.user_agent.contains('Mozilla')"
-      - "actions.ngrok.oauth.identity != null && actions.ngrok.oauth.identity.email.endsWith('$YOUR_EMAIL_DOMAIN')"
+      - "actions.ngrok.oauth.identity != null && actions.ngrok.oauth.identity.email.endsWith('@$YOUR_EMAIL_DOMAIN')"
     actions:
       - type: "forward-internal"
         config:

--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -982,72 +982,72 @@ const redirects = [
 	],
 	// Traffic Policy Macros consolidation (2025)
 	[
-		fromIncludes("/docs/traffic-policy/macros/core"),
+		fromExact("/docs/traffic-policy/macros/core"),
 		"/docs/traffic-policy/macros/",
 	],
 	[
-		fromIncludes("/docs/traffic-policy/macros/ext"),
+		fromExact("/docs/traffic-policy/macros/ext"),
 		"/docs/traffic-policy/macros/",
 	],
 	[
-		fromIncludes("/docs/traffic-policy/macros/http"),
+		fromExact("/docs/traffic-policy/macros/http"),
 		"/docs/traffic-policy/macros/",
 	],
 	[
-		fromIncludes("/docs/traffic-policy/macros/security"),
+		fromExact("/docs/traffic-policy/macros/security"),
 		"/docs/traffic-policy/macros/",
 	],
 	[
-		fromIncludes("/docs/traffic-policy/macros/utility"),
+		fromExact("/docs/traffic-policy/macros/utility"),
 		"/docs/traffic-policy/macros/",
 	],
 
 	[
-		fromIncludes(
+		fromExact(
 			"/docs/guides/other-guides/how-to-terminate-traffic-with-ngrok-configs",
 		),
 		"/docs/agent/agent-tls-termination/",
 	],
 	[
-		fromIncludes("/docs/guides/other-guides/using-tls-mutual-authentication"),
+		fromExact("/docs/guides/other-guides/using-tls-mutual-authentication"),
 		"/docs/agent/agent-mutual-tls-termination/",
 	],
 	[
-		fromIncludes("/docs/guides/other-guides/using-mcp/"),
+		fromExact("/docs/guides/other-guides/using-mcp/"),
 		"/docs/using-ngrok-with/using-mcp/",
 	],
 	[
-		fromIncludes("/docs/guides/other-guides/running-behind-firewalls/"),
+		fromExact("/docs/guides/other-guides/running-behind-firewalls/"),
 		"/docs/guides/running-behind-firewalls/",
 	],
 	[
-		fromIncludes("/docs/universal-gateway/examples/combine-auth-methods/"),
+		fromExact("/docs/universal-gateway/examples/combine-auth-methods/"),
 		"/docs/universal-gateway/examples/ip-restrictions-basic-auth/",
 	],
 	[
-		fromIncludes(
+		fromExact(
 			"/docs/guides/other-guides/path-based-routing-and-policy-decentralization-with-cloud-endpoints",
 		),
 		"/docs/universal-gateway/cloud-endpoints/routing-and-policy-decentralization/",
 	],
 	[
-		fromIncludes(
+		fromExact(
 			"/docs/guides/other-guides/forwarding-and-load-balancing-with-cloud-endpoints",
 		),
 		"/docs/universal-gateway/cloud-endpoints/forwarding-and-load-balancing/",
 	],
 	[
-		fromIncludes(
+		fromExact(
 			"/docs/guides/other-guides/how-to-set-up-auth-on-your-endpoint-using-traffic-policy",
 		),
 		"/docs/traffic-policy/examples/oauth-protection",
 	],
 	[
-		fromIncludes("/docs/guides/other-guides/dashboard-sso-okta-setup/"),
+		fromExact("/docs/guides/other-guides/dashboard-sso-okta-setup/"),
 		"/docs/integrations/okta/dashboard-sso-okta-setup",
 	],
 	// Just a redirect so the top-level guides path goes somewhere (there's no guides/index)
-	[fromIncludes("/docs/guides/"), "/docs/guides/api-gateway/get-started/"],
+	[fromExact("/docs/guides/"), "/docs/guides/api-gateway/get-started/"],
 ];
 
 // get current href from window

--- a/traffic-policy/gallery/OAuthConditionalAccess.tsx
+++ b/traffic-policy/gallery/OAuthConditionalAccess.tsx
@@ -19,7 +19,7 @@ export const OAuthConditionalAccess = () => (
 				{
 					name: "good email",
 					expressions: [
-						"actions.ngrok.oauth.identity.email.endsWith('ngrok.com')",
+						"actions.ngrok.oauth.identity.email.endsWith('@ngrok.com')",
 					],
 					actions: [
 						{
@@ -34,7 +34,7 @@ export const OAuthConditionalAccess = () => (
 				{
 					name: "bad email",
 					expressions: [
-						"!actions.ngrok.oauth.identity.email.endsWith('ngrok.com')",
+						"!actions.ngrok.oauth.identity.email.endsWith('@ngrok.com')",
 					],
 					actions: [
 						{


### PR DESCRIPTION
A check like `endsWith('example.com')` can be subverted if someone registers the domain "not-the-real-example.com", and then logs in with an email on that domain.

We should avoid suggesting something that has security issues like that.