### PR TITLE
Mark client_id field in OIDC/OAuth policies as CEL supported

### DIFF
--- a/traffic-policy/actions/oauth/config.mdx
+++ b/traffic-policy/actions/oauth/config.mdx
@@ -37,9 +37,10 @@ reference for this action.
 			`?redirect_path=/`
 		</p>
 	</ConfigItem>
-	<ConfigItem title="client_id" type="string" required={false}>
+	<ConfigItem title="client_id" type="string" required={false} cel={true}>
 		<p>Your OAuth app's client ID.</p>
 		<p>Leave this empty if you want to use ngrok’s managed application.</p>
+		<p>Supports [CEL Interpolation](/traffic-policy/concepts/cel-interpolation).</p>
 	</ConfigItem>
 	<ConfigItem title="client_secret" type="string" required={false} cel={true}>
 		<p>Your OAuth app's client secret.</p>

--- a/traffic-policy/actions/oidc/config.mdx
+++ b/traffic-policy/actions/oidc/config.mdx
@@ -25,8 +25,9 @@ reference for this action.
 	<ConfigItem title="auth_id" type="string" required={false}>
 		<p>Unique authentication identifier for this provider.</p>
 	</ConfigItem>
-	<ConfigItem title="client_id" type="string" required={false}>
+	<ConfigItem title="client_id" type="string" required={false} cel={true}>
 		<p>Your OpenID Connect app's client ID.</p>
+		<p>Supports [CEL Interpolation](/traffic-policy/concepts/cel-interpolation).</p>
 	</ConfigItem>
 	<ConfigItem title="client_secret" type="string" required={false} cel={true}>
 		<p>Your OpenID Connect app's client secret.</p>


### PR DESCRIPTION
We recently added CEL support to the `client_id` fields of the OIDC and OAuth actions. This PR updates the docs to reflect that change