### PR TITLE
Add snippet back into Traffic Policy CLI quickstart

### DIFF
--- a/traffic-policy/getting-started/agent-endpoints/cli.mdx
+++ b/traffic-policy/getting-started/agent-endpoints/cli.mdx
@@ -4,8 +4,6 @@ sidebarTitle: via CLI
 description: Learn how to set up an Agent Endpoint with a custom Traffic Policy using the ngrok agent CLI.
 ---
 
-
-
 ## What you'll need
 
 - An [ngrok account](https://dashboard.ngrok.com/).
@@ -15,7 +13,14 @@ description: Learn how to set up an Agent Endpoint with a custom Traffic Policy 
 
 Create a custom traffic policy file with the following contents:
 
-<GettingStarted />
+```yaml
+on_http_request:
+  - actions:
+      - type: custom-response
+        config:
+          status_code: 200
+          body: "Hello, World!"
+```
 
 This policy will respond to each HTTP request with a simple “Hello, World!” message.
 


### PR DESCRIPTION
This is currently missing, looks like it was referencing an import that no longer exists? 

Maybe the "better" way is to fix the import, but I wanted to prioritize just getting this back alive again.