### PR TITLE
Fix links for traffic policy variables

### DIFF
--- a/traffic-policy/variables/index.mdx
+++ b/traffic-policy/variables/index.mdx
@@ -11,13 +11,13 @@ ngrok provides a set of variables that you can use in Traffic Policy to:
 
 ### Available Variables:
 
-- [Action Variables](./action)
-- [Connection Variables](./connection)
-  - [GeoIP Variables](./connection#connection-geo-variables)
-  - [IP Intelligence Variables](./ip-intel)
+- [Action Variables](/traffic-policy/variables/action)
+- [Connection Variables](/traffic-policy/variables/connection)
+  - [GeoIP Variables](/traffic-policy/variables/connection#connection-geo-variables)
+  - [IP Intelligence Variables](/traffic-policy/variables/ip-intel)
     - [IP Categories](/traffic-policy/variables/ip-intel/#ip-categories)
-  - [TLS Variables](./connection#connection-tls-variables)
-- [Endpoint Variables](./endpoint)
-- [Request Variables](./req)
-- [Response Variables](./res)
-- [Time Variables](./time)
+  - [TLS Variables](/traffic-policy/variables/connection#connection-tls-variables)
+- [Endpoint Variables](/traffic-policy/variables/endpoint)
+- [Request Variables](/traffic-policy/variables/req)
+- [Response Variables](/traffic-policy/variables/res)
+- [Time Variables](/traffic-policy/variables/time)


### PR DESCRIPTION
Use absolute paths instead of relative paths to fix the missing `/variables` path.