### PR TITLE
Correcting a Provider in providers.mdx

### DIFF
--- a/traffic-policy/actions/verify-webhook/providers.mdx
+++ b/traffic-policy/actions/verify-webhook/providers.mdx
@@ -32,7 +32,7 @@ Currently, these integration guides refer to modules.
 | Go1                         | `go1`                   | [Documentation](https://www.go1.com/developers/partners/concepts/webhook-signature-authentification) |
 | Heroku                      | `heroku`                | [Documentation](/docs/integrations/heroku/webhooks/)                                                 |
 | Hosted Hooks                | `hostedhooks`           | [Documentation](/docs/integrations/hostedhooks/webhooks/)                                            |
-| HubsSpot                    | `hubspot`               | [Documentation](/docs/integrations/hubspot/webhooks/)                                                |
+| HubSpot                    | `hubspot`               | [Documentation](/docs/integrations/hubspot/webhooks/)                                                |
 | Hygraph (Formerly GraphCMS) | `graphcms`              | [Documentation](/docs/integrations/hygraph/webhooks/)                                                |
 | Instagram                   | `instagram`             | [Documentation](/docs/integrations/instagram/webhooks/)                                              |
 | Intercom                    | `intercom`              | [Documentation](/docs/integrations/intercom/webhooks/)                                               |


### PR DESCRIPTION
HubsSpot -> HubSpot. The typo was detected only in the human-readable name, the identifier is correct.