### PR TITLE
Make definition wrapper color-mode aware

### DIFF
--- a/definition-wrapper.js
+++ b/definition-wrapper.js
@@ -405,7 +405,7 @@ function addTooltipBehavior(button) {
       const learnMoreLink = document.createElement('a');
       learnMoreLink.href = link;
       learnMoreLink.style.cssText = `
-        color: #60a5fa !important;
+        color: light-dark(#1e40af, #60a5fa) !important;
         text-decoration: none !important;
         cursor: pointer !important;
         font-size: 14px !important;
@@ -468,7 +468,7 @@ function addTooltipBehavior(button) {
       border-radius: 8px !important;
       font-size: 16px !important;
       font-weight: 400 !important;
-      line-height: 1.3 !important;
+      line-height: 1.75 !important;
       width: auto !important;
       max-width: ${maxWidth} !important;
       min-width: 0 !important;

--- a/definition-wrapper.js
+++ b/definition-wrapper.js
@@ -399,7 +399,7 @@ function addTooltipBehavior(button) {
       learnMoreDiv.style.cssText = `
         margin-top: 8px !important;
         padding-top: 8px !important;
-        border-top: 1px solid rgba(255, 255, 255, 0.2) !important;
+        border-top: 1px solid light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.2)) !important;
       `;
       
       const learnMoreLink = document.createElement('a');
@@ -457,12 +457,13 @@ function addTooltipBehavior(button) {
     const isMobile = window.innerWidth <= 768;
     const maxWidth = isMobile ? 'calc(100vw - 32px)' : 'min(320px, 90vw)';
     
-    // Style to match the image - dark rounded rectangle with white text
+    // Style with light/dark mode support
     tooltipElement.style.cssText = `
       position: fixed !important;
       z-index: 999999 !important;
-      background-color: #000000 !important;
-      color: white !important;
+      background-color: light-dark(white, #000000) !important;
+      color: light-dark(black, white) !important;
+      border: 1px solid light-dark(#e5e7eb, #374151) !important;
       padding: ${isMobile ? '12px' : '12px'} !important;
       border-radius: 8px !important;
       font-size: 16px !important;
@@ -475,7 +476,7 @@ function addTooltipBehavior(button) {
       overflow-wrap: break-word !important;
       white-space: normal !important;
       pointer-events: auto !important;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
+      box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3)) !important;
       display: block !important;
       visibility: visible !important;
       opacity: 1 !important;


### PR DESCRIPTION
Before this change, the definition wrapper's modal was always black with white text. Now, in light mode, it's white with black text.

Test it here:
- /universal-gateway/load-balancing-multiple-clouds#using-cloud-endpoints

Before:

<img width="1628" height="880" alt="image" src="https://github.com/user-attachments/assets/f45d40e9-4fcf-4ab7-a51f-175e1b23049f" />


After:

<img width="1626" height="878" alt="image" src="https://github.com/user-attachments/assets/5f045f4f-24ef-499e-91b5-01618e7c24ee" />