### PR TITLE
feat: add 'enforce' option in rate limit config

### DIFF
--- a/traffic-policy/actions/rate-limit/config.mdx
+++ b/traffic-policy/actions/rate-limit/config.mdx
@@ -26,7 +26,7 @@ reference for this action.
     </ConfigItem>
 
     <ConfigItem title="enforce" type="boolean" required={false}>
-        <p>Controls whether the rate limit is actively applied at runtime. When enabled, requests exceeding the limit are blocked or throttled as configured. When disabled, the system evaluates the rate limit but does not enforce it, allowing you to test configurations, gather metrics, or return a custom response without affecting live traffic.</p>
+        <p>Controls whether the rate limit is actively applied at runtime. When enabled, requests exceeding the limit are blocked or throttled as configured. When disabled, the system evaluates the rate limit but does not enforce it, allowing you to test configurations, gather metrics, or return a custom response.</p>
         <p>The default value is <code>true</code>.</p>
     </ConfigItem>
 

--- a/traffic-policy/actions/rate-limit/config.mdx
+++ b/traffic-policy/actions/rate-limit/config.mdx
@@ -25,6 +25,11 @@ reference for this action.
         <p>A name for this rate limit configuration. Must be less than <code>1024</code> characters.</p>
     </ConfigItem>
 
+    <ConfigItem title="enforce" type="boolean" required={false}>
+        <p>Controls whether the rate limit is actively applied at runtime. When enabled, requests exceeding the limit are blocked or throttled as configured. When disabled, the system evaluates the rate limit but does not enforce it, allowing you to test configurations, gather metrics, or return a custom response without affecting live traffic.</p>
+        <p>The default value is <code>true</code>.</p>
+    </ConfigItem>
+
     <ConfigItem title="algorithm" type="enum" required={true}>
         <p>The rate limit algorithm to be used.</p>
         <ConfigEnum label="Supported values">


### PR DESCRIPTION
Expose and document the 'enforce' configuration option for rate limits.