### PR TITLE
Add docs for ippolicy crd that are missing

### DIFF
--- a/k8s/crds/ippolicy.mdx
+++ b/k8s/crds/ippolicy.mdx
@@ -1,5 +1,6 @@
 ---
 title: IPPolicy
+description: Learn how to use IP Policies to control traffic through your K8s endpoints.
 ---
 
 ## IPPolicy Custom Resource


### PR DESCRIPTION
The Ip Policy CRD is missing from our docs. Generated some docs using amp + the code + a dump of kubectl explain and `k get ippolicies -o yaml -A` and following the other CRD doc conventions