### PR TITLE
Replace unnecessary external link with internal one.

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -200,7 +200,7 @@ endpoints:
 
 :::note
 This example uses ngrok's default Google OAuth application.
-To use your own, see [the OAuth Traffic Policy Action documentation](https://ngrok-docs-git-sg-doc-326-agent-endpoints-cli-f7e245-ngrok-dev.vercel.app/docs/traffic-policy/actions/oauth/#google-example).
+To use your own, see [the OAuth Traffic Policy Action documentation](/docs/traffic-policy/actions/oauth/#google-example).
 :::
 
 Now you can start up your endpoint using its name:


### PR DESCRIPTION
This external link seemed unnecessary. The Google examples are identical both internally and externally.

Link navigates to https://ngrok.com/docs/traffic-policy/actions/oauth/#google-example instead of https://ngrok-docs-git-sg-doc-326-agent-endpoints-cli-f7e245-ngrok-dev.vercel.app/docs/traffic-policy/actions/oauth/#google-example

I'm happy to close this if I am missing some context here.

# Screenshot

<img width="1041" height="135" alt="image" src="https://github.com/user-attachments/assets/c411e97a-e75c-4140-879f-d53906d81a3e" />
