### PR TITLE
Fixed incorrect MCP acronym

### DIFF
--- a/docs/using-ngrok-with/using-mcp.mdx
+++ b/docs/using-ngrok-with/using-mcp.mdx
@@ -7,7 +7,7 @@ description: Learn how to use ngrok to proxy a local server so you can build cus
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
-[Claude.ai](https://www.anthropic.com/news/introducing-claude) supports [Custom MCP (Messages Control Protocol) Integrations](https://support.anthropic.com/en/articles/11175166-about-custom-integrations-using-remote-mcp) — allowing it to interact with your own tools and APIs via structured function calls.
+[Claude.ai](https://www.anthropic.com/news/introducing-claude) supports [Custom MCP (Model Context Protocol) Integrations](https://support.anthropic.com/en/articles/11175166-about-custom-integrations-using-remote-mcp) — allowing it to interact with your own tools and APIs via structured function calls.
 
 That means you can bring any custom MCP server into Claude.ai or Claude Desktop — as long as it's reachable via a public endpoint.
 


### PR DESCRIPTION
The first line says MCP stands for "Messages Control Protocol", but it's actually "Model Context Protocol".

Just to confirm I wasn't thinking of the wrong thing, I double checked in the Anthropic page linked in this first line (https://support.anthropic.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp), and it agrees.