### PR TITLE
Fix pages with fetched content

### DIFF
--- a/k8s/changelog.mdx
+++ b/k8s/changelog.mdx
@@ -7,7 +7,4 @@ import Changelog from "/snippets/k8s/_changelog.mdx";
 
 
 
-<RemoteMarkdownEmbedder
-	textToRemove="# Changelog"
-	url="https://raw.githubusercontent.com/ngrok/ngrok-operator/refs/heads/main/CHANGELOG.md"
-/>
+<Changelog />

--- a/k8s/installation/helm.mdx
+++ b/k8s/installation/helm.mdx
@@ -6,18 +6,13 @@ sidebarTitle: Helm Configuration
 import HelmValues from "/snippets/k8s/_helm-config.mdx";
 
 
-
-
 The following YAML block contains the default `values.yaml` used when installing the ngrok Kubernetes Operator. You can reference these values and change them individually with `--set` flags while installing/upgrading the ngrok Kubernetes operator.
 
 You can also see these values in [the ngrok operator repo](https://github.com/ngrok/ngrok-operator/blob/main/helm/ngrok-operator/values.yaml).
 
 ## Helm values
 
-<RemoteYamlBlock
-	url="https://raw.githubusercontent.com/ngrok/ngrok-operator/main/helm/ngrok-operator/values.yaml"
-	title="values.yaml"
-/>
+<HelmValues />
 
 ## Common configurations
 


### PR DESCRIPTION
the k8s changelog and helm values pages fetch content from endpoints, but that wasn't being rendered in prod. This fixes that issue.