### PR TITLE
Remove TLS 1.0 and 1.1 mentions in docs 

### DIFF
--- a/snippets/traffic-policy/actions/terminate-tls/config.mdx
+++ b/snippets/traffic-policy/actions/terminate-tls/config.mdx
@@ -12,11 +12,11 @@ This is the [Traffic Policy](/traffic-policy/) configuration reference for this 
 
 <Config>
     <ConfigField title="min_version" type="string" required={false}>
-        <p>The minimum TLS version to support. Must be one of `1.0`, `1.1`, `1.2`, or `1.3`. Defaults to `1.2`.</p>
+        <p>The minimum TLS version to support. Must be one of `1.2` or `1.3`. Defaults to `1.2`.</p>
     </ConfigField>
 
     <ConfigField title="max_version" type="string" required={false}>
-        <p>The maximum TLS version to support. Must be one of `1.0`, `1.1`, `1.2`, or `1.3`. Defaults to `1.3`.</p>
+        <p>The maximum TLS version to support. Must be one of `1.2` or `1.3`. Defaults to `1.3`.</p>
     </ConfigField>
 
     <ConfigField title="server_private_key" type="string" required={false} cel={true}>

--- a/traffic-policy/actions/terminate-tls.mdx
+++ b/traffic-policy/actions/terminate-tls.mdx
@@ -21,11 +21,11 @@ This is the [Traffic Policy](/traffic-policy/) configuration reference for this 
 ### Configuration Fields
 
 <ConfigField title="min_version" type="string" required={false} defaultValue="1.2">
-  The minimum TLS version to support. Must be one of `1.0`, `1.1`, `1.2`, or `1.3`.
+  The minimum TLS version to support. Must be one of `1.2` or `1.3`.
 </ConfigField>
 
 <ConfigField title="max_version" type="string" required={false} defaultValue="1.3">
-  The maximum TLS version to support. Must be one of `1.0`, `1.1`, `1.2`, or `1.3`.
+  The maximum TLS version to support. Must be one of `1.2` or `1.3`.
 </ConfigField>
 
 <ConfigField title="server_private_key" type="string" required={false} cel={true}>

--- a/universal-gateway/tls-termination.mdx
+++ b/universal-gateway/tls-termination.mdx
@@ -204,7 +204,7 @@ configuration file.
 
 ngrok uses TLS 1.3 (the latest version) by default. If a client does not
 support TLS 1.3, ngrok will use the highest possible version that the client
-supports, down to TLS 1.1.
+supports, down to TLS 1.2.
 
 You may customize the minimum and maximum supported versions of TLS with the
 [`terminate-tls`](/traffic-policy/actions/terminate-tls) traffic policy action.


### PR DESCRIPTION
Remove TLS 1.0 and 1.1 mentions in docs 
https://linear.app/ngrok/project/default-minimum-tls-version-to-12-d0b9c4fb3ae2/issues