### PR TITLE
make new ip policy crd navigatable

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -403,7 +403,8 @@
                   "k8s/crds/ngroktrafficpolicy",
                   "k8s/crds/boundendpoint",
                   "k8s/crds/domain",
-                  "k8s/crds/kubernetesoperator"
+                  "k8s/crds/kubernetesoperator",
+                  "k8s/crds/ippolicy"
                 ]
               },
               {

--- a/k8s/crds/index.mdx
+++ b/k8s/crds/index.mdx
@@ -86,3 +86,16 @@ This document will cover the CRDs you might use to achieve your goals with the n
     </Link>
 
 </div>
+
+<div className="ngrok--cards ngrok--cards-flex ngrok--cards-row">
+    <Link to={`/k8s/crds/ippolicy/`}>
+        <div className="ngrok--card hover:bg-card-hover">
+            <div className="ngrok--card-heading">
+                <h3 className="text-md sm:text-base">IPPolicy</h3>
+            </div>
+            <p className="flex-grow text-md sm:text-sm">
+              A policy to restrict access to an endpoint based on IP that can be used across endpoints.
+            </p>
+        </div>
+    </Link>
+</div>

--- a/k8s/guides/using-crds.mdx
+++ b/k8s/guides/using-crds.mdx
@@ -249,9 +249,9 @@ spec:
 
 See the [NgrokTrafficPolicy Reference](/k8s/crds/ngroktrafficpolicy) for more detailed information about `NgrokTrafficPolicy` structure and fields.
 
-## Using `Domain`, `Tunnel`, `BoundEndpoint`, and `KubernetesOperator`
+## Using `Domain`, `AgentEndpoint`, `BoundEndpoint`, and `KubernetesOperator`
 
-`Domain`, `Tunnel`, `BoundEndpoint`, and `KubernetesOperator` are all custom resources that you should not need to interface with directly very much.
+`Domain`, `AgentEndpoint`, `BoundEndpoint`, and `KubernetesOperator` are all custom resources that you should not need to interface with directly very much.
 They are created by the operator in response to `AgentEndpoint`, `CloudEndpoint`, `Ingress`, and Gateway API resources. They exist primarily to provide feedback to the user about events and resources that are created in response to your configuration and help keep the state of your cluster configuration in-sync with the resources in your ngrok account.
 
 You can use `kubectl describe` on any of them to check their status and conditions when debugging configuration.


### PR DESCRIPTION
I created a doc file for the IP Policy CRD here https://github.com/ngrok/ngrok-docs/pull/1668 but hadn't added all the links and stuff that were necessary that i learned via https://github.com/ngrok/ngrok-docs/pull/1667/files#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9e

This follows the guideline set in the tunnel PR to add navigation in the docs.json file and to add a link in the index.mdx