### PR TITLE
"Bot user" to "Service user"

### DIFF
--- a/docs/iam/index.mdx
+++ b/docs/iam/index.mdx
@@ -29,7 +29,7 @@ terminology and concepts ngrok uses to describe its IAM primitives.
 - [**Service Users**](/iam/bot-users): Accounts also contain **Service Users** which are like Users but
   meant to be used for automated processes. Other systems may call these 'Service
   Accounts'.
-- [**Principals**](/obs/events/#principal-object): A principal is either a User or Bot User. Principals are
+- [**Principals**](/obs/events/#principal-object): A principal is either a User or Service User. Principals are
   members of an Account that may take actions inside of it.
 - [**Credentials**](/iam/users/#credentials): These are the keys and tokens that Principals use to
   authenticate with the ngrok service. Types of Credential include Authtokens,


### PR DESCRIPTION
Happened to notice an instance of the old "Bot user" term. Updated it to "Service user". 

(side note: I *highly* approve of the new name, it's much more clear)