### PR TITLE
feat: Add k8s gateway Custom Domain docs

### DIFF
--- a/docs/k8s/guides/custom-domain.mdx
+++ b/docs/k8s/guides/custom-domain.mdx
@@ -3,11 +3,27 @@ sidebar_label: Custom Domains
 title: Kubernetes Custom White Label Domains
 ---
 
-In the Kubernetes Ingress and Gateway API specs, ingresses and routes can have multiple rules with different hostnames. While standard ngrok domains are available for use immediately after reservation, custom white label domains may require a couple extra steps to get working. The following outlines 2 options for getting custom white label domains working with the ngrok Kubernetes Operator.
+In the Kubernetes Ingress and Gateway API specs, ingresses and routes can have multiple rules with different hostnames. While standard ngrok
+domains are available for use immediately after reservation, custom white label domains may require a couple extra steps to get working.
+The following outlines 2 options for getting custom white label domains working with the ngrok Kubernetes Operator.
 
 ## Managed by Kubernetes
 
-If you create an ingress object (k8s ingress) or route object (Gateway API) with a hostname that is not a standard ngrok domain, the operator will attempt to create a custom white label domain for you. This domain will be reserved and registered with ngrok, but will not be configured until you have configured the DNS records for it. This will be registered in the ngrok API and also show up as a domain CRD For example:
+If you have [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) installed and configured, you can fully automate the process
+of:
+
+* reserving domains in ngrok
+* updating DNS records with your DNS provider with the ngrok provided CNAME record
+* automatically receiving a TLS certificate
+
+all just by creating an Ingress object, for example. If you are not using ExternalDNS or a similar
+tool, you will need to manually create records for each Ingress or Gateway you provision.
+
+### Ingress
+
+If you create an ingress object (k8s ingress) or route object (Gateway API) with a hostname that is not a standard ngrok domain, the operator
+will attempt to create a custom white label domain for you. This domain will be reserved and registered with ngrok, but will not be configured
+until you have configured the DNS records for it. This will be registered in the ngrok API and also show up as a domain CRD For example:
 
 If you create an ingress object such as this
 
@@ -30,20 +46,59 @@ spec:
                   number: 80
 ```
 
-The operator will attempt to reserve and register the domain `foo.bar.com` with ngrok. This will be registered in the ngrok API and also show up as a domain CRD. The operator will then wait for the DNS records to be configured for this domain. Once the DNS records are configured, the operator will configure the endpoint to route traffic to the ingress or route object.
+The operator will attempt to reserve and register the domain `foo.bar.com` with ngrok. This will be registered in the ngrok API and also show up as
+a domain CRD. The operator will then wait for the DNS records to be configured for this domain. Once the DNS records are configured, the operator will
+configure the endpoint to route traffic to the ingress or route object.
+
 You should be able to see the domain CRD via kubectl
 
-`kubectl describe domain foo.bar.com`
+`kubectl get domains.ingress.k8s.ngrok.com`
 
-For custom domains, the domain resource contains the CNAME target value that needs to be created for DNS resolution and certificates to work properly. This value is added to the ingress or route object's status.loadBalancer field.
+For custom domains, the domain resource contains the CNAME target value that needs to be created for DNS resolution and certificates to work properly.
+This value is added to the ingress or route object's `status.loadBalancer.ingress` field.
 
-`kubectl describe ingress example-ingress`
+`kubectl get ingress -o yaml example-ingress`
 
 ```yaml
 Status:
   loadBalancer:
     ingress:
-      hostname: 12jkh25.cname.ngrok.app
+    - hostname: abc123.def456.ngrok-cname.com
+```
+
+### Gateway
+
+Using a custom domain with the Gateway API is similar to the Ingress example above.
+
+If you create the following Gateway,
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: ngrok
+  listeners:
+    - allowedRoutes:
+        kinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        namespaces:
+          from: All
+      hostname: foo.bar.com
+      name: http
+      port: 443
+      protocol: HTTPS
+```
+
+the ngrok-operator will reserve the domain for you, and populate the Gateway's `status.addresses` field:
+
+```yaml
+status:
+  addresses:
+    - type: Hostname
+      value: abc123.def456.ngrok-cname.com
 ```
 
 ## Externally managed
@@ -54,4 +109,5 @@ Domains can also be created
 - via the ngrok API
 - via the ngrok terraform provider
 
-If created externally, the operator will discover the domain is already registered, and not interact with it unless you modify or delete the crd itself. Deleting the ingress objects that use that host won't result in the domain CRD being deleted.
+If created externally, the operator will discover the domain is already registered, and not interact with it unless you modify or delete the crd itself.
+Deleting the ingress objects that use that host won't result in the domain CRD being deleted.


### PR DESCRIPTION
* Mention ExternalDNS in the k8s custom domains section as it can help provide a more friction free experience for users using custom domains.
* Split apart the existing section into `Ingress` and `Gateway` sections.
* Add example for custom domains with the Gateway API.