### PR TITLE
chore: Nix flake update to node 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ ngrok is built using [Docusaurus 3](https://docusaurus.io/).
 The fastest and safest (isolated) way to run the documentation is with the Docker command below, then browse to http://localhost:3000/docs.
 
 ```sh
-docker run --rm -p 3000:3000 -it --name=ngrokDocs -v "./:/app" -w "/app" --platform=linux/amd64 guergeiro/pnpm:20-8-alpine sh -c "apk add direnv; direnv allow; pnpm install; pnpm run start"
+docker run --rm -p 3000:3000 -it --name=ngrokDocs -v "./:/app" -w "/app" --platform=linux/amd64 guergeiro/pnpm:22-9-alpine sh -c "apk add direnv; direnv allow; pnpm install; pnpm run start"
 ```
 
 Otherwise, you can install and run everything on your local host.
 
 Prerequisites required:
 
-- [Node 20](https://nodejs.org/en/download)
+- [Node 22](https://nodejs.org/en/download)
 - [pnpm 9](https://pnpm.io/installation#using-npm)
 - [nvm](https://github.com/nvm-sh/nvm)
 
@@ -30,7 +30,7 @@ We use [direnv](https://direnv.net/) to assist you with setting up all of the re
   <summary>Prefer to install and manage the tooling yourself?</summary>
 
 1. Install [nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) or your node version manager of choice.
-2. Ensure that `node 20` is installed. With `nvm`, run `nvm install`.
+2. Ensure that `node 22` is installed. With `nvm`, run `nvm install`.
 3. Enable `pnpm` with `corepack`: `corepack enable pnpm`
 4. Install `pnpm` with `corepack`: `corepack install`
 5. Install project dependencies with `pnpm`: `pnpm install`

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "lastModified": 1754800730,
+        "narHash": "sha256-HfVZCXic9XLBgybP0318ym3cDnGwBs/+H5MgxFVYF4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "rev": "641d909c4a7538f1539da9240dedb1755c907e40",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         };
         pnpm-shim = pkgs.writeShellScriptBin "pnpm" ''
           #!${pkgs.bash}/bin/bash
-          exec ${pkgs.lib.getBin pkgs.nodejs_20}/bin/node ${pkgs.lib.getBin pkgs.nodejs_20}/bin/corepack pnpm "$@"
+          exec ${pkgs.lib.getBin pkgs.nodejs_22}/bin/node ${pkgs.lib.getBin pkgs.nodejs_22}/bin/corepack pnpm "$@"
         '';
       in
       {
@@ -27,8 +27,8 @@
             export PATH="$PATH:$(git rev-parse --show-toplevel)/node_modules/.bin"
           '';
           buildInputs = with pkgs; [
-            nodejs_20
-            corepack_20
+            nodejs_22
+            corepack_22
             pnpm-shim
           ];
         };


### PR DESCRIPTION
## Why

It looks like we are now on node 22.

## What

Run `nix flake update` and update to node 22. Update the README as well