### PR TITLE
Add warning callout about use of CEL in `basic-auth.credentials`

### DIFF
--- a/traffic-policy/actions/basic-auth/config.mdx
+++ b/traffic-policy/actions/basic-auth/config.mdx
@@ -19,6 +19,11 @@ reference for this action.
     <ConfigItem title="credentials" type="array of strings" required={true}>
         <p>A list of up to 10 allowed <code>username:password</code> credential pairs.</p>
         <p>Password must be at least <code>8</code> characters and no more than <code>128</code> characters.</p>
+
+        :::warning
+            Unlike other traffic policy actions and fields, `basic-auth.credentials` cannot contain CEL.
+        :::
+
     </ConfigItem>
 
     <ConfigItem title="realm" type="string" required={false}>


### PR DESCRIPTION
https://ngrok.slack.com/archives/C0855TVJ69W/p1755791646409549