### PR TITLE
Add canonical URL to docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,11 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "ngrok documentation",
+  "seo": {
+    "metatags": {
+        "canonical": "https://ngrok.com/docs"
+    }
+  },
   "contextual": {
     "options": [
       "copy",


### PR DESCRIPTION
Our ngrok.mintlify.dev URL shows up in google. It seems one thing that will help is to add ngrok.com to our canonical URL

## Relevant slack threads

- https://ngrok.slack.com/archives/C09ETCLP0NS/p1760120157307379?thread_ts=1759951003.602219&cid=C09ETCLP0NS
- https://ngrok.slack.com/archives/C09ETCLP0NS/p1760120157307379?thread_ts=1759951003.602219&cid=C09ETCLP0NS

