### PR TITLE
fix: ab example typo

### DIFF
--- a/docs/traffic-policy/examples/a-b-tests.mdx
+++ b/docs/traffic-policy/examples/a-b-tests.mdx
@@ -26,7 +26,11 @@ This rule:
 						config: {
 							url: "https://a.internal",
 						},
-					},
+					}
+				],
+			},
+			{
+				actions: [
 					{
 						type: "forward-internal",
 						config: {


### PR DESCRIPTION
this example is broken. this fixes it