### PR TITLE
deprecate public_url

### DIFF
--- a/api/resources/endpoints.mdx
+++ b/api/resources/endpoints.mdx
@@ -52,7 +52,7 @@ Returns a 201 response on success
 | `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| `public_url`        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | `proto`             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | `scheme`            | string             |                                                                                                                                                           |
 | `hostport`          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |
@@ -115,7 +115,7 @@ Returns a 200 response on success
 | `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| `public_url`        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | `proto`             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | `scheme`            | string             |                                                                                                                                                           |
 | `hostport`          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |
@@ -170,7 +170,7 @@ Returns a 200 response on success
 | `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| `public_url`        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | `proto`             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | `scheme`            | string             |                                                                                                                                                           |
 | `hostport`          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |
@@ -237,7 +237,7 @@ Returns a 200 response on success
 | `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| `public_url`        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | `proto`             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | `scheme`            | string             |                                                                                                                                                           |
 | `hostport`          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |

--- a/api/resources/kubernetes-operators.mdx
+++ b/api/resources/kubernetes-operators.mdx
@@ -383,7 +383,7 @@ Returns a 200 response on success
 | `region`            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | `created_at`        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | `updated_at`        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| `public_url`        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| `public_url`        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | `proto`             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | `scheme`            | string             |                                                                                                                                                           |
 | `hostport`          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |

--- a/snippets/obs/_endpoint-list.mdx
+++ b/snippets/obs/_endpoint-list.mdx
@@ -5,7 +5,7 @@
 | region            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | created_at        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | updated_at        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| public_url        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| public_url        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | proto             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | scheme            | string             |                                                                                                                                                           |
 | hostport          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |

--- a/snippets/obs/_endpoint.mdx
+++ b/snippets/obs/_endpoint.mdx
@@ -5,7 +5,7 @@
 | region            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | created_at        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | updated_at        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| public_url        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| public_url        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | proto             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | scheme            | string             |                                                                                                                                                           |
 | hostport          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |

--- a/snippets/obs/events/reference/_endpoint-list.mdx
+++ b/snippets/obs/events/reference/_endpoint-list.mdx
@@ -5,7 +5,7 @@
 | region            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | created_at        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | updated_at        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| public_url        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| public_url        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | proto             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | scheme            | string             |                                                                                                                                                           |
 | hostport          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |

--- a/snippets/obs/events/reference/_endpoint.mdx
+++ b/snippets/obs/events/reference/_endpoint.mdx
@@ -5,7 +5,7 @@
 | region            | string             | identifier of the region this endpoint belongs to                                                                                                         |
 | created_at        | string             | timestamp when the endpoint was created in RFC 3339 format                                                                                                |
 | updated_at        | string             | timestamp when the endpoint was updated in RFC 3339 format                                                                                                |
-| public_url        | string             | URL of the hostport served by this endpoint                                                                                                               |
+| public_url        | string             | URL of the hostport served by this endpoint [deprecated: replaced by URL]                                                                                 |
 | proto             | string             | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls`                                                                                 |
 | scheme            | string             |                                                                                                                                                           |
 | hostport          | string             | hostport served by this endpoint (hostname:port) -> soon to be deprecated                                                                                 |


### PR DESCRIPTION
followup to https://github.com/ngrok-private/ngrok/pull/39817