### PR TITLE
refactor: More 2048 Example refactoring

### DIFF
--- a/docs/integrations/amazon-eks/eks.mdx
+++ b/docs/integrations/amazon-eks/eks.mdx
@@ -11,7 +11,8 @@ tags:
   - operator
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from '../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx';
+import TrafficPolicyGoogleOauth from '../../../examples/k8s/trafficpolicy/example.mdx';
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
 
 The [ngrok Kubernetes Operator](https://github.com/ngrok/ngrok-operator) is our official open-source controller for adding public and secure ingress traffic to your k8s services. It works out of the box with n AWS EKS Kubernetes cluster to provide ingress to your services no matter the network configuration, as long as it has outbound access to the ngrok service. This allows ngrok to be portable and work seamlessly across any type of infrastructure.
 
@@ -59,60 +60,7 @@ export KUBECONFIG=$(pwd)/kubeconfig
 
 Create a manifest file (for example `ngrok-manifest.yaml`) with the following contents. You will need to replace the `NGROK_DOMAIN` on line 45 with your own custom value. This is the URL you will use to access your service from anywhere. If you're on a free account, it must be on a static subdomain which you can claim by logging into your account and following the instructions on the claim static subdomain banner. For paid accounts, you can use a custom domain or a subdomain of `ngrok.app` or `ngrok.dev` (for example, `username-loves-ingress.ngrok.app` or `k8s.example.com`).
 
-```yaml showLineNumbers
-apiVersion: v1
-kind: Service
-metadata:
-  name: game-2048
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-  selector:
-    app: game-2048
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: game-2048
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: game-2048
-  template:
-    metadata:
-      labels:
-        app: game-2048
-    spec:
-      containers:
-        - name: backend
-          image: alexwhen/docker-2048
-          ports:
-            - name: http
-              containerPort: 80
----
-# Configuration for ngrok's Kubernetes Operator
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: game-2048-ingress
-  namespace: default
-spec:
-  ingressClassName: ngrok
-  rules:
-    - host: <NGROK_DOMAIN>
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: game-2048
-                port:
-                  number: 80
-```
+<TwentyFourtyEight deployment={true} service={true} ingress={true} />
 
 1. Apply the manifest file to your k8s cluster.
 
@@ -144,44 +92,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `Service` and `Deployment` as they were. Note the new `annotations` field and
    the `NgrokTrafficPolicy` CR.
 
-   ```yaml
-    ...
-   ---
-   # Configuration for ngrok's Kubernetes Operator
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: default
-     annotations:
-       k8s.ngrok.com/traffic-policy: oauth
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ---
-   # Traffic Policy configuration for OAuth
-   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-   kind: NgrokTrafficPolicy
-   metadata:
-     name: oauth
-     namespace: default
-   spec:
-     policy:
-   	   on_http_request:
-   		   - type: oauth
-   			   config:
-   			     provider: google
-   ```
+   <TwentyFourtyEight withOauth={true} ingress={true} trafficPolicy={true} />
 
 1. Re-apply your `2048.yaml` configuration.
 
@@ -198,7 +109,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-    <TrafficPolicyGoogleOauthWithDomain />
+    <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed 2048 app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/docs/integrations/azure-aks/k8s.mdx
+++ b/docs/integrations/azure-aks/k8s.mdx
@@ -3,7 +3,8 @@ title: Ingress to Kubernetes apps deployed on Azure Kubernetes Service (AKS)
 description: Learn how to deploy a new Kubernetes cluster and demo app via AKS, then add ingress to applications with ngrok's Kubernetes Operator.
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from '../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx';
+import TrafficPolicyGoogleOauth from '../../../examples/k8s/trafficpolicy/example.mdx';
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
 
 In this guide, you'll launch a new cluster with [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service) and a demo app. You'll then add the ngrok Kubernetes Operator to route public traffic directly to your demo app through an encrypted, feature-rich tunnel for a complete proof of concept.
 
@@ -371,44 +372,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
 1. Edit your existing ingress YAML with the following. Note the new `annotations` field and
    the `NgrokTrafficPolicy` CR.
 
-   ```yaml
-    ...
-   ---
-   # Configuration for ngrok's Kubernetes Operator
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: default
-     annotations:
-       k8s.ngrok.com/traffic-policy: oauth
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ---
-   # Traffic Policy configuration for OAuth
-   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-   kind: NgrokTrafficPolicy
-   metadata:
-     name: oauth
-     namespace: default
-   spec:
-     policy:
-   	   on_http_request:
-   		   - type: oauth
-   			   config:
-   			     provider: google
-   ```
+   <TwentyFourtyEight withOauth={true} ingress={true} trafficPolicy={true} />
 
 1. When you open your demo app again, you'll be asked to log in via Google.
    That's a start, but what if you want to authenticate only yourself or colleagues?
@@ -419,7 +383,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-   <TrafficPolicyGoogleOauthWithDomain />
+   <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/docs/integrations/consul/k8s.mdx
+++ b/docs/integrations/consul/k8s.mdx
@@ -3,7 +3,7 @@ title: Kubernetes ingress to services in a Consul service mesh
 description: Setup a local Consul Service mesh to demonstrate how to use the ngrok Kubernetes Operator with Consul.
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from '../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx';
+import TrafficPolicyGoogleOauth from '../../../examples/k8s/trafficpolicy/example.mdx';
 
 The [ngrok Kubernetes Operator](https://github.com/ngrok/ngrok-operator) is our official open-source controller for adding public and secure ingress traffic to your k8s services. It works on any cloud, local, or on-prem Kubernetes cluster to provide ingress to your services no matter the network configuration, as long as it has outbound access to the ngrok service. This allows ngrok to be portable and work seamlessly across any type of infrastructure.
 
@@ -340,7 +340,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-   <TrafficPolicyGoogleOauthWithDomain />
+   <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed HashiCups app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/docs/integrations/digitalocean/k8s.mdx
+++ b/docs/integrations/digitalocean/k8s.mdx
@@ -3,7 +3,7 @@ title: Ingress to Kubernetes apps on clusters managed by DigitalOcean
 description: Add Kubernetes ingress to any app running in a cluster managed by DigitalOcean using the ngrok Kubernetes Operator.
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from '../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx';
+import TrafficPolicyGoogleOauth from '../../../examples/k8s/trafficpolicy/example.mdx';
 
 Using this guide, you'll launch a new cluster on [DigitalOcean](https://digitalocean.com) and use the DigitalOcean Marketplace to provision the [ngrok Kubernetes Operator](https://marketplace.digitalocean.com/apps/ngrok-ingress-controller) to securely ingress public traffic to a demo app.
 
@@ -228,7 +228,7 @@ To demonstrate how ingress configuration and [OAuth support](/traffic-policy/act
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-   <TrafficPolicyGoogleOauthWithDomain />
+   <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed 2048 app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/docs/integrations/google-gke/google-kubernetes-engine.mdx
+++ b/docs/integrations/google-gke/google-kubernetes-engine.mdx
@@ -10,7 +10,8 @@ tags:
   - ingress controller
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from '../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx';
+import TrafficPolicyGoogleOauth from '../../../examples/k8s/trafficpolicy/example.mdx';
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
 
 The [ngrok Kubernetes Operator](https://github.com/ngrok/ngrok-operator) is our official open-source controller for adding public and secure ingress traffic to your k8s services. It works out of the box with Google Kubernetes Engine cluster to provide ingress to your services no matter the network configuration, as long as it has outbound access to the ngrok service. This allows ngrok to be portable and work seamlessly across any type of infrastructure.
 
@@ -72,62 +73,7 @@ Create a manifest file (for example `ngrok-manifest.yaml`) with the following co
 
 :::
 
-```yaml showLineNumbers
-apiVersion: v1
-kind: Service
-metadata:
-  name: game-2048
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-  selector:
-    app: game-2048
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: game-2048
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: game-2048
-  template:
-    metadata:
-      labels:
-        app: game-2048
-    spec:
-      containers:
-        - name: backend
-          image: alexwhen/docker-2048
-          ports:
-            - name: http
-              containerPort: 80
----
-# highlight-start
-# ngrok Kubernetes Operator Configuration
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: game-2048-ingress
-  namespace: ngrok-operator
-spec:
-  ingressClassName: ngrok
-  rules:
-    - host: <NGROK_DOMAIN>
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: game-2048
-                port:
-                  number: 80
-# highlight-end
-```
+<TwentyFourtyEight deployment={true} service={true} ingress={true} />
 
 1. Apply the manifest file to your k8s cluster.
 
@@ -156,53 +102,16 @@ apply the policy to just a specific backend or as the default backend for an
 `Ingress`—see our doc on using the [Operator with
 Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingress).
 
-1. Edit your existing `2048.yaml` manifest with the following, leaving the
+1. Edit your existing `ngrok-manifest.yaml` manifest with the following, leaving the
    `Service` and `Deployment` as they were. Note the new `annotations` field and
    the `NgrokTrafficPolicy` CR.
 
-   ```yaml
-    ...
-   ---
-   # Configuration for ngrok's Kubernetes Operator
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: default
-     annotations:
-       k8s.ngrok.com/traffic-policy: oauth
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ---
-   # Traffic Policy configuration for OAuth
-   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-   kind: NgrokTrafficPolicy
-   metadata:
-     name: oauth
-     namespace: default
-   spec:
-     policy:
-   	   on_http_request:
-   		   - type: oauth
-   			   config:
-   			     provider: google
-   ```
+    <TwentyFourtyEight withOauth={true} ingress={true} trafficPolicy={true} />
 
-1. Re-apply your `2048.yaml` configuration.
+1. Re-apply your `ngrok-manifest.yaml` configuration.
 
    ```bash
-   kubectl apply -f 2048.yaml
+   kubectl apply -f ngrok-manifest.yaml
    ```
 
 1. When you open your demo app again, you'll be asked to log in via Google.
@@ -214,7 +123,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-   <TrafficPolicyGoogleOauthWithDomain />
+   <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed 2048 app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/docs/integrations/microk8s/k8s.mdx
+++ b/docs/integrations/microk8s/k8s.mdx
@@ -3,6 +3,8 @@ title: Kubernetes ingress to apps/APIs on clusters managed by Canonical MicroK8s
 description: Add ingress to any app running in a Kubernetes cluster managed by Canonical Microk8s using the ngrok Kubernetes Operator.
 ---
 
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
+
 Using this guide, you'll launch a new Kubernetes cluster with Canonical's open-source [MicroK8s](https://microk8s.io/) and use the [ngrok Kubernetes Operator](https://marketplace.digitalocean.com/apps/ngrok-ingress-controller) to securely ingress public traffic to an example app using the **new [Kubernetes Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/)**.
 
 Along the way, you'll learn enough to leverage MicroK8s in your next Kubernetes deployment—local development, embedded in a CI environment, and production workloads—with simple and secure traffic ingress.
@@ -61,42 +63,7 @@ Now you need a domain and Kubernetes service to ingress traffic to!
 
 1. Create a new Kubernetes manifest (`2048.yaml`) with the YAML below. This manifest defines the 2048 application service and deployment, then configures the ngrok Kubernetes Operator to connect the `game-2048` service to the ngrok edge via your `NGROK_DOMAIN`.
 
-   ```yaml showLineNumbers
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: game-2048
-     namespace: default
-   spec:
-     ports:
-       - name: http
-         port: 80
-         targetPort: 80
-     selector:
-       app: game-2048
-   ---
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: game-2048
-     namespace: default
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: game-2048
-     template:
-       metadata:
-         labels:
-           app: game-2048
-       spec:
-         containers:
-           - name: backend
-             image: alexwhen/docker-2048
-             ports:
-               - name: http
-                 containerPort: 80
-   ```
+   <TwentyFourtyEight title="2048.yaml" deployment={true} service={true} />
 
 1. Apply the `2048.yaml` manifest to your MicroK8s cluster.
 

--- a/docs/integrations/rancher/k8s.mdx
+++ b/docs/integrations/rancher/k8s.mdx
@@ -3,6 +3,8 @@ title: Kubernetes ingress to applications and clusters managed by Rancher
 description: Set up a local installation of Rancher to deploy a new RKE2 cluster and add ingress to applications with ngrok's Kubernetes Operator.
 ---
 
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
+
 The ngrok [Operator for Kubernetes](https://ngrok.com/blog-post/ngrok-k8s) is the official controller for
 adding secure public ingress and middleware execution to your Kubernetes applications with ngrok's cloud service. With
 ngrok, you can manage and secure traffic to your applications at every stage of the development lifecycle while also
@@ -151,68 +153,16 @@ simplifying how you route external traffic through your Rancher-managed cluster.
 
    Creating a subdomain on the ngrok network provides a public route to accept HTTP, HTTPS, and TLS traffic.
 
-1. Create a new Kubernetes manifest (`2048.yaml`) with the below contents. This manifest defines the 2048 application
+1. Create a new Kubernetes manifest (`ngrok-manifest.yaml`) with the below contents. This manifest defines the 2048 application
    service and deployment, then configures the ngrok Kubernetes Operator to connect the `game-2048` service to the ngrok
    edge via your `<NGROK_DOMAIN>`.
 
-   ```yaml showLineNumbers
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: game-2048
-   spec:
-     ports:
-       - name: http
-         port: 80
-         targetPort: 80
-     selector:
-       app: game-2048
-   ---
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: game-2048
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: game-2048
-     template:
-       metadata:
-         labels:
-           app: game-2048
-       spec:
-         containers:
-           - name: backend
-             image: alexwhen/docker-2048
-             ports:
-               - name: http
-                 containerPort: 80
-   ---
-   # ngrok Kubernetes Operator configuration
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ```
+    <TwentyFourtyEight deployment={true} service={true} ingress={true} />
 
-1. Apply the `2048.yaml` manifest to your RKE2 cluster.
+1. Apply the `ngrok-manifest.yaml` manifest to your RKE2 cluster.
 
    ```bash
-   kubectl apply -f 2048.yaml
+   kubectl apply -f ngrok-manifest.yaml
    ```
 
 1. Access your 2048 demo app by navigating to your ngrok subdomain, e.g. `https://one-two-three.ngrok.app`.

--- a/docs/integrations/spectro-cloud/k8s.mdx
+++ b/docs/integrations/spectro-cloud/k8s.mdx
@@ -2,6 +2,8 @@
 description: Add ingress to any app running in a Kubernetes cluster managed by Spectro Cloud's Palette platform using the ngrok Kubernetes Operator.
 ---
 
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
+
 # Ingress to Kubernetes apps deployed on Spectro Cloud Palette
 
 :::tip TL;DR
@@ -115,69 +117,17 @@ For the former, Palette has a [ready-to-apply pack](https://docs.spectrocloud.co
 
    Name the layer `2048`, then click **New manifest** and name it `deployment`. Copy the following YAML content to create a Kubernetes deployment named `game-2048`.
 
-   ```yaml showLineNumbers
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: game-2048
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: game-2048
-     template:
-       metadata:
-         labels:
-           app: game-2048
-       spec:
-         containers:
-           - name: backend
-             image: alexwhen/docker-2048
-             ports:
-               - name: http
-                 containerPort: 80
-   ```
+   <TwentyFourtyEight title="2048-deployment.yaml" deployment={true} />
 
    Create a second manifest named `service` copy in the following YAML:
 
-   ```yaml showLineNumbers
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: game-2048
-   spec:
-     ports:
-       - name: http
-         port: 80
-         targetPort: 80
-     selector:
-       app: game-2048
-   ```
+    <TwentyFourtyEight title="2048-service.yaml" service={true} />
 
    Click **Confirm & Create** to save the deployment.
 
 1. Add another manifest to create a Kubernetes ingress service, which will inform the ngrok Kubernetes Operator to create a new Edge for your app. Name it `2048-ingress` and create an `ingress` manifest with the following YAML content, replacing the `<NGROK_DOMAIN>` variable with the subdomain you created, which should look like `one-two-three.ngrok.app`.
 
-   ```yaml showLineNumbers
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: ngrok-operator
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ```
+   <TwentyFourtyEight title="2048-ingress.yaml" ingress={true} />
 
    Click **Confirm & Create** once again to add this layer before finishing the configuration.
 

--- a/docs/integrations/vcluster/k8s.mdx
+++ b/docs/integrations/vcluster/k8s.mdx
@@ -3,7 +3,8 @@ title: Ingress to Kubernetes apps and srevices with vcluster
 description: Setup a local virtual cluster to demonstrate how to use the ngrok Kubernetes Operator with vcluster.
 ---
 
-import TrafficPolicyGoogleOauthWithDomain from "../../../examples/k8s/trafficpolicy/oauth-google-domain.mdx";
+import TrafficPolicyGoogleOauth from "../../../examples/k8s/trafficpolicy/example.mdx";
+import TwentyFourtyEight from "../../../examples/k8s/apps/2048/example.mdx";
 
 The ngrok [Operator for Kubernetes](https://ngrok.com/blog-post/ngrok-k8s) is the official controller for
 adding public and secure ingress traffic to your k8s services. This open source Operator works with any cloud,
@@ -114,62 +115,7 @@ cluster, virtual cluster, and ultimately an exposed service or endpoint, you can
    network. Be sure to replace `<NGROK_DOMAIN>` with the domain you reserved a
    moment ago.
 
-   ```yaml
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: game-2048
-     namespace: default
-   spec:
-     ports:
-       - name: http
-         port: 80
-         targetPort: 80
-     selector:
-       app: game-2048
-   ---
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: game-2048
-     namespace: default
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: game-2048
-     template:
-       metadata:
-         labels:
-           app: game-2048
-       spec:
-         containers:
-           - name: backend
-             image: alexwhen/docker-2048
-             ports:
-               - name: http
-                 containerPort: 80
-   ---
-   # ngrok Kubernetes Operator Configuration
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: default
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ```
+   <TwentyFourtyEight deployment={true} service={true} ingress={true} />
 
 1. Apply the `2048.yaml` manifest to your vcluster.
 
@@ -212,44 +158,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `Service` and `Deployment` as they were. Note the new `annotations` field and
    the `NgrokTrafficPolicy` CR.
 
-   ```yaml
-    ...
-   ---
-   # Configuration for ngrok's Kubernetes Operator
-   apiVersion: networking.k8s.io/v1
-   kind: Ingress
-   metadata:
-     name: game-2048-ingress
-     namespace: default
-     annotations:
-       k8s.ngrok.com/traffic-policy: oauth
-   spec:
-     ingressClassName: ngrok
-     rules:
-       - host: <NGROK_DOMAIN>
-         http:
-           paths:
-             - path: /
-               pathType: Prefix
-               backend:
-                 service:
-                   name: game-2048
-                   port:
-                     number: 80
-   ---
-   # Traffic Policy configuration for OAuth
-   apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-   kind: NgrokTrafficPolicy
-   metadata:
-     name: oauth
-     namespace: default
-   spec:
-     policy:
-   	   on_http_request:
-   		   - type: oauth
-   			   config:
-   			     provider: google
-   ```
+    <TwentyFourtyEight withOauth={true} ingress={true} trafficPolicy={true} />
 
 1. Re-apply your `2048.yaml` configuration.
 
@@ -266,7 +175,7 @@ Ingresses](/docs/k8s/guides/using-ingresses/#using-ngroktrafficpolicy-with-ingre
    `NgrokTrafficPolicy` portion of your manifest after changing `example.com` to
    your domain.
 
-   <TrafficPolicyGoogleOauthWithDomain />
+   <TrafficPolicyGoogleOauth withDomain={true} />
 
 1. Check out your deployed 2048 app once again. If you log in with an email that
    doesn't match your domain, ngrok rejects your request. Authentication... done!

--- a/examples/k8s/apps/2048/_deployment.yaml
+++ b/examples/k8s/apps/2048/_deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: game-2048
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: game-2048
+  template:
+    metadata:
+      labels:
+        app: game-2048
+    spec:
+      containers:
+        - name: backend
+          image: alexwhen/docker-2048
+          ports:
+            - name: http
+              containerPort: 80
+

--- a/examples/k8s/apps/2048/_ingress.yaml
+++ b/examples/k8s/apps/2048/_ingress.yaml
@@ -1,0 +1,20 @@
+# ngrok Kubernetes Operator Configuration
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: game-2048-ingress
+  namespace: default
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: <NGROK_DOMAIN>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: game-2048
+                port:
+                  number: 80
+

--- a/examples/k8s/apps/2048/_ingress_oauth.yaml
+++ b/examples/k8s/apps/2048/_ingress_oauth.yaml
@@ -1,0 +1,21 @@
+# Configuration for ngrok's Kubernetes Operator
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: game-2048-ingress
+  namespace: default
+  annotations:
+    k8s.ngrok.com/traffic-policy: oauth
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: <NGROK_DOMAIN>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: game-2048
+                port:
+                  number: 80

--- a/examples/k8s/apps/2048/_service.yaml
+++ b/examples/k8s/apps/2048/_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: game-2048
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+  selector:
+    app: game-2048
+

--- a/examples/k8s/apps/2048/example.mdx
+++ b/examples/k8s/apps/2048/example.mdx
@@ -1,0 +1,42 @@
+import CodeBlock from "@theme/CodeBlock";
+import Ingress from '!!raw-loader!./_ingress.yaml';
+import Service from '!!raw-loader!./_service.yaml';
+import Deployment from '!!raw-loader!./_deployment.yaml';
+import IngressWithOauth from '!!raw-loader!./_ingress_oauth.yaml';
+import TrafficPolicy from '!!raw-loader!../../trafficpolicy/oauth-google.yaml';
+import { joinYamlDocs } from './utils';
+
+export default function AllInOne(props) {
+	let docs = [];
+	const ingress = props.withOauth ? IngressWithOauth : Ingress;
+
+    if (props.ingress) {
+    		docs.push(ingress);
+    }
+
+    if (props.service) {
+    		docs.push(Service);
+    }
+
+    if (props.deployment) {
+    		docs.push(Deployment);
+    }
+
+    if (props.trafficPolicy) {
+    		docs.push(TrafficPolicy);
+    }
+
+    const content = docs.length > 1 ? joinYamlDocs(...docs) : docs[0];
+    return (
+    		<div>
+    			<CodeBlock
+    				language="yaml"
+    				title={props.title || "ngrok-manifest.yaml"}
+    				showLineNumbers={props.showLineNumbers ?? true}
+    			>
+    			{content}
+    			</CodeBlock>
+    		</div>
+    )
+
+}

--- a/examples/k8s/apps/2048/utils.ts
+++ b/examples/k8s/apps/2048/utils.ts
@@ -1,0 +1,3 @@
+export function joinYamlDocs(...docs: string[]): string {
+	return docs.map((doc) => doc.trim()).join("\n---\n");
+}

--- a/examples/k8s/trafficpolicy/example.mdx
+++ b/examples/k8s/trafficpolicy/example.mdx
@@ -1,0 +1,15 @@
+import CodeBlock from '@theme/CodeBlock';
+import withDomain from '!!raw-loader!./oauth-google-domain.yaml';
+import withoutDomain from '!!raw-loader!./oauth-google.yaml';
+
+export default function OauthGoogle(props) {
+	const content = props.withDomain ? withDomain : withoutDomain;
+	const title = props.title || (props.withDomain ? "oauth-google-with-domain.yaml" : "oauth-google.yaml");
+
+    return (
+    	<div>
+    	  <CodeBlock language="yaml" title={title}>{content}</CodeBlock>
+    	</div>
+    )
+
+}

--- a/examples/k8s/trafficpolicy/oauth-google-domain.yaml
+++ b/examples/k8s/trafficpolicy/oauth-google-domain.yaml
@@ -1,4 +1,3 @@
-```yaml
 # Traffic Policy configuration for OAuth
 apiVersion: ngrok.k8s.ngrok.com/v1alpha1
 kind: NgrokTrafficPolicy
@@ -19,4 +18,3 @@ spec:
         config:
           body: Hey, no auth for you ${actions.ngrok.oauth.identity.name}!
           status_code: 400
-```

--- a/examples/k8s/trafficpolicy/oauth-google.yaml
+++ b/examples/k8s/trafficpolicy/oauth-google.yaml
@@ -1,4 +1,3 @@
-```yaml
 apiVersion: ngrok.k8s.ngrok.com/v1alpha1
 kind: NgrokTrafficPolicy
 metadata:
@@ -11,4 +10,3 @@ spec:
       - type: oauth
         config:
           provider: google
-```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dotenv": "17.2.1",
     "mermaid": "11.9.0",
     "prismjs": "1.30.0",
+    "raw-loader": "^4.0.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hubspot-form": "1.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
+      raw-loader:
+        specifier: ^4.0.2
+        version: 4.0.2(webpack@5.101.0)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -5790,6 +5793,12 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-loader@4.0.2:
+    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -13971,6 +13980,12 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  raw-loader@4.0.2(webpack@5.101.0):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.101.0
 
   rc@1.2.8:
     dependencies:

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -69,6 +69,10 @@ function DocsCodeBlock({
 		metastring ? `${className} ${metastring}` : className,
 	);
 
+	if (_title) {
+		meta.title = _title;
+	}
+
 	return (
 		<CodeBlockWithInfo
 			content={children}

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -5,6 +5,12 @@ import DocsCodeBlock, { CodeBlockFallback } from "../../components/code-block";
 type Props = ComponentProps<typeof DocsCodeBlock>;
 
 export default function CodeBlock({ className, ...props }: Props) {
+	// If className is not provided, check if props.language exists. If it does,
+	// use that to construct a className, prefixed with "language-".
+	if (!className && props.language) {
+		className = `language-${props.language}`;
+	}
+
 	return (
 		<BrowserOnly
 			fallback={


### PR DESCRIPTION
I'm still working on migrating the 2048 examples to use the tinyllama examples. This moves all the disparate 2048 k8s manifests into 1 place so it should make the Indiana Jones style swap easier.