### PR TITLE
Fix definition wrapper

### DIFF
--- a/definition-wrapper.js
+++ b/definition-wrapper.js
@@ -272,7 +272,7 @@ function replaceInTextNodes(element, regex, termTitle, termObj) {
     {
       acceptNode: function(node) {
         // Skip text nodes that are inside excluded elements
-        if (isInsideExcludedElement(node.parentElement) || window?.location?.href?.pathname?.includes("glossary")) {
+        if (isInsideExcludedElement(node.parentElement) || window?.location?.pathname?.includes("glossary")) {
           return NodeFilter.FILTER_REJECT;
         }
         return NodeFilter.FILTER_ACCEPT;


### PR DESCRIPTION
In my PR that created the glossary, I accidentally made the definition wrapper stop showing up. This fixes it (and prevents it from showing up on the glossary page)

- [Glossary page](https://ngrok-fix-definition-wrapper.mintlify.app/glossary) (should not render definition wrapper component)
- [Homepage](https://ngrok-fix-definition-wrapper.mintlify.app/what-is-ngrok) (should render definitions for ingress for example)