### PR TITLE
Remove pnpm build command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To make changes to the documentation, edit the relevant Markdown files in your l
 
 When making changes, please follow the Markdown style guide and try to keep your changes concise and to the point. If you're making significant changes or adding new content, please consider including examples or other resources to help readers understand the topic better.
 
-Once you have finished making your changes, we recommend you run a local build with mintilify (command pnpm run build) to ensure your contribution will not present errors with links or build. After a successful build, push them to your fork on GitHub and create a pull request to submit your changes for review.
+Once you have finished making your changes, we recommend you run a local build with mintilify (command pnpm run dev) to ensure your contribution will not present errors with links or build. After a successful build, push them to your fork on GitHub and create a pull request to submit your changes for review.
 
 # Code of Conduct
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "mint build",
     "dev": "mint dev --port 3333",
     "fmt:check": "biome check . --diagnostic-level=error && prettier --check .",
     "fmt": "biome check . --write --diagnostic-level=error --organize-imports-enabled=true && prettier --write .",


### PR DESCRIPTION
This doesn't seem to be a command

```
pnpm run build

> ngrok-docs-v2@1.0.0 build /Users/alex/code/ngrok-docs
> mint build

mint <command>

Commands:
  mint dev                       initialize a local preview environment
  mint openapi-check <filename>  check if an OpenAPI spec is valid
  mint broken-links              check for invalid internal links
  mint rename <from> <to>        rename a file and update all internal link refe
                                 rences
  mint update                    update the CLI to the latest version
  mint upgrade                   upgrade mint.json file to docs.json (current fo
                                 rmat)
  mint migrate-mdx               migrate MDX OpenAPI endpoint pages to x-mint ex
                                 tensions and docs.json
  mint a11y                      check for accessibility issues in documentation
                       [aliases: accessibility-check, a11y-check, accessibility]
  mint version                   display the current version of the CLI and clie
                                 nt                                 [aliases: v]
  mint new [directory]           Create a new Mintlify documentation site

Options:
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]

Unknown command: build
```

open to other suggestions, but this causes confusion when the contributing doc says to run this command and it fails