### PR TITLE
Fix broken redirects in `security-dev-productivity` directory

### DIFF
--- a/static/scripts/fix-redirect.js
+++ b/static/scripts/fix-redirect.js
@@ -146,12 +146,6 @@ const redirects = [
 		"/docs/guides/other-guides/upgrade-v2-v3",
 	],
 
-	// /docs/guides/security-dev-productivity -> /docs/guides/other-guides/security-dev-productivity
-	[
-		fromIncludes("/docs/guides/security-dev-productivity"),
-		"/docs/guides/other-guides/security-dev-productivity",
-	],
-
 	// /docs/guides/securing-your-tunnels -> /docs/guides/other-guides/securing-your-tunnels
 	[
 		fromIncludes("/docs/guides/securing-your-tunnels"),


### PR DESCRIPTION
IIUC this `fromIncludes` was causing all pages in this directory to redirect to the index page

https://ngrok.slack.com/archives/C09BHFQRF3M/p1756148357192719?thread_ts=1755889889.111169&cid=C09BHFQRF3M