### PR TITLE
Revise the K8s Overview page

### DIFF
--- a/k8s/index.mdx
+++ b/k8s/index.mdx
@@ -4,11 +4,11 @@ sidebarTitle: Overview
 description: Learn about the ngrok Kubernetes Operator for providing secure ingress to your k8s applications.
 ---
 
-The ngrok Kubernetes Operator provides secure ingress to your Kubernetes applications through Custom Resource Definitions (CRDs), Ingress resources, and Gateway API resources. 
-It translates Kubernetes configuration into ngrok endpoints, enabling developers to self-service endpoints to their apps and services using a shared ngrok account.
+The ngrok Kubernetes Operator exposes your Kubernetes services securely using standard Kubernetes resources like Ingress or the Gateway API. 
+With the Operator, teams can create and manage ngrok endpoints for their apps using a shared ngrok account.
 
-The Operator supports Kubernetes Bindings, which allow you to remotely deploy services to clusters by projecting endpoints as Kubernetes Services. 
-With Kubernetes Bindings, you can enable secure cross-cluster networking and project services from one cluster into other clusters running the ngrok Operator, all without exposing publicly accessible URLs.
+Optionally, bindings let you make services running elsewhere (including your local machine or another cluster) appear inside a cluster as normal Kubernetes Services. 
+This enables private, cross-cluster connectivity without publishing publicly accessible URLs.
 
 ## Concepts
 


### PR DESCRIPTION
The PR revises the K8s overview page to match the structure and style of the new Universal Gateway overview.