### PR TITLE
Update rate-limit-requests.mdx

### DIFF
--- a/traffic-policy/examples/rate-limit-requests.mdx
+++ b/traffic-policy/examples/rate-limit-requests.mdx
@@ -11,7 +11,7 @@ See [the `rate-limit` Traffic Policy action docs](/traffic-policy/actions/rate-l
 
 ## By endpoint
 
-This rule applies rate limiting of `30` requests per 60 seconds to the endpoint `/api/videos`.
+This rule applies rate limiting of 30 requests per minute to the endpoint `/api/videos`.
 
 <CodeGroup>
 


### PR DESCRIPTION
We had incorrect language in an example that said "30 requests per second" but should say per minute. The example specifies a rate of 60s, which is 60 seconds, so it should be "per minute"