### PR TITLE
Fix tabbed view for traffic policy with CRDs

### DIFF
--- a/docs/getting-started/kubernetes/crds.mdx
+++ b/docs/getting-started/kubernetes/crds.mdx
@@ -177,7 +177,7 @@ spec:
   url: http://tinyllama.internal
   upstream:
     url: http://tinyllama.default:80
-````
+```
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
The extra backquote breaks the <Tabs> container

I am not fully sure it is the issue, but going on https://ngrok.com/docs/getting-started/kubernetes/crds/#4-secure-your-app-with-traffic-policy we currently see

<img width="958" height="1296" alt="image" src="https://github.com/user-attachments/assets/5a1b9f89-9bbd-49b0-8e81-ff6f3edef79a" />
