### PR TITLE
Sg/doc 363 Update docs to teach users to put quotes around yaml

### DIFF
--- a/docs/traffic-policy/concepts/expressions.mdx
+++ b/docs/traffic-policy/concepts/expressions.mdx
@@ -85,6 +85,10 @@ CEL provides a rich set of operators for arithmetic, comparison, and logical ope
 - **Comparison**: `==`, `!=`, `<`, `<=`, `>`, `>=`
 - **Logical**: `&&`, `||`, `!`
 
+:::info
+You must wrap expressions containing `!` in quotes for them to be parsed correctly.
+:::
+
 #### Using Arithmetic
 
 ```go

--- a/docs/traffic-policy/concepts/expressions.mdx
+++ b/docs/traffic-policy/concepts/expressions.mdx
@@ -87,6 +87,26 @@ CEL provides a rich set of operators for arithmetic, comparison, and logical ope
 
 :::info
 You must wrap expressions containing `!` in quotes for them to be parsed correctly.
+
+❌ This expression does not work:
+
+```yaml
+on_tcp_connect:
+  - expressions:
+      - !(conn.client_ip in ['2001:4860:7:f0e::f4', '98.35.32.113'])
+    actions:
+      - type: deny
+```
+
+✅ Wrapping the expression in quotes ensures that it'll be parsed correctly:
+
+```yaml
+on_tcp_connect:
+  - expressions:
+      - "!(conn.client_ip in ['2001:4860:7:f0e::f4', '98.35.32.113'])"
+    actions:
+      - type: deny
+```
 :::
 
 #### Using Arithmetic


### PR DESCRIPTION
context: https://linear.app/ngrok/issue/NE-318/spacing-shouldnt-matter-when-using-in-expressions