### PR TITLE
Update secrets docs -> open beta + removing 'early access' callouts

### DIFF
--- a/docs/traffic-policy/secrets.mdx
+++ b/docs/traffic-policy/secrets.mdx
@@ -11,14 +11,11 @@ When you update a secret in a vault, it automatically rotates across all traffic
 Secrets are supported in all Traffic Policy actions and fields that support CEL.
 
 :::info
-Secrets and vaults are currently in Developer Preview.
-Log into the [ngrok dashboard](https://dashboard.ngrok.com/developer-preview) to request access.
-During the Developer Preview, the following limitations apply:
+Secrets and vaults are currently in Open Beta.
+During the Open Beta, the following limitations apply:
 
 - Secrets management is only available via the ngrok API (no dashboard UI)
 - Secrets interpolated into certain actions may appear in cleartext in Traffic Inspector when full capture mode is enabled
-- Secrets are only supported in the fields listed in the [supported actions and fields section](#supported-actions-and-fields) below
-  :::
 
 ## How it works
 


### PR DESCRIPTION
I'm finding 'Developer Preview' hard to talk about in the blog post without saying 'Open Beta' to clearly indicate it's open to all. Therefore, updating this doc to use that same language. I am also removing the instructions to request Early Access, as we've now enabled this for all users and this flag is no longer needed, as well as the disclaimer about supporting a limited swath of fields.