### PR TITLE
Remove broken markup, remove reference to "clinic"

### DIFF
--- a/docs/guides/ssh-rdp/index.mdx
+++ b/docs/guides/ssh-rdp/index.mdx
@@ -57,7 +57,7 @@ curl -X POST \
 
 ### 2. Define internal endpoints in ngrok.yml for privatized device access
 
-An [internal endpoint](https://ngrok.com/docs/universal-gateway/internal-endpoints/) enables a service inside the clinic to be reachable within ngrok, without being publicly exposed. They can:
+An [internal endpoint](https://ngrok.com/docs/universal-gateway/internal-endpoints/) enables a service inside the network to be reachable within ngrok, without being publicly exposed. They can:
 
 1. Only receive traffic from cloud endpoints or internal services that explicitly route traffic to them.
 2. Not be accessed directly from the internet.
@@ -88,9 +88,7 @@ endpoints:
       url: 3389
 ```
 
-:::
 If there is no edge gateway present in your network, you must configure each agent on each device with an internal endpoint for that device.
-:::
 
 ### 3. Reserve a tcp address for each device/server
 


### PR DESCRIPTION
The `:::` syntax doesn't appear to get parsed, and appears in the page as-is.

<img width="2010" height="464" alt="CleanShot 2025-09-08 at 10 19 41@2x" src="https://github.com/user-attachments/assets/ef143ed4-5a26-4625-8869-5b1130816d9b" />

The word `clinic` in the sentence it is found feels like a typo of some sort, but I'm not sure what it was originally supposed to be. I've changed it to "network" as that feels like it works in the sentence.