### PR TITLE
Adding command to extract root CA to docs

### DIFF
--- a/agent/config/v3.mdx
+++ b/agent/config/v3.mdx
@@ -151,16 +151,6 @@ This is the root certificate authorities used to validate the TLS connection to 
 | other values |         | path to a certificate PEM file on disk with certificate authorities to trust                
                                                                                 |
 
-#### Working with Machine-in-the-Middle (MITM) Proxies
-If you're working with machine-in-the-middle (MITM) proxies, you may need to specify a custom CA certificate to trust the ngrok server. 
-This may require you to use the ngrok root CA certificate that the agent uses to connect to the ngrok edge.
-
-Use the following command to extract the ngrok agent self-signed root CA certificate:
-
-``` strings `which ngrok` | grep 'BEGIN CERTIFICATE' -A 22 ```
-
-This outputs the root CA certificate in PEM format.
-
 #### `connect_interface`
 
 Sets the specific network interface that the ngrok agent should use. This is only supported on Linux platforms.
@@ -312,6 +302,16 @@ agent:
     - 8.8.8.8
     - example.com
 ```
+
+### Working with Machine-in-the-Middle (MITM) Proxies
+If you're working with machine-in-the-middle (MITM) proxies, you may need to specify a custom CA certificate to trust the ngrok server. 
+This may require you to use the ngrok root CA certificate that the agent uses to connect to the ngrok edge.
+
+Use the following command to extract the ngrok agent self-signed root CA certificate:
+
+``` strings `which ngrok` | grep 'BEGIN CERTIFICATE' -A 22 ```
+
+This outputs the root CA certificate in PEM format.
 
 ## Endpoint Definitions
 


### PR DESCRIPTION
[](https://ngrok.slack.com/archives/C020H4JH6Q2/p1705428345835399)

This will give users a CLI command to get the root ca of the agent so they can use ngrok with software that does deep packet inspection. 

This ticket coming in motivated the change: [](https://ngrok.zendesk.com/agent/tickets/56949)



