### PR TITLE
Add Mantle fonts to new site

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -26,9 +26,7 @@
       "format": "woff"
     },
     "body": {
-      "family": "EuclidSquareRegular",
-      "source": "https://assets.ngrok.com/fonts/euclid-square/EuclidSquare-Regular-WebS.woff",
-      "format": "woff"
+      "family": "Nunito Sans"
     }
   },
   "favicon": "favicon.ico",

--- a/docs.json
+++ b/docs.json
@@ -19,6 +19,18 @@
     "light": "#699AFC",
     "dark": "#699AFC"
   },
+  "fonts": {
+    "heading": {
+      "family": "EuclidSquareSemiBold",
+      "source": "https://assets.ngrok.com/fonts/euclid-square/EuclidSquare-Semibold-WebS.woff",
+      "format": "woff"
+    },
+    "body": {
+      "family": "EuclidSquareRegular",
+      "source": "https://assets.ngrok.com/fonts/euclid-square/EuclidSquare-Regular-WebS.woff",
+      "format": "woff"
+    }
+  },
   "favicon": "favicon.ico",
   "logo": {
     "light": "/logo/light.svg",

--- a/style.css
+++ b/style.css
@@ -90,3 +90,45 @@ td pre {
 td code {
   min-width: 150px;
 }
+
+/* IBM Plex Mono font for code blocks */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://assets.ngrok.com/fonts/ibm-plex-mono/IBMPlexMono-Text.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://assets.ngrok.com/fonts/ibm-plex-mono/IBMPlexMono-TextItalic.woff') format('woff');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://assets.ngrok.com/fonts/ibm-plex-mono/IBMPlexMono-SemiBold.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://assets.ngrok.com/fonts/ibm-plex-mono/IBMPlexMono-SemiBoldItalic.woff') format('woff');
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+
+/* Apply IBM Plex Mono to code elements */
+code,
+pre,
+pre code,
+.hljs,
+.token {
+  font-family: 'IBM Plex Mono', 'Courier New', monospace !important;
+}


### PR DESCRIPTION
To better align the Mintlify site with ngrok's branding and design system, this PR adds:

- Euclid Square Semibold as the header font
- Nunito Sans as the body font
- IBM Plex as the code font (only possible via custom CSS)