### PR TITLE
adding some additional information to the custom response page

### DIFF
--- a/traffic-policy/actions/custom-response/behavior.mdx
+++ b/traffic-policy/actions/custom-response/behavior.mdx
@@ -4,7 +4,7 @@ If this action is executed, no subsequent actions in your traffic policy will be
 
 ### `on_http_request` Usage
 
-When used during the `on_http_request` phase, this action bypasses the upstream server and immediately returns the configured response to the caller. 
+When used during the `on_http_request` phase, this action bypasses the upstream server and immediately returns the configured response to the caller.
 Keep in mind that because this action bypasses the upstream server, request bodies will not be forwarded and will not be visible within the ngrok [Traffic Inspector](/obs/traffic-inspection/).
 
 ### `on_http_response` Usage


### PR DESCRIPTION
We have seen users that have custom responses set up along with on_error:continue that are confused as to why their request bodies dont show up in traffic inspector, adding this to provide clarification: https://ngrok.slack.com/archives/C053S5EUL69/p1755871171448969?thread_ts=1753978229.902829&cid=C053S5EUL69