### PR TITLE
x-link to secrets macro doc

### DIFF
--- a/docs/traffic-policy/secrets.mdx
+++ b/docs/traffic-policy/secrets.mdx
@@ -33,7 +33,7 @@ Reference secrets in your Traffic Policy using the `secrets.get()` macro:
 secrets.get("vault-name", "secret-name")
 ```
 
-The macro dynamically retrieves the secret value from the specified vault at runtime.
+The [macro](https://ngrok.com/docs/traffic-policy/macros/#secretsgetstring-string---string) dynamically retrieves the secret value from the specified vault at runtime.
 
 ## Using vaults and secrets
 


### PR DESCRIPTION
X-linking between conceptual and ref docs for `secrets.get()`