### PR TITLE
Testing fixes for error docs

### DIFF
--- a/errors/err_ngrok_3200.mdx
+++ b/errors/err_ngrok_3200.mdx
@@ -6,11 +6,9 @@ title: ERR_NGROK_3200
 keywords: ["ERR_NGROK_3200", "error 3200"]
 ---
 
-import { EndpointUrlOrigin } from "/snippets/search-params-endpoint-url.jsx";
+## Message
 
-### Message
-
-The endpoint <code><EndpointUrlOrigin fallback="HOSTNAME" /></code> is offline.
+The endpoint is offline.
 
 ### Why am I seeing ERR_NGROK_3200?
 


### PR DESCRIPTION
This should hopefully fix the issue where error docs are rendering with metadata appearing in the page content (Also the err_3200 page is broken, and this should fix that)

## Update

It did not fix the metadata issue. But the 3200 page is no longer broken