### PR TITLE
Use defaultValue property for status_code in redirect.mdx

### DIFF
--- a/traffic-policy/actions/redirect.mdx
+++ b/traffic-policy/actions/redirect.mdx
@@ -36,8 +36,8 @@ reference for this action.
   A regular expression pattern used to replace the matched part of the URL.
 </ConfigField>
 
-<ConfigField title="status_code" type="integer" required={false}>
-  A <code>3xx</code> status code used for redirecting. Default is <code>302</code>.
+<ConfigField title="status_code" type="integer" required={false} defaultValue="302">
+  A <code>3xx</code> status code used for redirecting.
 </ConfigField>
 
 <ConfigField title="headers" type="object" required={false} cel={true}>


### PR DESCRIPTION
Use `defaultValue` property instead of inline for `status_code` field in redirect configuration.