### PR TITLE
 API Ref docs tweaks

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -824,7 +824,7 @@
                     ]
                   },
                   {
-                    "group": "ReservedAddrs",
+                    "group": "Reserved Addrs",
                     "pages": [
                       "api-reference/reservedaddrs/list",
                       "api-reference/reservedaddrs/create",
@@ -834,7 +834,7 @@
                     ]
                   },
                   {
-                    "group": "ReservedDomains",
+                    "group": "Reserved Domains",
                     "pages": [
                       "api-reference/reserveddomains/list",
                       "api-reference/reserveddomains/create",
@@ -846,7 +846,7 @@
                     ]
                   },
                   {
-                    "group": "TLSCertificates",
+                    "group": "TLS Certificates",
                     "pages": [
                       "api-reference/tlscertificates/list",
                       "api-reference/tlscertificates/create",
@@ -862,7 +862,7 @@
                 "group": "Traffic Policy",
                 "pages": [
                   {
-                    "group": "CertificateAuthorities",
+                    "group": "Certificate Authorities",
                     "pages": [
                       "api-reference/certificateauthorities/list",
                       "api-reference/certificateauthorities/create",
@@ -872,7 +872,7 @@
                     ]
                   },
                   {
-                    "group": "IPPolicies",
+                    "group": "IP Policies",
                     "pages": [
                       "api-reference/ippolicies/list",
                       "api-reference/ippolicies/create",
@@ -882,7 +882,7 @@
                     ]
                   },
                   {
-                    "group": "IPPolicyRules",
+                    "group": "IP Policy Rules",
                     "pages": [
                       "api-reference/ippolicyrules/list",
                       "api-reference/ippolicyrules/create",
@@ -895,7 +895,7 @@
                     "group": "Applications",
                     "pages": [
                       {
-                        "group": "ApplicationUsers",
+                        "group": "Application Users",
                         "pages": [
                           "api-reference/applicationusers/list",
                           "api-reference/applicationusers/get",
@@ -903,7 +903,7 @@
                         ]
                       },
                       {
-                        "group": "ApplicationSessions",
+                        "group": "Application Sessions",
                         "pages": [
                           "api-reference/applicationsessions/list",
                           "api-reference/applicationsessions/get",
@@ -918,7 +918,7 @@
                 "group": "Secure Tunnels",
                 "pages": [
                   {
-                    "group": "AgentIngresses",
+                    "group": "Agent Ingresses",
                     "pages": [
                       "api-reference/agentingresses/list",
                       "api-reference/agentingresses/create",
@@ -935,7 +935,7 @@
                     ]
                   },
                   {
-                    "group": "TunnelSessions",
+                    "group": "Tunnel Sessions",
                     "pages": [
                       "api-reference/tunnelsessions/list",
                       "api-reference/tunnelsessions/get",
@@ -950,7 +950,7 @@
                 "group": "Observability",
                 "pages": [
                   {
-                    "group": "EventDestinations",
+                    "group": "Event Destinations",
                     "pages": [
                       "api-reference/eventdestinations/list",
                       "api-reference/eventdestinations/create",
@@ -960,7 +960,7 @@
                     ]
                   },
                   {
-                    "group": "EventSources",
+                    "group": "Event Sources",
                     "pages": [
                       "api-reference/eventsources/list",
                       "api-reference/eventsources/create",
@@ -970,7 +970,7 @@
                     ]
                   },
                   {
-                    "group": "EventSubscriptions",
+                    "group": "Event Subscriptions",
                     "pages": [
                       "api-reference/eventsubscriptions/list",
                       "api-reference/eventsubscriptions/create",
@@ -985,7 +985,7 @@
                 "group": "IAM",
                 "pages": [
                   {
-                    "group": "IPRestrictions",
+                    "group": "IP Restrictions",
                     "pages": [
                       "api-reference/iprestrictions/list",
                       "api-reference/iprestrictions/create",
@@ -995,7 +995,7 @@
                     ]
                   },
                   {
-                    "group": "APIKeys",
+                    "group": "API Keys",
                     "pages": [
                       "api-reference/apikeys/list",
                       "api-reference/apikeys/create",
@@ -1005,7 +1005,7 @@
                     ]
                   },
                   {
-                    "group": "SSHCredentials",
+                    "group": "SSH Credentials",
                     "pages": [
                       "api-reference/sshcredentials/list",
                       "api-reference/sshcredentials/create",
@@ -1031,7 +1031,7 @@
                 "group": "SSH Certificates",
                 "pages": [
                   {
-                    "group": "SSHCertificateAuthorities",
+                    "group": "SSH Certificate Authorities",
                     "pages": [
                       "api-reference/sshcertificateauthorities/list",
                       "api-reference/sshcertificateauthorities/create",
@@ -1041,7 +1041,7 @@
                     ]
                   },
                   {
-                    "group": "SSHHostCertificates",
+                    "group": "SSH Host Certificates",
                     "pages": [
                       "api-reference/sshhostcertificates/list",
                       "api-reference/sshhostcertificates/create",
@@ -1051,7 +1051,7 @@
                     ]
                   },
                   {
-                    "group": "SSHUserCertificates",
+                    "group": "SSH User Certificates",
                     "pages": [
                       "api-reference/sshusercertificates/list",
                       "api-reference/sshusercertificates/create",
@@ -1066,7 +1066,7 @@
                 "group": "Partners",
                 "pages": [
                   {
-                    "group": "AbuseReports",
+                    "group": "Abuse Reports",
                     "pages": [
                       "api-reference/abusereports/create",
                       "api-reference/abusereports/get"
@@ -1103,7 +1103,7 @@
                 "group": "Deprecated",
                 "pages": [
                   {
-                    "group": "BotUsers",
+                    "group": "Bot Users",
                     "pages": [
                       "api-reference/botusers/list",
                       "api-reference/botusers/create",
@@ -1116,7 +1116,7 @@
                     "group": "Backends",
                     "pages": [
                       {
-                        "group": "FailoverBackends",
+                        "group": "Failover Backends",
                         "pages": [
                           "api-reference/failoverbackends/list",
                           "api-reference/failoverbackends/create",
@@ -1126,7 +1126,7 @@
                         ]
                       },
                       {
-                        "group": "HTTPResponseBackends",
+                        "group": "HTTP Response Backends",
                         "pages": [
                           "api-reference/httpresponsebackends/list",
                           "api-reference/httpresponsebackends/create",
@@ -1136,7 +1136,7 @@
                         ]
                       },
                       {
-                        "group": "StaticBackends",
+                        "group": "Static Backends",
                         "pages": [
                           "api-reference/staticbackends/list",
                           "api-reference/staticbackends/create",
@@ -1146,7 +1146,7 @@
                         ]
                       },
                       {
-                        "group": "TunnelGroupBackends",
+                        "group": "Tunnel Group Backends",
                         "pages": [
                           "api-reference/tunnelgroupbackends/list",
                           "api-reference/tunnelgroupbackends/create",
@@ -1156,7 +1156,7 @@
                         ]
                       },
                       {
-                        "group": "WeightedBackends",
+                        "group": "Weighted Backends",
                         "pages": [
                           "api-reference/weightedbackends/list",
                           "api-reference/weightedbackends/create",
@@ -1168,7 +1168,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteBackendModule",
+                    "group": "Edge Route Backend Module",
                     "pages": [
                       "api-reference/edgeroutebackendmodule/get",
                       "api-reference/edgeroutebackendmodule/replace",
@@ -1176,7 +1176,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteCircuitBreakerModule",
+                    "group": "Edge Route Circuit Breaker Module",
                     "pages": [
                       "api-reference/edgeroutecircuitbreakermodule/get",
                       "api-reference/edgeroutecircuitbreakermodule/replace",
@@ -1184,7 +1184,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteCompressionModule",
+                    "group": "Edge Route Compression Module",
                     "pages": [
                       "api-reference/edgeroutecompressionmodule/get",
                       "api-reference/edgeroutecompressionmodule/replace",
@@ -1192,7 +1192,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteIPRestrictionModule",
+                    "group": "Edge Route IP Restriction Module",
                     "pages": [
                       "api-reference/edgerouteiprestrictionmodule/get",
                       "api-reference/edgerouteiprestrictionmodule/replace",
@@ -1200,7 +1200,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteOAuthModule",
+                    "group": "Edge Route OAuth Module",
                     "pages": [
                       "api-reference/edgerouteoauthmodule/get",
                       "api-reference/edgerouteoauthmodule/replace",
@@ -1208,7 +1208,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteOIDCModule",
+                    "group": "Edge Route OIDC Module",
                     "pages": [
                       "api-reference/edgerouteoidcmodule/get",
                       "api-reference/edgerouteoidcmodule/replace",
@@ -1216,7 +1216,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteRequestHeadersModule",
+                    "group": "Edge Route Request Headers Module",
                     "pages": [
                       "api-reference/edgerouterequestheadersmodule/get",
                       "api-reference/edgerouterequestheadersmodule/replace",
@@ -1224,7 +1224,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteResponseHeadersModule",
+                    "group": "Edge Route Response Headers Module",
                     "pages": [
                       "api-reference/edgerouteresponseheadersmodule/get",
                       "api-reference/edgerouteresponseheadersmodule/replace",
@@ -1232,7 +1232,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteSAMLModule",
+                    "group": "Edge Route SAML Module",
                     "pages": [
                       "api-reference/edgeroutesamlmodule/get",
                       "api-reference/edgeroutesamlmodule/replace",
@@ -1240,7 +1240,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteTrafficPolicyModule",
+                    "group": "Edge Route Traffic Policy Module",
                     "pages": [
                       "api-reference/edgeroutetrafficpolicymodule/get",
                       "api-reference/edgeroutetrafficpolicymodule/replace",
@@ -1248,7 +1248,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteUserAgentFilterModule",
+                    "group": "Edge Route User Agent Filter Module",
                     "pages": [
                       "api-reference/edgerouteuseragentfiltermodule/get",
                       "api-reference/edgerouteuseragentfiltermodule/replace",
@@ -1256,7 +1256,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteWebhookVerificationModule",
+                    "group": "Edge Route Webhook Verification Module",
                     "pages": [
                       "api-reference/edgeroutewebhookverificationmodule/get",
                       "api-reference/edgeroutewebhookverificationmodule/replace",
@@ -1264,7 +1264,7 @@
                     ]
                   },
                   {
-                    "group": "EdgeRouteWebsocketTCPConverterModule",
+                    "group": "Edge Route Websocket TCP Converter Module",
                     "pages": [
                       "api-reference/edgeroutewebsockettcpconvertermodule/get",
                       "api-reference/edgeroutewebsockettcpconvertermodule/replace",
@@ -1272,7 +1272,7 @@
                     ]
                   },
                   {
-                    "group": "EdgesHTTPS",
+                    "group": "Edges HTTPS",
                     "pages": [
                       "api-reference/edgeshttps/list",
                       "api-reference/edgeshttps/create",
@@ -1282,7 +1282,7 @@
                     ]
                   },
                   {
-                    "group": "EdgesHTTPSRoutes",
+                    "group": "Edges HTTPS Routes",
                     "pages": [
                       "api-reference/edgeshttpsroutes/create",
                       "api-reference/edgeshttpsroutes/get",
@@ -1291,7 +1291,7 @@
                     ]
                   },
                   {
-                    "group": "EdgesTCP",
+                    "group": "Edges TCP",
                     "pages": [
                       "api-reference/edgestcp/list",
                       "api-reference/edgestcp/create",
@@ -1301,7 +1301,7 @@
                     ]
                   },
                   {
-                    "group": "EdgesTLS",
+                    "group": "Edges TLS",
                     "pages": [
                       "api-reference/edgestls/list",
                       "api-reference/edgestls/create",
@@ -1311,7 +1311,7 @@
                     ]
                   },
                   {
-                    "group": "HTTPSEdgeMutualTLSModule",
+                    "group": "HTTPS Edge Mutual TLS Module",
                     "pages": [
                       "api-reference/httpsedgemutualtlsmodule/get",
                       "api-reference/httpsedgemutualtlsmodule/replace",
@@ -1319,7 +1319,7 @@
                     ]
                   },
                   {
-                    "group": "HTTPSEdgeTLSTerminationModule",
+                    "group": "HTTPS Edge TLS Termination Module",
                     "pages": [
                       "api-reference/httpsedgetlsterminationmodule/get",
                       "api-reference/httpsedgetlsterminationmodule/replace",
@@ -1327,7 +1327,7 @@
                     ]
                   },
                   {
-                    "group": "TCPEdgeBackendModule",
+                    "group": "TCP Edge Backend Module",
                     "pages": [
                       "api-reference/tcpedgebackendmodule/get",
                       "api-reference/tcpedgebackendmodule/replace",
@@ -1335,7 +1335,7 @@
                     ]
                   },
                   {
-                    "group": "TCPEdgeIPRestrictionModule",
+                    "group": "TCP Edge IP Restriction Module",
                     "pages": [
                       "api-reference/tcpedgeiprestrictionmodule/get",
                       "api-reference/tcpedgeiprestrictionmodule/replace",
@@ -1343,7 +1343,7 @@
                     ]
                   },
                   {
-                    "group": "TCPEdgeTrafficPolicyModule",
+                    "group": "TCP Edge Traffic Policy Module",
                     "pages": [
                       "api-reference/tcpedgetrafficpolicymodule/get",
                       "api-reference/tcpedgetrafficpolicymodule/replace",
@@ -1351,7 +1351,7 @@
                     ]
                   },
                   {
-                    "group": "TLSEdgeBackendModule",
+                    "group": "TLS Edge Backend Module",
                     "pages": [
                       "api-reference/tlsedgebackendmodule/get",
                       "api-reference/tlsedgebackendmodule/replace",
@@ -1359,7 +1359,7 @@
                     ]
                   },
                   {
-                    "group": "TLSEdgeIPRestrictionModule",
+                    "group": "TLS Edge IP Restriction Module",
                     "pages": [
                       "api-reference/tlsedgeiprestrictionmodule/get",
                       "api-reference/tlsedgeiprestrictionmodule/replace",
@@ -1367,7 +1367,7 @@
                     ]
                   },
                   {
-                    "group": "TLSEdgeMutualTLSModule",
+                    "group": "TLS Edge Mutual TLS Module",
                     "pages": [
                       "api-reference/tlsedgemutualtlsmodule/get",
                       "api-reference/tlsedgemutualtlsmodule/replace",
@@ -1375,7 +1375,7 @@
                     ]
                   },
                   {
-                    "group": "TLSEdgeTLSTerminationModule",
+                    "group": "TLS Edge TLS Termination Module",
                     "pages": [
                       "api-reference/tlsedgetlsterminationmodule/get",
                       "api-reference/tlsedgetlsterminationmodule/replace",
@@ -1383,7 +1383,7 @@
                     ]
                   },
                   {
-                    "group": "TLSEdgeTrafficPolicyModule",
+                    "group": "TLS Edge Traffic Policy Module",
                     "pages": [
                       "api-reference/tlsedgetrafficpolicymodule/get",
                       "api-reference/tlsedgetrafficpolicymodule/replace",


### PR DESCRIPTION
 - Un-nest IP Policies and IP Policy Rules docs 
 - Add spaces between the words, so an entry like `TLSEdgeTrafficPolicyModule` becomes `TLS Edge Traffic Policy Module`.

Preview: https://ngrok-api-ref-docs-tweaks.mintlify.app/api-reference/endpoints/list
