### PR TITLE
Add links to clone quickstart example apps

### DIFF
--- a/docs/getting-started/go.mdx
+++ b/docs/getting-started/go.mdx
@@ -9,11 +9,11 @@ import { YouTubeEmbed } from "@components/youtube-embed";
 [The ngrok Go SDK](https://pkg.go.dev/golang.ngrok.com/ngrok/v2) is an open-source, idiomatic Go package that enables you to quickly and efficiently serve Go applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Go library.
 
+This quickstart uses the ngrok Go SDK to create an agent endpoint that forwards traffic from the internet to a Go app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
+
 :::info
 If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/go-quickstart).
 :::
-
-This quickstart uses the ngrok Go SDK to create an agent endpoint that forwards traffic from the internet to a Go app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 <YouTubeEmbed videoId="YtFlIKfADO4" title="Watch the video to learn how to add an API gateway to your Go apps" />
 

--- a/docs/getting-started/go.mdx
+++ b/docs/getting-started/go.mdx
@@ -9,6 +9,10 @@ import { YouTubeEmbed } from "@components/youtube-embed";
 [The ngrok Go SDK](https://pkg.go.dev/golang.ngrok.com/ngrok/v2) is an open-source, idiomatic Go package that enables you to quickly and efficiently serve Go applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Go library.
 
+:::info
+If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/go-quickstart).
+:::
+
 This quickstart uses the ngrok Go SDK to create an agent endpoint that forwards traffic from the internet to a Go app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 <YouTubeEmbed videoId="YtFlIKfADO4" title="Watch the video to learn how to add an API gateway to your Go apps" />

--- a/docs/getting-started/javascript.mdx
+++ b/docs/getting-started/javascript.mdx
@@ -9,6 +9,10 @@ tags:
 [The ngrok JavaScript (Node.js) SDK](https://ngrok.github.io/ngrok-javascript/) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a JS library.
 
+:::info
+If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/javascript-quickstart).
+:::
+
 This quickstart uses the ngrok JavaScript SDK to create an agent endpoint that forwards traffic from the internet to a Node.js app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need

--- a/docs/getting-started/javascript.mdx
+++ b/docs/getting-started/javascript.mdx
@@ -9,11 +9,11 @@ tags:
 [The ngrok JavaScript (Node.js) SDK](https://ngrok.github.io/ngrok-javascript/) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a JS library.
 
+This quickstart uses the ngrok JavaScript SDK to create an agent endpoint that forwards traffic from the internet to a Node.js app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
+
 :::info
 If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/javascript-quickstart).
 :::
-
-This quickstart uses the ngrok JavaScript SDK to create an agent endpoint that forwards traffic from the internet to a Node.js app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need
 

--- a/docs/getting-started/python.mdx
+++ b/docs/getting-started/python.mdx
@@ -9,11 +9,11 @@ tags:
 [The ngrok Python SDK](https://ngrok.github.io/ngrok-python/index.html) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Python library.
 
+This quickstart uses the ngrok Python SDK to create an agent endpoint that forwards traffic from the internet to a Python app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
+
 :::info
 If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/python-quickstart).
 :::
-
-This quickstart uses the ngrok Python SDK to create an agent endpoint that forwards traffic from the internet to a Python app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need
 

--- a/docs/getting-started/python.mdx
+++ b/docs/getting-started/python.mdx
@@ -9,6 +9,10 @@ tags:
 [The ngrok Python SDK](https://ngrok.github.io/ngrok-python/index.html) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Python library.
 
+:::info
+If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/python-quickstart).
+:::
+
 This quickstart uses the ngrok Python SDK to create an agent endpoint that forwards traffic from the internet to a Python app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need

--- a/docs/getting-started/rust.mdx
+++ b/docs/getting-started/rust.mdx
@@ -7,11 +7,11 @@ pagination_next: universal-gateway/overview
 [The ngrok Rust SDK](https://docs.rs/ngrok/latest/ngrok/) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Python library.
 
+This quickstart uses the ngrok Rust SDK to create an agent endpoint that forwards traffic from the internet to a Rust app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
+
 :::info
 If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/rust-quickstart).
 :::
-
-This quickstart uses the ngrok Rust SDK to create an agent endpoint that forwards traffic from the internet to a Rust app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need
 

--- a/docs/getting-started/rust.mdx
+++ b/docs/getting-started/rust.mdx
@@ -7,6 +7,10 @@ pagination_next: universal-gateway/overview
 [The ngrok Rust SDK](https://docs.rs/ngrok/latest/ngrok/) is an open-source package that enables you to quickly and efficiently serve Node.js applications on the internet without the need to configure low-level network primitives like IPs, certificates, load balancers, or ports.
 You can think of it as the [ngrok Agent CLI](/getting-started/) packaged as a Python library.
 
+:::info
+If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/rust-quickstart).
+:::
+
 This quickstart uses the ngrok Rust SDK to create an agent endpoint that forwards traffic from the internet to a Rust app running on your local device, then secure it by requiring visitors to log in with a Google account to access it.
 
 ## What you'll need


### PR DESCRIPTION
@S3Prototype I could also use your eyes on the actual quickstart repos themselves to confirm they all work as expected. (They ran on my machine! 😜)

- https://github.com/ngrok-samples/go-quickstart
- https://github.com/ngrok-samples/javascript-quickstart
- https://github.com/ngrok-samples/python-quickstart
- https://github.com/ngrok-samples/rust-quickstart