### PR TITLE
Add missing title for page - Using ngrok with Docker

### DIFF
--- a/docs/using-ngrok-with/docker.mdx
+++ b/docs/using-ngrok-with/docker.mdx
@@ -7,6 +7,8 @@ description: Learn how to use ngrok with Docker to expose your local application
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
+# Using ngrok with Docker
+
 :::tip
 For detailed instructions on using ngrok with Kubernetes, check out the [k8s quickstart](/docs/k8s/).
 :::


### PR DESCRIPTION
https://github.com/ngrok/ngrok-docs/pull/1452/commits/3c668921d0d98b0fd2d43f057a1979381e034b3e erroneously removed this page's title.

This PR puts it back.