### PR TITLE
feat: Add k8s Gateway API status conditions documentation

### DIFF
--- a/docs/k8s/guides/using-gwapi.mdx
+++ b/docs/k8s/guides/using-gwapi.mdx
@@ -170,3 +170,87 @@ spec:
   selector:
     app: example-app
 ```
+
+## Gateway API Status Conditions
+
+The Gateway API has guidance on status and condition handling in [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/) and the
+Gateway API [Implementer's guide](https://gateway-api.sigs.k8s.io/guides/implementers/#standard-status-fields-and-conditions). The
+ngrok-operator sets status and conditions on Gateway API resources.
+
+### Viewing Gateway Statuses
+
+You can view your gateways and whether or not they have been programmed by running `kubectl get gateways.gateway.networking.k8s.io --all-namespaces`:
+
+```shell
+NAMESPACE   NAME                           CLASS   ADDRESS                                              PROGRAMMED   AGE
+infra       custom-gateway                 ngrok   vxvuakisp8tmkwmn.4ras8yu7nq6zsudp3.ngrok-cname.com   True         97d
+infra       invalid-http-port-gw           ngrok   invalid-gw-2.tests.ngrok.io                          Unknown      62d
+infra       invalid-https-port-gw          ngrok   invalid-gw-1.tests.ngrok.io                          Unknown      62d
+infra       invalid-no-hostname-http-gw    ngrok                                                        Unknown      62d
+infra       invalid-no-hostname-https-gw   ngrok                                                        Unknown      62d
+infra       shared-gateway                 ngrok   gateway.my-sub-domain.ngrok.io                       True         140d
+```
+
+In this example, you can see that 2 gateways have been successfully programmed in ngrok. The first one, `custom-gateway`, is using
+a [Custom Domain](./custom-domain.mdx) and shows the ngrok CNAME assigned to it. The last one, `shared-gateway`, is using a ngrok
+managed domain and has also been programmed. The other Gateways you see here are invalid and not able to be programmed.
+
+We can check the reason why a gateway is invalid, by checking the status condition on the gateway and the listener status conditions
+with `kubectl -n infra get gateway -o yaml invalid-http-port-gw`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: invalid-http-port-gw
+  namespace: infra
+spec:
+  gatewayClassName: ngrok
+  listeners:
+  - allowedRoutes:
+      kinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      namespaces:
+        from: All
+    hostname: invalid-gw-2.tests.ngrok.io
+    name: http
+    port: 443
+    protocol: HTTP
+status:
+  addresses:
+  - type: Hostname
+    value: invalid-gw-2.tests.ngrok.io
+  conditions:
+  - lastTransitionTime: "2025-06-11T15:00:27Z"
+    message: gateway listeners are not valid
+    observedGeneration: 1
+    reason: ListenersNotValid
+    status: "False"
+    type: Accepted
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: Waiting for controller
+    reason: Pending
+    status: Unknown
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2025-06-11T15:00:27Z"
+      message: ngrok only supports HTTP on port 80
+      observedGeneration: 1
+      reason: PortUnavailable
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-06-11T20:28:15Z"
+      message: listener is not valid
+      observedGeneration: 1
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    name: http
+    supportedKinds: []
+```
+
+We can see that the listener for this Gateway is invalid because the listener specified listening for HTTP on port 443 and
+ngrok only supports HTTPS listeners on port 443.


### PR DESCRIPTION
Add k8s Gateway API documentation on status conditions and how to view the status of Gateways.