### PR TITLE
automated generation of docs from buildkite

### DIFF
--- a/agent/cli.mdx
+++ b/agent/cli.mdx
@@ -59,7 +59,7 @@ ngrok http 80 --url https://api.example.com --pooling-enabled
 ngrok http 80 --url https://svc.internal
 ngrok tcp 5432 --url tcp://postgres.internal:5432
 
-# make your endpoint URL addressable only from k8s clusters
+# make your endpoint url addressable only from k8s clusters
 # where you've installed the ngrok k8s operator
 ngrok http 80 --url https://example.namespace --binding kubernetes
 

--- a/errors/err_ngrok_4027.mdx
+++ b/errors/err_ngrok_4027.mdx
@@ -1,0 +1,15 @@
+---
+mode: wide
+title: ERR_NGROK_4027
+keywords: ["ERR_NGROK_4027", "error 4027"]
+---
+
+## Message
+Your account’s included bandwidth has been depleted. If you still have credit, you may still use it to buy more bandwidth.
+
+
+
+
+## Further help
+If you're having trouble resolving this error, please reach out to [support@ngrok.com](mailto:support@ngrok.com?subject=Help%20with%20ERR_NGROK_4027)
+

--- a/errors/err_ngrok_702.mdx
+++ b/errors/err_ngrok_702.mdx
@@ -12,7 +12,7 @@ Too many connections! The tunnel session `SESSION` has violated the rate-limit p
 ### Additional Info
 
 - ngrok limits the number of inbound connections to your tunnels.
-- Limits are imposed on connections, not requests. If your HTTP clients use persistent connections such as HTTP keep-alive (most modern ones do), you'll likely never hit this limit.
+- Limits are imposed on connections, not requests. If your HTTP clients use persistent connections aka HTTP keep-alive (most modern ones do), you'll likely never hit this limit.
 - ngrok will return a `429` response to HTTP connections that exceed the rate limit.
 - Connections to TCP and TLS tunnels violating the rate limit will be closed without a response.
 

--- a/snippets/errors/_err_ngrok_list.mdx
+++ b/snippets/errors/_err_ngrok_list.mdx
@@ -778,6 +778,7 @@
 | [ERR_NGROK_4024](/errors/err_ngrok_4024) | Your account plan cannot be downgraded: `REASON` |
 | [ERR_NGROK_4025](/errors/err_ngrok_4025) | Your account plan cannot be upgraded: `REASON` |
 | [ERR_NGROK_4026](/errors/err_ngrok_4026) | Your account has run out of credit, please upgrade to continue using paid actions, or use your dev domain and remove all paid traffic policy from it. |
+| [ERR_NGROK_4027](/errors/err_ngrok_4027) | Your account’s included bandwidth has been depleted. If you still have credit, you may still use it to buy more bandwidth. |
 | [ERR_NGROK_4100](/errors/err_ngrok_4100) | The email or password you entered is not valid. |
 | [ERR_NGROK_4101](/errors/err_ngrok_4101) | A user with the email address `EMAIL` already exists. |
 | [ERR_NGROK_4103](/errors/err_ngrok_4103) | `EMAIL` is not a valid email address. |

--- a/snippets/obs/_abuse-report.mdx
+++ b/snippets/obs/_abuse-report.mdx
@@ -6,5 +6,5 @@
 | urls | List&lt;string&gt; | a list of URLs containing suspected abusive content |
 | metadata | string | arbitrary user-defined data about this abuse report. Optional, max 4096 bytes. |
 | status | string | Indicates whether ngrok has processed the abuse report. one of `PENDING`, `PROCESSED`, or `PARTIALLY_PROCESSED` |
-| hostname | string | the hostname ngrok has parsed out of one of the reported URLs in this abuse report |
-| status | string | indicates what action ngrok has taken against the hostname. one of `PENDING`, `BANNED`, `UNBANNED`, or `IGNORE` |
+| hostnames.hostname | string | the hostname ngrok has parsed out of one of the reported URLs in this abuse report |
+| hostnames.status | string | indicates what action ngrok has taken against the hostname. one of `PENDING`, `BANNED`, `UNBANNED`, or `IGNORE` |

--- a/snippets/obs/_agent-ingress-cert-status.mdx
+++ b/snippets/obs/_agent-ingress-cert-status.mdx
@@ -1,7 +1,7 @@
 | Name | Type | Description |
 |---|---|---|
 | renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
+| provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| provisioning_job.msg | string | a message describing the current status or error |
+| provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |

--- a/snippets/obs/_agent-ingress-create.mdx
+++ b/snippets/obs/_agent-ingress-create.mdx
@@ -3,5 +3,5 @@
 | description | string | human-readable description of the use of this Agent Ingress. optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this Agent Ingress. optional, max 4096 bytes |
 | domain | string | the domain that you own to be used as the base domain name to generate regional agent ingress domains. |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |

--- a/snippets/obs/_agent-ingress-list.mdx
+++ b/snippets/obs/_agent-ingress-list.mdx
@@ -1,19 +1,19 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique Agent Ingress resource identifier |
-| uri | string | URI to the API resource of this Agent ingress |
-| description | string | human-readable description of the use of this Agent Ingress. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this Agent Ingress. optional, max 4096 bytes |
-| domain | string | the domain that you own to be used as the base domain name to generate regional agent ingress domains. |
-| ns_targets | List&lt;string&gt; | a list of target values to use as the values of NS records for the domain property these values will delegate control over the domain to ngrok |
-| region_domains | List&lt;string&gt; | a list of regional agent ingress domains that are subdomains of the value of domain this value may increase over time as ngrok adds more regions |
-| created_at | string | timestamp when the Agent Ingress was created, RFC 3339 format |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
-| renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
+| ingresses.id | string | unique Agent Ingress resource identifier |
+| ingresses.uri | string | URI to the API resource of this Agent ingress |
+| ingresses.description | string | human-readable description of the use of this Agent Ingress. optional, max 255 bytes. |
+| ingresses.metadata | string | arbitrary user-defined machine-readable data of this Agent Ingress. optional, max 4096 bytes |
+| ingresses.domain | string | the domain that you own to be used as the base domain name to generate regional agent ingress domains. |
+| ingresses.ns_targets | List&lt;string&gt; | a list of target values to use as the values of NS records for the domain property these values will delegate control over the domain to ngrok |
+| ingresses.region_domains | List&lt;string&gt; | a list of regional agent ingress domains that are subdomains of the value of domain this value may increase over time as ngrok adds more regions |
+| ingresses.created_at | string | timestamp when the Agent Ingress was created, RFC 3339 format |
+| ingresses.certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| ingresses.certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
+| ingresses.certificate_management_status.renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
+| ingresses.certificate_management_status.provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| ingresses.certificate_management_status.provisioning_job.msg | string | a message describing the current status or error |
+| ingresses.certificate_management_status.provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| ingresses.certificate_management_status.provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |
 | uri | string | URI of the Agent Ingress list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_agent-ingress-update.mdx
+++ b/snippets/obs/_agent-ingress-update.mdx
@@ -3,5 +3,5 @@
 | id | string |  |
 | description | string | human-readable description of the use of this Agent Ingress. optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this Agent Ingress. optional, max 4096 bytes |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |

--- a/snippets/obs/_agent-ingress.mdx
+++ b/snippets/obs/_agent-ingress.mdx
@@ -8,10 +8,10 @@
 | ns_targets | List&lt;string&gt; | a list of target values to use as the values of NS records for the domain property these values will delegate control over the domain to ngrok |
 | region_domains | List&lt;string&gt; | a list of regional agent ingress domains that are subdomains of the value of domain this value may increase over time as ngrok adds more regions |
 | created_at | string | timestamp when the Agent Ingress was created, RFC 3339 format |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
-| renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to rsa, can be either rsa or ecdsa. |
+| certificate_management_status.renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
+| certificate_management_status.provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| certificate_management_status.provisioning_job.msg | string | a message describing the current status or error |
+| certificate_management_status.provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| certificate_management_status.provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |

--- a/snippets/obs/_agent-session-event.mdx
+++ b/snippets/obs/_agent-session-event.mdx
@@ -1,9 +1,9 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| session.id | string | a resource identifier |
+| session.uri | string | a uri for locating a resource |
+| credential.id | string | a resource identifier |
+| credential.uri | string | a uri for locating a resource |
 | agent_ip | string | the ip address from which the agent is connecting |
 | ingress_server_ip | string | the ip address of the ingress server to which the agent is connecting |
 | region | string | the region of the tunnel server |
@@ -16,7 +16,7 @@
 | started_at | string | the time at which the session started |
 | expires_at | string | the time at which the session expires |
 | stopped_at | string | the time at which the session stopped |
-| upcoming_minimum_version | string | the upcoming minimum supported agent version |
-| upcoming_enforcement_date | string | the date by which the current agent must be upgraded to the upcoming minimum version |
-| message | string | additional information about the agent deprecation |
+| deprecated.upcoming_minimum_version | string | the upcoming minimum supported agent version |
+| deprecated.upcoming_enforcement_date | string | the date by which the current agent must be upgraded to the upcoming minimum version |
+| deprecated.message | string | additional information about the agent deprecation |
 | error | string | on a failed session start, an explanation of the failure on a successful session start, the empty string on a session stop, the reason for the session stop |

--- a/snippets/obs/_api-key-list.mdx
+++ b/snippets/obs/_api-key-list.mdx
@@ -1,11 +1,11 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique API key resource identifier |
-| uri | string | URI to the API resource of this API key |
-| description | string | human-readable description of what uses the API key to authenticate. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined data of this API key. optional, max 4096 bytes |
-| created_at | string | timestamp when the api key was created, RFC 3339 format |
-| token | string | the bearer token that can be placed into the Authorization header to authenticate request to the ngrok API. **This value is only available one time, on the API response from key creation. Otherwise it is null.** |
-| owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
+| keys.id | string | unique API key resource identifier |
+| keys.uri | string | URI to the API resource of this API key |
+| keys.description | string | human-readable description of what uses the API key to authenticate. optional, max 255 bytes. |
+| keys.metadata | string | arbitrary user-defined data of this API key. optional, max 4096 bytes |
+| keys.created_at | string | timestamp when the api key was created, RFC 3339 format |
+| keys.token | string | the bearer token that can be placed into the Authorization header to authenticate request to the ngrok API. **This value is only available one time, on the API response from key creation. Otherwise it is null.** |
+| keys.owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
 | uri | string | URI of the API keys list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_application-session-list.mdx
+++ b/snippets/obs/_application-session-list.mdx
@@ -1,29 +1,29 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique application session resource identifier |
-| uri | string | URI of the application session API resource |
-| public_url | string | URL of the hostport served by this endpoint |
-| raw | string | raw User-Agent request header |
-| browser_name | string | browser name (e.g. Chrome) |
-| browser_version | string | browser version (e.g. 102) |
-| device_type | string | type of device (e.g. Desktop) |
-| os_name | string | operating system name (e.g. MacOS) |
-| os_version | string | operating system version (e.g. 10.15.7) |
-| ip_address | string | IP address |
-| country_code | string | ISO country code |
-| latitude | float64 | geographical latitude |
-| longitude | float64 | geographical longitude |
-| lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| created_at | string | timestamp when the user was created in RFC 3339 format |
-| last_active | string | timestamp when the user was last active in RFC 3339 format |
-| expires_at | string | timestamp when session expires in RFC 3339 format |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| application_sessions.id | string | unique application session resource identifier |
+| application_sessions.uri | string | URI of the application session API resource |
+| application_sessions.public_url | string | URL of the hostport served by this endpoint |
+| application_sessions.browser_session.user_agent.raw | string | raw User-Agent request header |
+| application_sessions.browser_session.user_agent.browser_name | string | browser name (e.g. Chrome) |
+| application_sessions.browser_session.user_agent.browser_version | string | browser version (e.g. 102) |
+| application_sessions.browser_session.user_agent.device_type | string | type of device (e.g. Desktop) |
+| application_sessions.browser_session.user_agent.os_name | string | operating system name (e.g. MacOS) |
+| application_sessions.browser_session.user_agent.os_version | string | operating system version (e.g. 10.15.7) |
+| application_sessions.browser_session.ip_address | string | IP address |
+| application_sessions.browser_session.location.country_code | string | ISO country code |
+| application_sessions.browser_session.location.latitude | float64 | geographical latitude |
+| application_sessions.browser_session.location.longitude | float64 | geographical longitude |
+| application_sessions.browser_session.location.lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |
+| application_sessions.application_user.id | string | a resource identifier |
+| application_sessions.application_user.uri | string | a uri for locating a resource |
+| application_sessions.created_at | string | timestamp when the user was created in RFC 3339 format |
+| application_sessions.last_active | string | timestamp when the user was last active in RFC 3339 format |
+| application_sessions.expires_at | string | timestamp when session expires in RFC 3339 format |
+| application_sessions.endpoint.id | string | a resource identifier |
+| application_sessions.endpoint.uri | string | a uri for locating a resource |
+| application_sessions.edge.id | string | a resource identifier |
+| application_sessions.edge.uri | string | a uri for locating a resource |
+| application_sessions.route.id | string | a resource identifier |
+| application_sessions.route.uri | string | a uri for locating a resource |
 | uri | string | URI of the application session list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_application-session.mdx
+++ b/snippets/obs/_application-session.mdx
@@ -3,25 +3,25 @@
 | id | string | unique application session resource identifier |
 | uri | string | URI of the application session API resource |
 | public_url | string | URL of the hostport served by this endpoint |
-| raw | string | raw User-Agent request header |
-| browser_name | string | browser name (e.g. Chrome) |
-| browser_version | string | browser version (e.g. 102) |
-| device_type | string | type of device (e.g. Desktop) |
-| os_name | string | operating system name (e.g. MacOS) |
-| os_version | string | operating system version (e.g. 10.15.7) |
-| ip_address | string | IP address |
-| country_code | string | ISO country code |
-| latitude | float64 | geographical latitude |
-| longitude | float64 | geographical longitude |
-| lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| browser_session.user_agent.raw | string | raw User-Agent request header |
+| browser_session.user_agent.browser_name | string | browser name (e.g. Chrome) |
+| browser_session.user_agent.browser_version | string | browser version (e.g. 102) |
+| browser_session.user_agent.device_type | string | type of device (e.g. Desktop) |
+| browser_session.user_agent.os_name | string | operating system name (e.g. MacOS) |
+| browser_session.user_agent.os_version | string | operating system version (e.g. 10.15.7) |
+| browser_session.ip_address | string | IP address |
+| browser_session.location.country_code | string | ISO country code |
+| browser_session.location.latitude | float64 | geographical latitude |
+| browser_session.location.longitude | float64 | geographical longitude |
+| browser_session.location.lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |
+| application_user.id | string | a resource identifier |
+| application_user.uri | string | a uri for locating a resource |
 | created_at | string | timestamp when the user was created in RFC 3339 format |
 | last_active | string | timestamp when the user was last active in RFC 3339 format |
 | expires_at | string | timestamp when session expires in RFC 3339 format |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| endpoint.id | string | a resource identifier |
+| endpoint.uri | string | a uri for locating a resource |
+| edge.id | string | a resource identifier |
+| edge.uri | string | a uri for locating a resource |
+| route.id | string | a resource identifier |
+| route.uri | string | a uri for locating a resource |

--- a/snippets/obs/_application-user-list.mdx
+++ b/snippets/obs/_application-user-list.mdx
@@ -1,15 +1,15 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique application user resource identifier |
-| uri | string | URI of the application user API resource |
-| name | string | name of the identity provider (e.g. Google) |
-| url | string | URL of the identity provider (e.g. https://accounts.google.com) |
-| provider_user_id | string | unique user identifier |
-| username | string | user username |
-| email | string | user email |
-| name | string | user common name |
-| created_at | string | timestamp when the user was created in RFC 3339 format |
-| last_active | string | timestamp when the user was last active in RFC 3339 format |
-| last_login | string | timestamp when the user last signed-in in RFC 3339 format |
+| application_users.id | string | unique application user resource identifier |
+| application_users.uri | string | URI of the application user API resource |
+| application_users.identity_provider.name | string | name of the identity provider (e.g. Google) |
+| application_users.identity_provider.url | string | URL of the identity provider (e.g. https://accounts.google.com) |
+| application_users.provider_user_id | string | unique user identifier |
+| application_users.username | string | user username |
+| application_users.email | string | user email |
+| application_users.name | string | user common name |
+| application_users.created_at | string | timestamp when the user was created in RFC 3339 format |
+| application_users.last_active | string | timestamp when the user was last active in RFC 3339 format |
+| application_users.last_login | string | timestamp when the user last signed-in in RFC 3339 format |
 | uri | string | URI of the application user list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_application-user.mdx
+++ b/snippets/obs/_application-user.mdx
@@ -2,8 +2,8 @@
 |---|---|---|
 | id | string | unique application user resource identifier |
 | uri | string | URI of the application user API resource |
-| name | string | name of the identity provider (e.g. Google) |
-| url | string | URL of the identity provider (e.g. https://accounts.google.com) |
+| identity_provider.name | string | name of the identity provider (e.g. Google) |
+| identity_provider.url | string | URL of the identity provider (e.g. https://accounts.google.com) |
 | provider_user_id | string | unique user identifier |
 | username | string | user username |
 | email | string | user email |

--- a/snippets/obs/_audit-event-tunnel-session.mdx
+++ b/snippets/obs/_audit-event-tunnel-session.mdx
@@ -17,9 +17,9 @@
 | config_version | string |  |
 | custom_cas | boolean |  |
 | client_type | string |  |
-| name | string | The product name |
-| version | string | The product version |
-| comment | string | An optional comment |
-| next_min | string |  |
-| next_date | string |  |
-| msg | string |  |
+| user_agent.products.name | string | The product name |
+| user_agent.products.version | string | The product version |
+| user_agent.products.comment | string | An optional comment |
+| deprecated.next_min | string |  |
+| deprecated.next_date | string |  |
+| deprecated.msg | string |  |

--- a/snippets/obs/_aws-auth.mdx
+++ b/snippets/obs/_aws-auth.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
+| role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| creds.aws_secret_access_key | string | The secret portion of an AWS access key. |

--- a/snippets/obs/_bot-user-list.mdx
+++ b/snippets/obs/_bot-user-list.mdx
@@ -1,9 +1,9 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique API key resource identifier |
-| uri | string | URI to the API resource of this bot user |
-| name | string | human-readable name used to identify the bot |
-| active | boolean | whether or not the bot is active |
-| created_at | string | timestamp when the api key was created, RFC 3339 format |
+| bot_users.id | string | unique API key resource identifier |
+| bot_users.uri | string | URI to the API resource of this bot user |
+| bot_users.name | string | human-readable name used to identify the bot |
+| bot_users.active | boolean | whether or not the bot is active |
+| bot_users.created_at | string | timestamp when the api key was created, RFC 3339 format |
 | uri | string | URI of the bot users list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_browser-session.mdx
+++ b/snippets/obs/_browser-session.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
-| raw | string | raw User-Agent request header |
-| browser_name | string | browser name (e.g. Chrome) |
-| browser_version | string | browser version (e.g. 102) |
-| device_type | string | type of device (e.g. Desktop) |
-| os_name | string | operating system name (e.g. MacOS) |
-| os_version | string | operating system version (e.g. 10.15.7) |
+| user_agent.raw | string | raw User-Agent request header |
+| user_agent.browser_name | string | browser name (e.g. Chrome) |
+| user_agent.browser_version | string | browser version (e.g. 102) |
+| user_agent.device_type | string | type of device (e.g. Desktop) |
+| user_agent.os_name | string | operating system name (e.g. MacOS) |
+| user_agent.os_version | string | operating system version (e.g. 10.15.7) |
 | ip_address | string | IP address |
-| country_code | string | ISO country code |
-| latitude | float64 | geographical latitude |
-| longitude | float64 | geographical longitude |
-| lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |
+| location.country_code | string | ISO country code |
+| location.latitude | float64 | geographical latitude |
+| location.longitude | float64 | geographical longitude |
+| location.lat_long_radius_km | uint64 | accuracy radius of the geographical coordinates |

--- a/snippets/obs/_certificate-authority-list.mdx
+++ b/snippets/obs/_certificate-authority-list.mdx
@@ -1,15 +1,15 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this Certificate Authority |
-| uri | string | URI of the Certificate Authority API resource |
-| created_at | string | timestamp when the Certificate Authority was created, RFC 3339 format |
-| description | string | human-readable description of this Certificate Authority. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this Certificate Authority. optional, max 4096 bytes. |
-| ca_pem | string | raw PEM of the Certificate Authority |
-| subject_common_name | string | subject common name of the Certificate Authority |
-| not_before | string | timestamp when this Certificate Authority becomes valid, RFC 3339 format |
-| not_after | string | timestamp when this Certificate Authority becomes invalid, RFC 3339 format |
-| key_usages | List&lt;string&gt; | set of actions the private key of this Certificate Authority can be used for |
-| extended_key_usages | List&lt;string&gt; | extended set of actions the private key of this Certificate Authority can be used for |
+| certificate_authorities.id | string | unique identifier for this Certificate Authority |
+| certificate_authorities.uri | string | URI of the Certificate Authority API resource |
+| certificate_authorities.created_at | string | timestamp when the Certificate Authority was created, RFC 3339 format |
+| certificate_authorities.description | string | human-readable description of this Certificate Authority. optional, max 255 bytes. |
+| certificate_authorities.metadata | string | arbitrary user-defined machine-readable data of this Certificate Authority. optional, max 4096 bytes. |
+| certificate_authorities.ca_pem | string | raw PEM of the Certificate Authority |
+| certificate_authorities.subject_common_name | string | subject common name of the Certificate Authority |
+| certificate_authorities.not_before | string | timestamp when this Certificate Authority becomes valid, RFC 3339 format |
+| certificate_authorities.not_after | string | timestamp when this Certificate Authority becomes invalid, RFC 3339 format |
+| certificate_authorities.key_usages | List&lt;string&gt; | set of actions the private key of this Certificate Authority can be used for |
+| certificate_authorities.extended_key_usages | List&lt;string&gt; | extended set of actions the private key of this Certificate Authority can be used for |
 | uri | string | URI of the certificates authorities list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_credential-list.mdx
+++ b/snippets/obs/_credential-list.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique tunnel credential resource identifier |
-| uri | string | URI of the tunnel credential API resource |
-| created_at | string | timestamp when the tunnel credential was created, RFC 3339 format |
-| description | string | human-readable description of who or what will use the credential to authenticate. Optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this credential. Optional, max 4096 bytes. |
-| token | string | the credential's authtoken that can be used to authenticate an ngrok agent. **This value is only available one time, on the API response from credential creation, otherwise it is null.** |
-| acl | List&lt;string&gt; | optional list of ACL rules. If unspecified, the credential will have no restrictions. The only allowed ACL rule at this time is the `bind` rule. The `bind` rule allows the caller to restrict what domains, addresses, and labels the token is allowed to bind. For example, to allow the token to open a tunnel on example.ngrok.io your ACL would include the rule `bind:example.ngrok.io`. Bind rules for domains may specify a leading wildcard to match multiple domains with a common suffix. For example, you may specify a rule of `bind:*.example.com` which will allow `x.example.com`, `y.example.com`, `*.example.com`, etc. Bind rules for labels may specify a wildcard key and/or value to match multiple labels. For example, you may specify a rule of `bind:*=example` which will allow `x=example`, `y=example`, etc. A rule of `'*'` is equivalent to no acl at all and will explicitly permit all actions. |
-| owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
+| credentials.id | string | unique tunnel credential resource identifier |
+| credentials.uri | string | URI of the tunnel credential API resource |
+| credentials.created_at | string | timestamp when the tunnel credential was created, RFC 3339 format |
+| credentials.description | string | human-readable description of who or what will use the credential to authenticate. Optional, max 255 bytes. |
+| credentials.metadata | string | arbitrary user-defined machine-readable data of this credential. Optional, max 4096 bytes. |
+| credentials.token | string | the credential's authtoken that can be used to authenticate an ngrok agent. **This value is only available one time, on the API response from credential creation, otherwise it is null.** |
+| credentials.acl | List&lt;string&gt; | optional list of ACL rules. If unspecified, the credential will have no restrictions. The only allowed ACL rule at this time is the `bind` rule. The `bind` rule allows the caller to restrict what domains, addresses, and labels the token is allowed to bind. For example, to allow the token to open a tunnel on example.ngrok.io your ACL would include the rule `bind:example.ngrok.io`. Bind rules for domains may specify a leading wildcard to match multiple domains with a common suffix. For example, you may specify a rule of `bind:*.example.com` which will allow `x.example.com`, `y.example.com`, `*.example.com`, etc. Bind rules for labels may specify a wildcard key and/or value to match multiple labels. For example, you may specify a rule of `bind:*=example` which will allow `x=example`, `y=example`, etc. A rule of `'*'` is equivalent to no acl at all and will explicitly permit all actions. |
+| credentials.owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
 | uri | string | URI of the tunnel credential list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_edge-backend-replace.mdx
+++ b/snippets/obs/_edge-backend-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.backend_id | string | backend to be used to back this endpoint |

--- a/snippets/obs/_edge-ip-restriction-replace.mdx
+++ b/snippets/obs/_edge-ip-restriction-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |

--- a/snippets/obs/_edge-mutual-tls-replace.mdx
+++ b/snippets/obs/_edge-mutual-tls-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |

--- a/snippets/obs/_edge-policy-replace.mdx
+++ b/snippets/obs/_edge-policy-replace.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.inbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| module.inbound.actions.type | string | the type of action on the policy rule. |
+| module.inbound.actions.config | object | the configuration for the action on the policy rule. |
+| module.inbound.name | string | the name of the rule that is part of the traffic policy. |
+| module.outbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| module.outbound.actions.type | string | the type of action on the policy rule. |
+| module.outbound.actions.config | object | the configuration for the action on the policy rule. |
+| module.outbound.name | string | the name of the rule that is part of the traffic policy. |

--- a/snippets/obs/_edge-route-backend-replace.mdx
+++ b/snippets/obs/_edge-route-backend-replace.mdx
@@ -2,5 +2,5 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.backend_id | string | backend to be used to back this endpoint |

--- a/snippets/obs/_edge-route-circuit-breaker-replace.mdx
+++ b/snippets/obs/_edge-route-circuit-breaker-replace.mdx
@@ -2,9 +2,9 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| module.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| module.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| module.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| module.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |

--- a/snippets/obs/_edge-route-compression-replace.mdx
+++ b/snippets/obs/_edge-route-compression-replace.mdx
@@ -2,4 +2,4 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |

--- a/snippets/obs/_edge-route-ip-restriction-replace.mdx
+++ b/snippets/obs/_edge-route-ip-restriction-replace.mdx
@@ -2,5 +2,5 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |

--- a/snippets/obs/_edge-route-o-auth-replace.mdx
+++ b/snippets/obs/_edge-route-o-auth-replace.mdx
@@ -2,51 +2,51 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| module.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| module.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.linkedin.client_id | string |  |
+| module.provider.linkedin.client_secret | string |  |
+| module.provider.linkedin.scopes | List&lt;string&gt; |  |
+| module.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| module.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| module.provider.gitlab.client_id | string |  |
+| module.provider.gitlab.client_secret | string |  |
+| module.provider.gitlab.scopes | List&lt;string&gt; |  |
+| module.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| module.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| module.provider.twitch.client_id | string |  |
+| module.provider.twitch.client_secret | string |  |
+| module.provider.twitch.scopes | List&lt;string&gt; |  |
+| module.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| module.provider.twitch.email_domains | List&lt;string&gt; |  |
+| module.provider.amazon.client_id | string |  |
+| module.provider.amazon.client_secret | string |  |
+| module.provider.amazon.scopes | List&lt;string&gt; |  |
+| module.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| module.provider.amazon.email_domains | List&lt;string&gt; |  |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |

--- a/snippets/obs/_edge-route-oidc-replace.mdx
+++ b/snippets/obs/_edge-route-oidc-replace.mdx
@@ -2,12 +2,12 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| module.client_id | string | The OIDC app's client ID and OIDC audience. |
+| module.client_secret | string | The OIDC app's client secret. |
+| module.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |

--- a/snippets/obs/_edge-route-policy-replace.mdx
+++ b/snippets/obs/_edge-route-policy-replace.mdx
@@ -2,12 +2,12 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.inbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| module.inbound.actions.type | string | the type of action on the policy rule. |
+| module.inbound.actions.config | object | the configuration for the action on the policy rule. |
+| module.inbound.name | string | the name of the rule that is part of the traffic policy. |
+| module.outbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| module.outbound.actions.type | string | the type of action on the policy rule. |
+| module.outbound.actions.config | object | the configuration for the action on the policy rule. |
+| module.outbound.name | string | the name of the rule that is part of the traffic policy. |

--- a/snippets/obs/_edge-route-request-headers-replace.mdx
+++ b/snippets/obs/_edge-route-request-headers-replace.mdx
@@ -2,6 +2,6 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| module.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |

--- a/snippets/obs/_edge-route-response-headers-replace.mdx
+++ b/snippets/obs/_edge-route-response-headers-replace.mdx
@@ -2,6 +2,6 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| module.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |

--- a/snippets/obs/_edge-route-saml-replace.mdx
+++ b/snippets/obs/_edge-route-saml-replace.mdx
@@ -2,13 +2,13 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| module.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| module.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| module.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| module.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |

--- a/snippets/obs/_edge-route-traffic-policy-replace.mdx
+++ b/snippets/obs/_edge-route-traffic-policy-replace.mdx
@@ -2,5 +2,5 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_edge-route-user-agent-filter-replace.mdx
+++ b/snippets/obs/_edge-route-user-agent-filter-replace.mdx
@@ -2,6 +2,6 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
+| module.enabled | boolean |  |
+| module.allow | List&lt;string&gt; |  |
+| module.deny | List&lt;string&gt; |  |

--- a/snippets/obs/_edge-route-webhook-verification-replace.mdx
+++ b/snippets/obs/_edge-route-webhook-verification-replace.mdx
@@ -2,6 +2,6 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| module.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |

--- a/snippets/obs/_edge-route-websocket-tcp-converter-replace.mdx
+++ b/snippets/obs/_edge-route-websocket-tcp-converter-replace.mdx
@@ -2,4 +2,4 @@
 |---|---|---|
 | edge_id | string |  |
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |

--- a/snippets/obs/_edge-tls-termination-at-edge-replace.mdx
+++ b/snippets/obs/_edge-tls-termination-at-edge-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |

--- a/snippets/obs/_edge-tls-termination-replace.mdx
+++ b/snippets/obs/_edge-tls-termination-replace.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| module.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |

--- a/snippets/obs/_edge-traffic-policy-replace.mdx
+++ b/snippets/obs/_edge-traffic-policy-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_endpoint-backend-replace.mdx
+++ b/snippets/obs/_endpoint-backend-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.backend_id | string | backend to be used to back this endpoint |

--- a/snippets/obs/_endpoint-backend.mdx
+++ b/snippets/obs/_endpoint-backend.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| backend.id | string | a resource identifier |
+| backend.uri | string | a uri for locating a resource |

--- a/snippets/obs/_endpoint-basic-auth-replace.mdx
+++ b/snippets/obs/_endpoint-basic-auth-replace.mdx
@@ -1,7 +1,7 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| auth_provider_id | string | determines how the basic auth credentials are validated. Currently only the value `agent` is supported which means that credentials will be validated against the username and password specified by the ngrok agent's `--basic-auth` flag, if any. |
-| realm | string | an arbitrary string to be specified in as the 'realm' value in the `WWW-Authenticate` header. default is `ngrok` |
-| allow_options | boolean | true or false indicating whether to allow OPTIONS requests through without authentication which is necessary for CORS. default is `false` |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.auth_provider_id | string | determines how the basic auth credentials are validated. Currently only the value `agent` is supported which means that credentials will be validated against the username and password specified by the ngrok agent's `--basic-auth` flag, if any. |
+| module.realm | string | an arbitrary string to be specified in as the 'realm' value in the `WWW-Authenticate` header. default is `ngrok` |
+| module.allow_options | boolean | true or false indicating whether to allow OPTIONS requests through without authentication which is necessary for CORS. default is `false` |

--- a/snippets/obs/_endpoint-circuit-breaker-replace.mdx
+++ b/snippets/obs/_endpoint-circuit-breaker-replace.mdx
@@ -1,9 +1,9 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| module.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| module.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| module.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| module.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |

--- a/snippets/obs/_endpoint-compression-replace.mdx
+++ b/snippets/obs/_endpoint-compression-replace.mdx
@@ -1,4 +1,4 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |

--- a/snippets/obs/_endpoint-configuration-create.mdx
+++ b/snippets/obs/_endpoint-configuration-create.mdx
@@ -3,95 +3,95 @@
 | type | string | they type of traffic this endpoint configuration can be applied to. one of: `http`, `https`, `tcp` |
 | description | string | human-readable description of what this endpoint configuration will be do when applied or what traffic it will be applied to. Optional, max 255 bytes |
 | metadata | string | arbitrary user-defined machine-readable data of this endpoint configuration. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| ip_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_policy.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| webhook_validation.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_validation.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_validation.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |

--- a/snippets/obs/_endpoint-configuration-list.mdx
+++ b/snippets/obs/_endpoint-configuration-list.mdx
@@ -1,107 +1,107 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier of this endpoint configuration |
-| type | string | they type of traffic this endpoint configuration can be applied to. one of: `http`, `https`, `tcp` |
-| description | string | human-readable description of what this endpoint configuration will be do when applied or what traffic it will be applied to. Optional, max 255 bytes |
-| metadata | string | arbitrary user-defined machine-readable data of this endpoint configuration. Optional, max 4096 bytes. |
-| created_at | string | timestamp when the endpoint configuration was created, RFC 3339 format |
-| uri | string | URI of the endpoint configuration API resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
-| assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
-| single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
-| request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
-| metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| endpoint_configurations.id | string | unique identifier of this endpoint configuration |
+| endpoint_configurations.type | string | they type of traffic this endpoint configuration can be applied to. one of: `http`, `https`, `tcp` |
+| endpoint_configurations.description | string | human-readable description of what this endpoint configuration will be do when applied or what traffic it will be applied to. Optional, max 255 bytes |
+| endpoint_configurations.metadata | string | arbitrary user-defined machine-readable data of this endpoint configuration. Optional, max 4096 bytes. |
+| endpoint_configurations.created_at | string | timestamp when the endpoint configuration was created, RFC 3339 format |
+| endpoint_configurations.uri | string | URI of the endpoint configuration API resource |
+| endpoint_configurations.circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| endpoint_configurations.circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| endpoint_configurations.circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| endpoint_configurations.circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| endpoint_configurations.circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| endpoint_configurations.compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| endpoint_configurations.request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| endpoint_configurations.response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| endpoint_configurations.response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| endpoint_configurations.ip_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.ip_policy.ip_policies.id | string | a resource identifier |
+| endpoint_configurations.ip_policy.ip_policies.uri | string | a uri for locating a resource |
+| endpoint_configurations.mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.mutual_tls.certificate_authorities.id | string | a resource identifier |
+| endpoint_configurations.mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| endpoint_configurations.tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| endpoint_configurations.tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| endpoint_configurations.webhook_validation.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.webhook_validation.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| endpoint_configurations.webhook_validation.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| endpoint_configurations.oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| endpoint_configurations.oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| endpoint_configurations.oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| endpoint_configurations.oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| endpoint_configurations.oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| endpoint_configurations.oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| endpoint_configurations.oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| endpoint_configurations.oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| endpoint_configurations.oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| endpoint_configurations.oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| endpoint_configurations.oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| endpoint_configurations.oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| endpoint_configurations.oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| endpoint_configurations.oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| endpoint_configurations.oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| endpoint_configurations.oauth.provider.linkedin.client_id | string |  |
+| endpoint_configurations.oauth.provider.linkedin.client_secret | string |  |
+| endpoint_configurations.oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.gitlab.client_id | string |  |
+| endpoint_configurations.oauth.provider.gitlab.client_secret | string |  |
+| endpoint_configurations.oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.twitch.client_id | string |  |
+| endpoint_configurations.oauth.provider.twitch.client_secret | string |  |
+| endpoint_configurations.oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.amazon.client_id | string |  |
+| endpoint_configurations.oauth.provider.amazon.client_secret | string |  |
+| endpoint_configurations.oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| endpoint_configurations.oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| endpoint_configurations.oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| endpoint_configurations.oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| endpoint_configurations.oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| endpoint_configurations.oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| endpoint_configurations.saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| endpoint_configurations.saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| endpoint_configurations.saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| endpoint_configurations.saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| endpoint_configurations.saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| endpoint_configurations.saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| endpoint_configurations.saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| endpoint_configurations.saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| endpoint_configurations.saml.entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
+| endpoint_configurations.saml.assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
+| endpoint_configurations.saml.single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
+| endpoint_configurations.saml.request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
+| endpoint_configurations.saml.metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
+| endpoint_configurations.saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| endpoint_configurations.oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| endpoint_configurations.oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| endpoint_configurations.oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| endpoint_configurations.oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| endpoint_configurations.oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| endpoint_configurations.oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| endpoint_configurations.oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| endpoint_configurations.oidc.client_secret | string | The OIDC app's client secret. |
+| endpoint_configurations.oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
 | uri | string | URI of the endpoint configurations list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_endpoint-configuration-update.mdx
+++ b/snippets/obs/_endpoint-configuration-update.mdx
@@ -3,95 +3,95 @@
 | id | string | unique identifier of this endpoint configuration |
 | description | string | human-readable description of what this endpoint configuration will be do when applied or what traffic it will be applied to. Optional, max 255 bytes |
 | metadata | string | arbitrary user-defined machine-readable data of this endpoint configuration. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| ip_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_policy.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| webhook_validation.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_validation.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_validation.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |

--- a/snippets/obs/_endpoint-configuration.mdx
+++ b/snippets/obs/_endpoint-configuration.mdx
@@ -6,100 +6,100 @@
 | metadata | string | arbitrary user-defined machine-readable data of this endpoint configuration. Optional, max 4096 bytes. |
 | created_at | string | timestamp when the endpoint configuration was created, RFC 3339 format |
 | uri | string | URI of the endpoint configuration API resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
-| assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
-| single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
-| request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
-| metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| ip_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_policy.ip_policies.id | string | a resource identifier |
+| ip_policy.ip_policies.uri | string | a uri for locating a resource |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authorities.id | string | a resource identifier |
+| mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| webhook_validation.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_validation.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_validation.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
+| saml.assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
+| saml.single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
+| saml.request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
+| saml.metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |

--- a/snippets/obs/_endpoint-ip-policy-replace.mdx
+++ b/snippets/obs/_endpoint-ip-policy-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |

--- a/snippets/obs/_endpoint-ip-policy.mdx
+++ b/snippets/obs/_endpoint-ip-policy.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| ip_policies.id | string | a resource identifier |
+| ip_policies.uri | string | a uri for locating a resource |

--- a/snippets/obs/_endpoint-list.mdx
+++ b/snippets/obs/_endpoint-list.mdx
@@ -1,37 +1,37 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique endpoint resource identifier |
-| region | string | identifier of the region this endpoint belongs to |
-| created_at | string | timestamp when the endpoint was created in RFC 3339 format |
-| updated_at | string | timestamp when the endpoint was updated in RFC 3339 format |
-| public_url | string | deprecated [replaced by URL]: URL of the hostport served by this endpoint |
-| proto | string | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls` |
-| scheme | string |  |
-| hostport | string | hostport served by this endpoint (hostname:port) -> soon to be deprecated |
-| host | string |  |
-| port | int64 |  |
-| type | string | whether the endpoint is `ephemeral` (served directly by an agent-initiated tunnel) or `edge` (served by an edge) or `cloud (represents a cloud endpoint)` |
-| metadata | string | user-supplied metadata of the associated tunnel or edge object |
-| description | string | user-supplied description of the associated tunnel |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| upstream_url | string | the local address the tunnel forwards to |
-| upstream_protocol | string | the protocol the agent uses to forward with |
-| url | string | the url of the endpoint |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| traffic_policy | string | The traffic policy attached to this endpoint |
-| bindings | List&lt;string&gt; | the bindings associated with this endpoint |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| uri | string | URI of the Cloud Endpoint API resource |
-| name | string | user supplied name for the endpoint |
-| pooling_enabled | boolean | whether the endpoint allows pooling |
+| endpoints.id | string | unique endpoint resource identifier |
+| endpoints.region | string | identifier of the region this endpoint belongs to |
+| endpoints.created_at | string | timestamp when the endpoint was created in RFC 3339 format |
+| endpoints.updated_at | string | timestamp when the endpoint was updated in RFC 3339 format |
+| endpoints.public_url | string | deprecated [replaced by URL]: URL of the hostport served by this endpoint |
+| endpoints.proto | string | protocol served by this endpoint. one of `http`, `https`, `tcp`, or `tls` |
+| endpoints.scheme | string |  |
+| endpoints.hostport | string | hostport served by this endpoint (hostname:port) -> soon to be deprecated |
+| endpoints.host | string |  |
+| endpoints.port | int64 |  |
+| endpoints.type | string | whether the endpoint is `ephemeral` (served directly by an agent-initiated tunnel) or `edge` (served by an edge) or `cloud (represents a cloud endpoint)` |
+| endpoints.metadata | string | user-supplied metadata of the associated tunnel or edge object |
+| endpoints.description | string | user-supplied description of the associated tunnel |
+| endpoints.domain.id | string | a resource identifier |
+| endpoints.domain.uri | string | a uri for locating a resource |
+| endpoints.tcp_addr.id | string | a resource identifier |
+| endpoints.tcp_addr.uri | string | a uri for locating a resource |
+| endpoints.tunnel.id | string | a resource identifier |
+| endpoints.tunnel.uri | string | a uri for locating a resource |
+| endpoints.edge.id | string | a resource identifier |
+| endpoints.edge.uri | string | a uri for locating a resource |
+| endpoints.upstream_url | string | the local address the tunnel forwards to |
+| endpoints.upstream_protocol | string | the protocol the agent uses to forward with |
+| endpoints.url | string | the url of the endpoint |
+| endpoints.principal.id | string | a resource identifier |
+| endpoints.principal.uri | string | a uri for locating a resource |
+| endpoints.traffic_policy | string | The traffic policy attached to this endpoint |
+| endpoints.bindings | List&lt;string&gt; | the bindings associated with this endpoint |
+| endpoints.tunnel_session.id | string | a resource identifier |
+| endpoints.tunnel_session.uri | string | a uri for locating a resource |
+| endpoints.uri | string | URI of the Cloud Endpoint API resource |
+| endpoints.name | string | user supplied name for the endpoint |
+| endpoints.pooling_enabled | boolean | whether the endpoint allows pooling |
 | uri | string | URI of the endpoints list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_endpoint-mutual-tls-replace.mdx
+++ b/snippets/obs/_endpoint-mutual-tls-replace.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |

--- a/snippets/obs/_endpoint-mutual-tls.mdx
+++ b/snippets/obs/_endpoint-mutual-tls.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
 | enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| certificate_authorities.id | string | a resource identifier |
+| certificate_authorities.uri | string | a uri for locating a resource |

--- a/snippets/obs/_endpoint-o-auth-provider.mdx
+++ b/snippets/obs/_endpoint-o-auth-provider.mdx
@@ -1,44 +1,44 @@
 | Name | Type | Description |
 |---|---|---|
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
+| github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| linkedin.client_id | string |  |
+| linkedin.client_secret | string |  |
+| linkedin.scopes | List&lt;string&gt; |  |
+| linkedin.email_addresses | List&lt;string&gt; |  |
+| linkedin.email_domains | List&lt;string&gt; |  |
+| gitlab.client_id | string |  |
+| gitlab.client_secret | string |  |
+| gitlab.scopes | List&lt;string&gt; |  |
+| gitlab.email_addresses | List&lt;string&gt; |  |
+| gitlab.email_domains | List&lt;string&gt; |  |
+| twitch.client_id | string |  |
+| twitch.client_secret | string |  |
+| twitch.scopes | List&lt;string&gt; |  |
+| twitch.email_addresses | List&lt;string&gt; |  |
+| twitch.email_domains | List&lt;string&gt; |  |
+| amazon.client_id | string |  |
+| amazon.client_secret | string |  |
+| amazon.scopes | List&lt;string&gt; |  |
+| amazon.email_addresses | List&lt;string&gt; |  |
+| amazon.email_domains | List&lt;string&gt; |  |

--- a/snippets/obs/_endpoint-o-auth-replace.mdx
+++ b/snippets/obs/_endpoint-o-auth-replace.mdx
@@ -1,51 +1,51 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| module.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| module.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| module.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| module.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| module.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| module.provider.linkedin.client_id | string |  |
+| module.provider.linkedin.client_secret | string |  |
+| module.provider.linkedin.scopes | List&lt;string&gt; |  |
+| module.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| module.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| module.provider.gitlab.client_id | string |  |
+| module.provider.gitlab.client_secret | string |  |
+| module.provider.gitlab.scopes | List&lt;string&gt; |  |
+| module.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| module.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| module.provider.twitch.client_id | string |  |
+| module.provider.twitch.client_secret | string |  |
+| module.provider.twitch.scopes | List&lt;string&gt; |  |
+| module.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| module.provider.twitch.email_domains | List&lt;string&gt; |  |
+| module.provider.amazon.client_id | string |  |
+| module.provider.amazon.client_secret | string |  |
+| module.provider.amazon.scopes | List&lt;string&gt; |  |
+| module.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| module.provider.amazon.email_domains | List&lt;string&gt; |  |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |

--- a/snippets/obs/_endpoint-o-auth.mdx
+++ b/snippets/obs/_endpoint-o-auth.mdx
@@ -1,48 +1,48 @@
 | Name | Type | Description |
 |---|---|---|
 | enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
+| provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| provider.linkedin.client_id | string |  |
+| provider.linkedin.client_secret | string |  |
+| provider.linkedin.scopes | List&lt;string&gt; |  |
+| provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| provider.linkedin.email_domains | List&lt;string&gt; |  |
+| provider.gitlab.client_id | string |  |
+| provider.gitlab.client_secret | string |  |
+| provider.gitlab.scopes | List&lt;string&gt; |  |
+| provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| provider.gitlab.email_domains | List&lt;string&gt; |  |
+| provider.twitch.client_id | string |  |
+| provider.twitch.client_secret | string |  |
+| provider.twitch.scopes | List&lt;string&gt; |  |
+| provider.twitch.email_addresses | List&lt;string&gt; |  |
+| provider.twitch.email_domains | List&lt;string&gt; |  |
+| provider.amazon.client_id | string |  |
+| provider.amazon.client_secret | string |  |
+| provider.amazon.scopes | List&lt;string&gt; |  |
+| provider.amazon.email_addresses | List&lt;string&gt; |  |
+| provider.amazon.email_domains | List&lt;string&gt; |  |
 | options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
 | cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
 | inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |

--- a/snippets/obs/_endpoint-oidc-replace.mdx
+++ b/snippets/obs/_endpoint-oidc-replace.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| module.client_id | string | The OIDC app's client ID and OIDC audience. |
+| module.client_secret | string | The OIDC app's client secret. |
+| module.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |

--- a/snippets/obs/_endpoint-policy.mdx
+++ b/snippets/obs/_endpoint-policy.mdx
@@ -1,11 +1,11 @@
 | Name | Type | Description |
 |---|---|---|
 | enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
-| expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
-| name | string | the name of the rule that is part of the traffic policy. |
+| inbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| inbound.actions.type | string | the type of action on the policy rule. |
+| inbound.actions.config | object | the configuration for the action on the policy rule. |
+| inbound.name | string | the name of the rule that is part of the traffic policy. |
+| outbound.expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
+| outbound.actions.type | string | the type of action on the policy rule. |
+| outbound.actions.config | object | the configuration for the action on the policy rule. |
+| outbound.name | string | the name of the rule that is part of the traffic policy. |

--- a/snippets/obs/_endpoint-request-headers-replace.mdx
+++ b/snippets/obs/_endpoint-request-headers-replace.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| module.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |

--- a/snippets/obs/_endpoint-response-headers-replace.mdx
+++ b/snippets/obs/_endpoint-response-headers-replace.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| module.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |

--- a/snippets/obs/_endpoint-rule.mdx
+++ b/snippets/obs/_endpoint-rule.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | expressions | List&lt;string&gt; | cel expressions that filter traffic the policy rule applies to. |
-| type | string | the type of action on the policy rule. |
-| config | object | the configuration for the action on the policy rule. |
+| actions.type | string | the type of action on the policy rule. |
+| actions.config | object | the configuration for the action on the policy rule. |
 | name | string | the name of the rule that is part of the traffic policy. |

--- a/snippets/obs/_endpoint-saml-replace.mdx
+++ b/snippets/obs/_endpoint-saml-replace.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| module.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| module.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| module.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| module.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| module.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| module.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| module.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| module.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |

--- a/snippets/obs/_endpoint-tls-termination-replace.mdx
+++ b/snippets/obs/_endpoint-tls-termination-replace.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| module.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |

--- a/snippets/obs/_endpoint-webhook-validation-replace.mdx
+++ b/snippets/obs/_endpoint-webhook-validation-replace.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
 | id | string |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| module.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| module.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| module.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |

--- a/snippets/obs/_endpoint.mdx
+++ b/snippets/obs/_endpoint.mdx
@@ -13,23 +13,23 @@
 | type | string | whether the endpoint is `ephemeral` (served directly by an agent-initiated tunnel) or `edge` (served by an edge) or `cloud (represents a cloud endpoint)` |
 | metadata | string | user-supplied metadata of the associated tunnel or edge object |
 | description | string | user-supplied description of the associated tunnel |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| domain.id | string | a resource identifier |
+| domain.uri | string | a uri for locating a resource |
+| tcp_addr.id | string | a resource identifier |
+| tcp_addr.uri | string | a uri for locating a resource |
+| tunnel.id | string | a resource identifier |
+| tunnel.uri | string | a uri for locating a resource |
+| edge.id | string | a resource identifier |
+| edge.uri | string | a uri for locating a resource |
 | upstream_url | string | the local address the tunnel forwards to |
 | upstream_protocol | string | the protocol the agent uses to forward with |
 | url | string | the url of the endpoint |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| principal.id | string | a resource identifier |
+| principal.uri | string | a uri for locating a resource |
 | traffic_policy | string | The traffic policy attached to this endpoint |
 | bindings | List&lt;string&gt; | the bindings associated with this endpoint |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| tunnel_session.id | string | a resource identifier |
+| tunnel_session.uri | string | a uri for locating a resource |
 | uri | string | URI of the Cloud Endpoint API resource |
 | name | string | user supplied name for the endpoint |
 | pooling_enabled | boolean | whether the endpoint allows pooling |

--- a/snippets/obs/_event-destination-create.mdx
+++ b/snippets/obs/_event-destination-create.mdx
@@ -3,25 +3,25 @@
 | metadata | string | Arbitrary user-defined machine-readable data of this Event Destination. Optional, max 4096 bytes. |
 | description | string | Human-readable description of the Event Destination. Optional, max 255 bytes. |
 | format | string | The output format you would like to serialize events into when sending to their target. Currently the only accepted value is `JSON`. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
-| api_key | string | Datadog API key to use. |
-| ddtags | string | Tags to send with the event. |
-| service | string | Service name to send with the event. |
-| ddsite | string | Datadog site to send event to. |
-| tenant_id | string | Tenant ID for the Azure account |
-| client_id | string | Client ID for the application client |
-| client_secret | string | Client Secret for the application client |
-| logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
-| data_collection_rule_id | string | Data collection rule immutable ID |
-| data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
+| target.firehose.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.firehose.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.firehose.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.firehose.delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
+| target.kinesis.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.kinesis.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.kinesis.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.kinesis.stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
+| target.cloudwatch_logs.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.cloudwatch_logs.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.cloudwatch_logs.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.cloudwatch_logs.log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
+| target.datadog.api_key | string | Datadog API key to use. |
+| target.datadog.ddtags | string | Tags to send with the event. |
+| target.datadog.service | string | Service name to send with the event. |
+| target.datadog.ddsite | string | Datadog site to send event to. |
+| target.azure_logs_ingestion.tenant_id | string | Tenant ID for the Azure account |
+| target.azure_logs_ingestion.client_id | string | Client ID for the application client |
+| target.azure_logs_ingestion.client_secret | string | Client Secret for the application client |
+| target.azure_logs_ingestion.logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
+| target.azure_logs_ingestion.data_collection_rule_id | string | Data collection rule immutable ID |
+| target.azure_logs_ingestion.data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |

--- a/snippets/obs/_event-destination-list.mdx
+++ b/snippets/obs/_event-destination-list.mdx
@@ -1,32 +1,32 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | Unique identifier for this Event Destination. |
-| metadata | string | Arbitrary user-defined machine-readable data of this Event Destination. Optional, max 4096 bytes. |
-| created_at | string | Timestamp when the Event Destination was created, RFC 3339 format. |
-| description | string | Human-readable description of the Event Destination. Optional, max 255 bytes. |
-| format | string | The output format you would like to serialize events into when sending to their target. Currently the only accepted value is `JSON`. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
-| api_key | string | Datadog API key to use. |
-| ddtags | string | Tags to send with the event. |
-| service | string | Service name to send with the event. |
-| ddsite | string | Datadog site to send event to. |
-| tenant_id | string | Tenant ID for the Azure account |
-| client_id | string | Client ID for the application client |
-| client_secret | string | Client Secret for the application client |
-| logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
-| data_collection_rule_id | string | Data collection rule immutable ID |
-| data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
-| uri | string | URI of the Event Destination API resource. |
+| event_destinations.id | string | Unique identifier for this Event Destination. |
+| event_destinations.metadata | string | Arbitrary user-defined machine-readable data of this Event Destination. Optional, max 4096 bytes. |
+| event_destinations.created_at | string | Timestamp when the Event Destination was created, RFC 3339 format. |
+| event_destinations.description | string | Human-readable description of the Event Destination. Optional, max 255 bytes. |
+| event_destinations.format | string | The output format you would like to serialize events into when sending to their target. Currently the only accepted value is `JSON`. |
+| event_destinations.target.firehose.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| event_destinations.target.firehose.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| event_destinations.target.firehose.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| event_destinations.target.firehose.delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
+| event_destinations.target.kinesis.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| event_destinations.target.kinesis.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| event_destinations.target.kinesis.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| event_destinations.target.kinesis.stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
+| event_destinations.target.cloudwatch_logs.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| event_destinations.target.cloudwatch_logs.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| event_destinations.target.cloudwatch_logs.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| event_destinations.target.cloudwatch_logs.log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
+| event_destinations.target.datadog.api_key | string | Datadog API key to use. |
+| event_destinations.target.datadog.ddtags | string | Tags to send with the event. |
+| event_destinations.target.datadog.service | string | Service name to send with the event. |
+| event_destinations.target.datadog.ddsite | string | Datadog site to send event to. |
+| event_destinations.target.azure_logs_ingestion.tenant_id | string | Tenant ID for the Azure account |
+| event_destinations.target.azure_logs_ingestion.client_id | string | Client ID for the application client |
+| event_destinations.target.azure_logs_ingestion.client_secret | string | Client Secret for the application client |
+| event_destinations.target.azure_logs_ingestion.logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
+| event_destinations.target.azure_logs_ingestion.data_collection_rule_id | string | Data collection rule immutable ID |
+| event_destinations.target.azure_logs_ingestion.data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
+| event_destinations.uri | string | URI of the Event Destination API resource. |
 | uri | string | URI of the Event Destinations list API resource. |
 | next_page_uri | string | URI of the next page, or null if there is no next page. |

--- a/snippets/obs/_event-destination-update.mdx
+++ b/snippets/obs/_event-destination-update.mdx
@@ -4,25 +4,25 @@
 | metadata | string | Arbitrary user-defined machine-readable data of this Event Destination. Optional, max 4096 bytes. |
 | description | string | Human-readable description of the Event Destination. Optional, max 255 bytes. |
 | format | string | The output format you would like to serialize events into when sending to their target. Currently the only accepted value is `JSON`. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
-| api_key | string | Datadog API key to use. |
-| ddtags | string | Tags to send with the event. |
-| service | string | Service name to send with the event. |
-| ddsite | string | Datadog site to send event to. |
-| tenant_id | string | Tenant ID for the Azure account |
-| client_id | string | Client ID for the application client |
-| client_secret | string | Client Secret for the application client |
-| logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
-| data_collection_rule_id | string | Data collection rule immutable ID |
-| data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
+| target.firehose.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.firehose.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.firehose.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.firehose.delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
+| target.kinesis.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.kinesis.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.kinesis.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.kinesis.stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
+| target.cloudwatch_logs.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.cloudwatch_logs.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.cloudwatch_logs.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.cloudwatch_logs.log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
+| target.datadog.api_key | string | Datadog API key to use. |
+| target.datadog.ddtags | string | Tags to send with the event. |
+| target.datadog.service | string | Service name to send with the event. |
+| target.datadog.ddsite | string | Datadog site to send event to. |
+| target.azure_logs_ingestion.tenant_id | string | Tenant ID for the Azure account |
+| target.azure_logs_ingestion.client_id | string | Client ID for the application client |
+| target.azure_logs_ingestion.client_secret | string | Client Secret for the application client |
+| target.azure_logs_ingestion.logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
+| target.azure_logs_ingestion.data_collection_rule_id | string | Data collection rule immutable ID |
+| target.azure_logs_ingestion.data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |

--- a/snippets/obs/_event-destination.mdx
+++ b/snippets/obs/_event-destination.mdx
@@ -5,26 +5,26 @@
 | created_at | string | Timestamp when the Event Destination was created, RFC 3339 format. |
 | description | string | Human-readable description of the Event Destination. Optional, max 255 bytes. |
 | format | string | The output format you would like to serialize events into when sending to their target. Currently the only accepted value is `JSON`. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
-| api_key | string | Datadog API key to use. |
-| ddtags | string | Tags to send with the event. |
-| service | string | Service name to send with the event. |
-| ddsite | string | Datadog site to send event to. |
-| tenant_id | string | Tenant ID for the Azure account |
-| client_id | string | Client ID for the application client |
-| client_secret | string | Client Secret for the application client |
-| logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
-| data_collection_rule_id | string | Data collection rule immutable ID |
-| data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
+| target.firehose.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.firehose.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.firehose.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.firehose.delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
+| target.kinesis.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.kinesis.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.kinesis.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.kinesis.stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
+| target.cloudwatch_logs.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| target.cloudwatch_logs.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| target.cloudwatch_logs.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| target.cloudwatch_logs.log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
+| target.datadog.api_key | string | Datadog API key to use. |
+| target.datadog.ddtags | string | Tags to send with the event. |
+| target.datadog.service | string | Service name to send with the event. |
+| target.datadog.ddsite | string | Datadog site to send event to. |
+| target.azure_logs_ingestion.tenant_id | string | Tenant ID for the Azure account |
+| target.azure_logs_ingestion.client_id | string | Client ID for the application client |
+| target.azure_logs_ingestion.client_secret | string | Client Secret for the application client |
+| target.azure_logs_ingestion.logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
+| target.azure_logs_ingestion.data_collection_rule_id | string | Data collection rule immutable ID |
+| target.azure_logs_ingestion.data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
 | uri | string | URI of the Event Destination API resource. |

--- a/snippets/obs/_event-source-list.mdx
+++ b/snippets/obs/_event-source-list.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
-| type | string | Type of event for which an event subscription will trigger |
-| uri | string | URI of the Event Source API resource. |
+| sources.type | string | Type of event for which an event subscription will trigger |
+| sources.uri | string | URI of the Event Source API resource. |
 | uri | string | URI of the next page, or null if there is no next page. |

--- a/snippets/obs/_event-subscription-create.mdx
+++ b/snippets/obs/_event-subscription-create.mdx
@@ -2,5 +2,5 @@
 |---|---|---|
 | metadata | string | Arbitrary customer supplied information intended to be machine readable. Optional, max 4096 chars. |
 | description | string | Arbitrary customer supplied information intended to be human readable. Optional, max 255 chars. |
-| type | string | Type of event for which an event subscription will trigger |
+| sources.type | string | Type of event for which an event subscription will trigger |
 | destination_ids | List&lt;string&gt; | A list of Event Destination IDs which should be used for this Event Subscription. |

--- a/snippets/obs/_event-subscription-list.mdx
+++ b/snippets/obs/_event-subscription-list.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | Unique identifier for this Event Subscription. |
-| uri | string | URI of the Event Subscription API resource. |
-| created_at | string | When the Event Subscription was created (RFC 3339 format). |
-| metadata | string | Arbitrary customer supplied information intended to be machine readable. Optional, max 4096 chars. |
-| description | string | Arbitrary customer supplied information intended to be human readable. Optional, max 255 chars. |
-| type | string | Type of event for which an event subscription will trigger |
-| uri | string | URI of the Event Source API resource. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| event_subscriptions.id | string | Unique identifier for this Event Subscription. |
+| event_subscriptions.uri | string | URI of the Event Subscription API resource. |
+| event_subscriptions.created_at | string | When the Event Subscription was created (RFC 3339 format). |
+| event_subscriptions.metadata | string | Arbitrary customer supplied information intended to be machine readable. Optional, max 4096 chars. |
+| event_subscriptions.description | string | Arbitrary customer supplied information intended to be human readable. Optional, max 255 chars. |
+| event_subscriptions.sources.type | string | Type of event for which an event subscription will trigger |
+| event_subscriptions.sources.uri | string | URI of the Event Source API resource. |
+| event_subscriptions.destinations.id | string | a resource identifier |
+| event_subscriptions.destinations.uri | string | a uri for locating a resource |
 | uri | string | URI of the Event Subscriptions list API resource. |
 | next_page_uri | string | URI of next page, or null if there is no next page. |

--- a/snippets/obs/_event-subscription-update.mdx
+++ b/snippets/obs/_event-subscription-update.mdx
@@ -3,5 +3,5 @@
 | id | string | Unique identifier for this Event Subscription. |
 | metadata | string | Arbitrary customer supplied information intended to be machine readable. Optional, max 4096 chars. |
 | description | string | Arbitrary customer supplied information intended to be human readable. Optional, max 255 chars. |
-| type | string | Type of event for which an event subscription will trigger |
+| sources.type | string | Type of event for which an event subscription will trigger |
 | destination_ids | List&lt;string&gt; | A list of Event Destination IDs which should be used for this Event Subscription. |

--- a/snippets/obs/_event-subscription.mdx
+++ b/snippets/obs/_event-subscription.mdx
@@ -5,7 +5,7 @@
 | created_at | string | When the Event Subscription was created (RFC 3339 format). |
 | metadata | string | Arbitrary customer supplied information intended to be machine readable. Optional, max 4096 chars. |
 | description | string | Arbitrary customer supplied information intended to be human readable. Optional, max 255 chars. |
-| type | string | Type of event for which an event subscription will trigger |
-| uri | string | URI of the Event Source API resource. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| sources.type | string | Type of event for which an event subscription will trigger |
+| sources.uri | string | URI of the Event Source API resource. |
+| destinations.id | string | a resource identifier |
+| destinations.uri | string | a uri for locating a resource |

--- a/snippets/obs/_event-target-cloudwatch-logs.mdx
+++ b/snippets/obs/_event-target-cloudwatch-logs.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
+| auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
 | log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |

--- a/snippets/obs/_event-target-firehose.mdx
+++ b/snippets/obs/_event-target-firehose.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
+| auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
 | delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |

--- a/snippets/obs/_event-target-kinesis.mdx
+++ b/snippets/obs/_event-target-kinesis.mdx
@@ -1,6 +1,6 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
+| auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
 | stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |

--- a/snippets/obs/_event-target-s-3.mdx
+++ b/snippets/obs/_event-target-s-3.mdx
@@ -1,8 +1,8 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
+| auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
 | bucket_arn | string | An Amazon Resource Name specifying the S3 bucket to deposit events into. |
 | object_prefix | string | An optional prefix to prepend to S3 object keys. |
 | compression | boolean | Whether or not to compress files with gzip. |

--- a/snippets/obs/_event-target.mdx
+++ b/snippets/obs/_event-target.mdx
@@ -1,24 +1,24 @@
 | Name | Type | Description |
 |---|---|---|
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
-| role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
-| aws_access_key_id | string | The ID portion of an AWS access key. |
-| aws_secret_access_key | string | The secret portion of an AWS access key. |
-| log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
-| api_key | string | Datadog API key to use. |
-| ddtags | string | Tags to send with the event. |
-| service | string | Service name to send with the event. |
-| ddsite | string | Datadog site to send event to. |
-| tenant_id | string | Tenant ID for the Azure account |
-| client_id | string | Client ID for the application client |
-| client_secret | string | Client Secret for the application client |
-| logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
-| data_collection_rule_id | string | Data collection rule immutable ID |
-| data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |
+| firehose.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| firehose.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| firehose.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| firehose.delivery_stream_arn | string | An Amazon Resource Name specifying the Firehose delivery stream to deposit events into. |
+| kinesis.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| kinesis.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| kinesis.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| kinesis.stream_arn | string | An Amazon Resource Name specifying the Kinesis stream to deposit events into. |
+| cloudwatch_logs.auth.role.role_arn | string | An ARN that specifies the role that ngrok should use to deliver to the configured target. |
+| cloudwatch_logs.auth.creds.aws_access_key_id | string | The ID portion of an AWS access key. |
+| cloudwatch_logs.auth.creds.aws_secret_access_key | string | The secret portion of an AWS access key. |
+| cloudwatch_logs.log_group_arn | string | An Amazon Resource Name specifying the CloudWatch Logs group to deposit events into. |
+| datadog.api_key | string | Datadog API key to use. |
+| datadog.ddtags | string | Tags to send with the event. |
+| datadog.service | string | Service name to send with the event. |
+| datadog.ddsite | string | Datadog site to send event to. |
+| azure_logs_ingestion.tenant_id | string | Tenant ID for the Azure account |
+| azure_logs_ingestion.client_id | string | Client ID for the application client |
+| azure_logs_ingestion.client_secret | string | Client Secret for the application client |
+| azure_logs_ingestion.logs_ingestion_uri | string | Data collection endpoint logs ingestion URI |
+| azure_logs_ingestion.data_collection_rule_id | string | Data collection rule immutable ID |
+| azure_logs_ingestion.data_collection_stream_name | string | Data collection stream name to use as destination, located inside the DCR |

--- a/snippets/obs/_failover-backend-list.mdx
+++ b/snippets/obs/_failover-backend-list.mdx
@@ -1,10 +1,10 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this Failover backend |
-| uri | string | URI of the FailoverBackend API resource |
-| created_at | string | timestamp when the backend was created, RFC 3339 format |
-| description | string | human-readable description of this backend. Optional |
-| metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
-| backends | List&lt;string&gt; | the ids of the child backends in order |
+| backends.id | string | unique identifier for this Failover backend |
+| backends.uri | string | URI of the FailoverBackend API resource |
+| backends.created_at | string | timestamp when the backend was created, RFC 3339 format |
+| backends.description | string | human-readable description of this backend. Optional |
+| backends.metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
+| backends.backends | List&lt;string&gt; | the ids of the child backends in order |
 | uri | string | URI of the Failover backends list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_http-response-backend-list.mdx
+++ b/snippets/obs/_http-response-backend-list.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string |  |
-| uri | string | URI of the HTTPResponseBackend API resource |
-| created_at | string | timestamp when the backend was created, RFC 3339 format |
-| description | string | human-readable description of this backend. Optional |
-| metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
-| body | string | body to return as fixed content |
-| headers | Map&lt;string, string&gt; | headers to return |
-| status_code | int32 | status code to return |
+| backends.id | string |  |
+| backends.uri | string | URI of the HTTPResponseBackend API resource |
+| backends.created_at | string | timestamp when the backend was created, RFC 3339 format |
+| backends.description | string | human-readable description of this backend. Optional |
+| backends.metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
+| backends.body | string | body to return as fixed content |
+| backends.headers | Map&lt;string, string&gt; | headers to return |
+| backends.status_code | int32 | status code to return |
 | uri | string |  |
 | next_page_uri | string |  |

--- a/snippets/obs/_https-edge-create.mdx
+++ b/snippets/obs/_https-edge-create.mdx
@@ -3,7 +3,7 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge; optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |

--- a/snippets/obs/_https-edge-list.mdx
+++ b/snippets/obs/_https-edge-list.mdx
@@ -1,124 +1,124 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier of this edge |
-| description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this edge; optional, max 4096 bytes. |
-| created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
-| uri | string | URI of the edge API resource |
-| hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| edge_id | string | unique identifier of this edge |
-| id | string | unique identifier of this edge route |
-| created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
-| match_type | string | Type of match to use for this route. Valid values are "exact_path" and "path_prefix". |
-| match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
-| uri | string | URI of the edge API resource |
-| description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
-| assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
-| single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
-| request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
-| metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| https_edges.id | string | unique identifier of this edge |
+| https_edges.description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
+| https_edges.metadata | string | arbitrary user-defined machine-readable data of this edge; optional, max 4096 bytes. |
+| https_edges.created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
+| https_edges.uri | string | URI of the edge API resource |
+| https_edges.hostports | List&lt;string&gt; | hostports served by this edge |
+| https_edges.mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.mutual_tls.certificate_authorities.id | string | a resource identifier |
+| https_edges.mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| https_edges.tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| https_edges.tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| https_edges.routes.edge_id | string | unique identifier of this edge |
+| https_edges.routes.id | string | unique identifier of this edge route |
+| https_edges.routes.created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
+| https_edges.routes.match_type | string | Type of match to use for this route. Valid values are "exact_path" and "path_prefix". |
+| https_edges.routes.match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
+| https_edges.routes.uri | string | URI of the edge API resource |
+| https_edges.routes.description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
+| https_edges.routes.metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
+| https_edges.routes.backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.backend.backend.id | string | a resource identifier |
+| https_edges.routes.backend.backend.uri | string | a uri for locating a resource |
+| https_edges.routes.ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.ip_restriction.ip_policies.id | string | a resource identifier |
+| https_edges.routes.ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| https_edges.routes.circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| https_edges.routes.circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| https_edges.routes.circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| https_edges.routes.circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| https_edges.routes.circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| https_edges.routes.compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| https_edges.routes.request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| https_edges.routes.response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| https_edges.routes.response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| https_edges.routes.webhook_verification.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.webhook_verification.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| https_edges.routes.webhook_verification.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| https_edges.routes.oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| https_edges.routes.oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| https_edges.routes.oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| https_edges.routes.oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| https_edges.routes.oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| https_edges.routes.oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| https_edges.routes.oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| https_edges.routes.oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| https_edges.routes.oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| https_edges.routes.oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| https_edges.routes.oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| https_edges.routes.oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| https_edges.routes.oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| https_edges.routes.oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| https_edges.routes.oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| https_edges.routes.oauth.provider.linkedin.client_id | string |  |
+| https_edges.routes.oauth.provider.linkedin.client_secret | string |  |
+| https_edges.routes.oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.gitlab.client_id | string |  |
+| https_edges.routes.oauth.provider.gitlab.client_secret | string |  |
+| https_edges.routes.oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.twitch.client_id | string |  |
+| https_edges.routes.oauth.provider.twitch.client_secret | string |  |
+| https_edges.routes.oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.amazon.client_id | string |  |
+| https_edges.routes.oauth.provider.amazon.client_secret | string |  |
+| https_edges.routes.oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| https_edges.routes.oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| https_edges.routes.oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| https_edges.routes.oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| https_edges.routes.oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| https_edges.routes.oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| https_edges.routes.oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| https_edges.routes.saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| https_edges.routes.saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| https_edges.routes.saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| https_edges.routes.saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| https_edges.routes.saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| https_edges.routes.saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| https_edges.routes.saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| https_edges.routes.saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| https_edges.routes.saml.entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
+| https_edges.routes.saml.assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
+| https_edges.routes.saml.single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
+| https_edges.routes.saml.request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
+| https_edges.routes.saml.metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
+| https_edges.routes.saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| https_edges.routes.oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| https_edges.routes.oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| https_edges.routes.oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| https_edges.routes.oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| https_edges.routes.oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| https_edges.routes.oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| https_edges.routes.oidc.client_secret | string | The OIDC app's client secret. |
+| https_edges.routes.oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| https_edges.routes.websocket_tcp_converter.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.user_agent_filter.enabled | boolean |  |
+| https_edges.routes.user_agent_filter.allow | List&lt;string&gt; |  |
+| https_edges.routes.user_agent_filter.deny | List&lt;string&gt; |  |
+| https_edges.routes.traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| https_edges.routes.traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |
 | uri | string | URI of the HTTPS Edge list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_https-edge-route-create.mdx
+++ b/snippets/obs/_https-edge-route-create.mdx
@@ -5,96 +5,96 @@
 | match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| webhook_verification.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_verification.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_verification.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| websocket_tcp_converter.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| user_agent_filter.enabled | boolean |  |
+| user_agent_filter.allow | List&lt;string&gt; |  |
+| user_agent_filter.deny | List&lt;string&gt; |  |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_https-edge-route-update.mdx
+++ b/snippets/obs/_https-edge-route-update.mdx
@@ -6,96 +6,96 @@
 | match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| webhook_verification.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_verification.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_verification.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| websocket_tcp_converter.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| user_agent_filter.enabled | boolean |  |
+| user_agent_filter.allow | List&lt;string&gt; |  |
+| user_agent_filter.deny | List&lt;string&gt; |  |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_https-edge-route.mdx
+++ b/snippets/obs/_https-edge-route.mdx
@@ -8,103 +8,103 @@
 | uri | string | URI of the edge API resource |
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
-| assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
-| single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
-| request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
-| metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend.id | string | a resource identifier |
+| backend.backend.uri | string | a uri for locating a resource |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policies.id | string | a resource identifier |
+| ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| webhook_verification.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| webhook_verification.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| webhook_verification.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| oauth.provider.linkedin.client_id | string |  |
+| oauth.provider.linkedin.client_secret | string |  |
+| oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| oauth.provider.gitlab.client_id | string |  |
+| oauth.provider.gitlab.client_secret | string |  |
+| oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| oauth.provider.twitch.client_id | string |  |
+| oauth.provider.twitch.client_secret | string |  |
+| oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| oauth.provider.amazon.client_id | string |  |
+| oauth.provider.amazon.client_secret | string |  |
+| oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| saml.entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
+| saml.assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
+| saml.single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
+| saml.request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
+| saml.metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
+| saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| oidc.client_secret | string | The OIDC app's client secret. |
+| oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| websocket_tcp_converter.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| user_agent_filter.enabled | boolean |  |
+| user_agent_filter.allow | List&lt;string&gt; |  |
+| user_agent_filter.deny | List&lt;string&gt; |  |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_https-edge-update.mdx
+++ b/snippets/obs/_https-edge-update.mdx
@@ -4,7 +4,7 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge; optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |

--- a/snippets/obs/_https-edge.mdx
+++ b/snippets/obs/_https-edge.mdx
@@ -6,117 +6,117 @@
 | created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
 | uri | string | URI of the edge API resource |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| edge_id | string | unique identifier of this edge |
-| id | string | unique identifier of this edge route |
-| created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
-| match_type | string | Type of match to use for this route. Valid values are "exact_path" and "path_prefix". |
-| match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
-| uri | string | URI of the edge API resource |
-| description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
-| rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
-| num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
-| volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
-| error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
-| remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
-| secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
-| organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
-| client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
-| scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
-| email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
-| email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| client_id | string |  |
-| client_secret | string |  |
-| scopes | List&lt;string&gt; |  |
-| email_addresses | List&lt;string&gt; |  |
-| email_domains | List&lt;string&gt; |  |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
-| force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
-| allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
-| authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
-| entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
-| assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
-| single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
-| request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
-| metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
-| nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
-| cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
-| inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
-| maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
-| issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
-| client_id | string | The OIDC app's client ID and OIDC audience. |
-| client_secret | string | The OIDC app's client secret. |
-| scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| enabled | boolean |  |
-| allow | List&lt;string&gt; |  |
-| deny | List&lt;string&gt; |  |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authorities.id | string | a resource identifier |
+| mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| routes.edge_id | string | unique identifier of this edge |
+| routes.id | string | unique identifier of this edge route |
+| routes.created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
+| routes.match_type | string | Type of match to use for this route. Valid values are "exact_path" and "path_prefix". |
+| routes.match | string | Route selector: "/blog" or "example.com" or "example.com/blog" |
+| routes.uri | string | URI of the edge API resource |
+| routes.description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
+| routes.metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
+| routes.backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.backend.backend.id | string | a resource identifier |
+| routes.backend.backend.uri | string | a uri for locating a resource |
+| routes.ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.ip_restriction.ip_policies.id | string | a resource identifier |
+| routes.ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| routes.circuit_breaker.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.circuit_breaker.tripped_duration | uint32 | Integer number of seconds after which the circuit is tripped to wait before re-evaluating upstream health |
+| routes.circuit_breaker.rolling_window | uint32 | Integer number of seconds in the statistical rolling window that metrics are retained for. |
+| routes.circuit_breaker.num_buckets | uint32 | Integer number of buckets into which metrics are retained. Max 128. |
+| routes.circuit_breaker.volume_threshold | uint32 | Integer number of requests in a rolling window that will trip the circuit. Helpful if traffic volume is low. |
+| routes.circuit_breaker.error_threshold_percentage | float64 | Error threshold percentage should be between 0 - 1.0, not 0-100.0 |
+| routes.compression.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.request_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.request_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Request before being sent to the upstream application server |
+| routes.request_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Request before being sent to the upstream application server |
+| routes.response_headers.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.response_headers.add | Map&lt;string, string&gt; | a map of header key to header value that will be injected into the HTTP Response returned to the HTTP client |
+| routes.response_headers.remove | List&lt;string&gt; | a list of header names that will be removed from the HTTP Response returned to the HTTP client |
+| routes.webhook_verification.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.webhook_verification.provider | string | a string indicating which webhook provider will be sending webhooks to this endpoint. Value must be one of the supported providers defined at https://ngrok.com/docs/cloud-edge/modules/webhook-verification |
+| routes.webhook_verification.secret | string | a string secret used to validate requests from the given provider. All providers except AWS SNS require a secret |
+| routes.oauth.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.oauth.provider.github.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| routes.oauth.provider.github.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| routes.oauth.provider.github.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| routes.oauth.provider.github.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.github.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.github.teams | List&lt;string&gt; | a list of github teams identifiers. users will be allowed access to the endpoint if they are a member of any of these teams. identifiers should be in the 'slug' format qualified with the org name, e.g. `org-name/team-name` |
+| routes.oauth.provider.github.organizations | List&lt;string&gt; | a list of github org identifiers. users who are members of any of the listed organizations will be allowed access. identifiers should be the organization's 'slug' |
+| routes.oauth.provider.facebook.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| routes.oauth.provider.facebook.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| routes.oauth.provider.facebook.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| routes.oauth.provider.facebook.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.facebook.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.microsoft.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| routes.oauth.provider.microsoft.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| routes.oauth.provider.microsoft.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| routes.oauth.provider.microsoft.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.microsoft.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.google.client_id | string | the OAuth app client ID. retrieve it from the identity provider's dashboard where you created your own OAuth app. optional. if unspecified, ngrok will use its own managed oauth application which has additional restrictions. see the OAuth module docs for more details. if present, client_secret must be present as well. |
+| routes.oauth.provider.google.client_secret | string | the OAuth app client secret. retrieve if from the identity provider's dashboard where you created your own OAuth app. optional, see all of the caveats in the docs for `client_id`. |
+| routes.oauth.provider.google.scopes | List&lt;string&gt; | a list of provider-specific OAuth scopes with the permissions your OAuth app would like to ask for. these may not be set if you are using the ngrok-managed oauth app (i.e. you must pass both `client_id` and `client_secret` to set scopes) |
+| routes.oauth.provider.google.email_addresses | List&lt;string&gt; | a list of email addresses of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.google.email_domains | List&lt;string&gt; | a list of email domains of users authenticated by identity provider who are allowed access to the endpoint |
+| routes.oauth.provider.linkedin.client_id | string |  |
+| routes.oauth.provider.linkedin.client_secret | string |  |
+| routes.oauth.provider.linkedin.scopes | List&lt;string&gt; |  |
+| routes.oauth.provider.linkedin.email_addresses | List&lt;string&gt; |  |
+| routes.oauth.provider.linkedin.email_domains | List&lt;string&gt; |  |
+| routes.oauth.provider.gitlab.client_id | string |  |
+| routes.oauth.provider.gitlab.client_secret | string |  |
+| routes.oauth.provider.gitlab.scopes | List&lt;string&gt; |  |
+| routes.oauth.provider.gitlab.email_addresses | List&lt;string&gt; |  |
+| routes.oauth.provider.gitlab.email_domains | List&lt;string&gt; |  |
+| routes.oauth.provider.twitch.client_id | string |  |
+| routes.oauth.provider.twitch.client_secret | string |  |
+| routes.oauth.provider.twitch.scopes | List&lt;string&gt; |  |
+| routes.oauth.provider.twitch.email_addresses | List&lt;string&gt; |  |
+| routes.oauth.provider.twitch.email_domains | List&lt;string&gt; |  |
+| routes.oauth.provider.amazon.client_id | string |  |
+| routes.oauth.provider.amazon.client_secret | string |  |
+| routes.oauth.provider.amazon.scopes | List&lt;string&gt; |  |
+| routes.oauth.provider.amazon.email_addresses | List&lt;string&gt; |  |
+| routes.oauth.provider.amazon.email_domains | List&lt;string&gt; |  |
+| routes.oauth.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| routes.oauth.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| routes.oauth.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| routes.oauth.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| routes.oauth.auth_check_interval | uint32 | Integer number of seconds after which ngrok guarantees it will refresh user state from the identity provider and recheck whether the user is still authorized to access the endpoint. This is the preferred tunable to use to enforce a minimum amount of time after which a revoked user will no longer be able to access the resource. |
+| routes.saml.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.saml.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| routes.saml.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| routes.saml.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| routes.saml.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| routes.saml.idp_metadata | string | The full XML IdP EntityDescriptor. Your IdP may provide this to you as a a file to download or as a URL. |
+| routes.saml.force_authn | boolean | If true, indicates that whenever we redirect a user to the IdP for authentication that the IdP must prompt the user for authentication credentials even if the user already has a valid session with the IdP. |
+| routes.saml.allow_idp_initiated | boolean | If true, the IdP may initiate a login directly (e.g. the user does not need to visit the endpoint first and then be redirected). The IdP should set the `RelayState` parameter to the target URL of the resource they want the user to be redirected to after the SAML login assertion has been processed. |
+| routes.saml.authorized_groups | List&lt;string&gt; | If present, only users who are a member of one of the listed groups may access the target endpoint. |
+| routes.saml.entity_id | string | The SP Entity's unique ID. This always takes the form of a URL. In ngrok's implementation, this URL is the same as the metadata URL. This will need to be specified to the IdP as configuration. |
+| routes.saml.assertion_consumer_service_url | string | The public URL of the SP's Assertion Consumer Service. This is where the IdP will redirect to during an authentication flow. This will need to be specified to the IdP as configuration. |
+| routes.saml.single_logout_url | string | The public URL of the SP's Single Logout Service. This is where the IdP will redirect to during a single logout flow. This will optionally need to be specified to the IdP as configuration. |
+| routes.saml.request_signing_certificate_pem | string | PEM-encoded x.509 certificate of the key pair that is used to sign all SAML requests that the ngrok SP makes to the IdP. Many IdPs do not support request signing verification, but we highly recommend specifying this in the IdP's configuration if it is supported. |
+| routes.saml.metadata_url | string | A public URL where the SP's metadata is hosted. If an IdP supports dynamic configuration, this is the URL it can use to retrieve the SP metadata. |
+| routes.saml.nameid_format | string | Defines the name identifier format the SP expects the IdP to use in its assertions to identify subjects. If unspecified, a default value of `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` will be used. A subset of the allowed values enumerated by the SAML specification are supported. |
+| routes.oidc.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.oidc.options_passthrough | boolean | Do not enforce authentication on HTTP OPTIONS requests. necessary if you are supporting CORS. |
+| routes.oidc.cookie_prefix | string | the prefix of the session cookie that ngrok sets on the http client to cache authentication. default is 'ngrok.' |
+| routes.oidc.inactivity_timeout | uint32 | Integer number of seconds of inactivity after which if the user has not accessed the endpoint, their session will time out and they will be forced to reauthenticate. |
+| routes.oidc.maximum_duration | uint32 | Integer number of seconds of the maximum duration of an authenticated session. After this period is exceeded, a user must reauthenticate. |
+| routes.oidc.issuer | string | URL of the OIDC "OpenID provider". This is the base URL used for discovery. |
+| routes.oidc.client_id | string | The OIDC app's client ID and OIDC audience. |
+| routes.oidc.client_secret | string | The OIDC app's client secret. |
+| routes.oidc.scopes | List&lt;string&gt; | The set of scopes to request from the OIDC identity provider. |
+| routes.websocket_tcp_converter.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.user_agent_filter.enabled | boolean |  |
+| routes.user_agent_filter.allow | List&lt;string&gt; |  |
+| routes.user_agent_filter.deny | List&lt;string&gt; |  |
+| routes.traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| routes.traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_ip-policy-list.mdx
+++ b/snippets/obs/_ip-policy-list.mdx
@@ -1,9 +1,9 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this IP policy |
-| uri | string | URI of the IP Policy API resource |
-| created_at | string | timestamp when the IP policy was created, RFC 3339 format |
-| description | string | human-readable description of the source IPs of this IP policy. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this IP policy. optional, max 4096 bytes. |
+| ip_policies.id | string | unique identifier for this IP policy |
+| ip_policies.uri | string | URI of the IP Policy API resource |
+| ip_policies.created_at | string | timestamp when the IP policy was created, RFC 3339 format |
+| ip_policies.description | string | human-readable description of the source IPs of this IP policy. optional, max 255 bytes. |
+| ip_policies.metadata | string | arbitrary user-defined machine-readable data of this IP policy. optional, max 4096 bytes. |
 | uri | string | URI of the IP policy list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ip-policy-rule-list.mdx
+++ b/snippets/obs/_ip-policy-rule-list.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this IP policy rule |
-| uri | string | URI of the IP policy rule API resource |
-| created_at | string | timestamp when the IP policy rule was created, RFC 3339 format |
-| description | string | human-readable description of the source IPs of this IP rule. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this IP policy rule. optional, max 4096 bytes. |
-| cidr | string | an IP or IP range specified in CIDR notation. IPv4 and IPv6 are both supported. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| action | string | the action to apply to the policy rule, either `allow` or `deny` |
+| ip_policy_rules.id | string | unique identifier for this IP policy rule |
+| ip_policy_rules.uri | string | URI of the IP policy rule API resource |
+| ip_policy_rules.created_at | string | timestamp when the IP policy rule was created, RFC 3339 format |
+| ip_policy_rules.description | string | human-readable description of the source IPs of this IP rule. optional, max 255 bytes. |
+| ip_policy_rules.metadata | string | arbitrary user-defined machine-readable data of this IP policy rule. optional, max 4096 bytes. |
+| ip_policy_rules.cidr | string | an IP or IP range specified in CIDR notation. IPv4 and IPv6 are both supported. |
+| ip_policy_rules.ip_policy.id | string | a resource identifier |
+| ip_policy_rules.ip_policy.uri | string | a uri for locating a resource |
+| ip_policy_rules.action | string | the action to apply to the policy rule, either `allow` or `deny` |
 | uri | string | URI of the IP policy rule list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ip-policy-rule.mdx
+++ b/snippets/obs/_ip-policy-rule.mdx
@@ -6,6 +6,6 @@
 | description | string | human-readable description of the source IPs of this IP rule. optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this IP policy rule. optional, max 4096 bytes. |
 | cidr | string | an IP or IP range specified in CIDR notation. IPv4 and IPv6 are both supported. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| ip_policy.id | string | a resource identifier |
+| ip_policy.uri | string | a uri for locating a resource |
 | action | string | the action to apply to the policy rule, either `allow` or `deny` |

--- a/snippets/obs/_ip-restriction-list.mdx
+++ b/snippets/obs/_ip-restriction-list.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this IP restriction |
-| uri | string | URI of the IP restriction API resource |
-| created_at | string | timestamp when the IP restriction was created, RFC 3339 format |
-| description | string | human-readable description of this IP restriction. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this IP restriction. optional, max 4096 bytes. |
-| enforced | boolean | true if the IP restriction will be enforced. if false, only warnings will be issued |
-| type | string | the type of IP restriction. this defines what traffic will be restricted with the attached policies. four values are currently supported: `dashboard`, `api`, `agent`, and `endpoints` |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| ip_restrictions.id | string | unique identifier for this IP restriction |
+| ip_restrictions.uri | string | URI of the IP restriction API resource |
+| ip_restrictions.created_at | string | timestamp when the IP restriction was created, RFC 3339 format |
+| ip_restrictions.description | string | human-readable description of this IP restriction. optional, max 255 bytes. |
+| ip_restrictions.metadata | string | arbitrary user-defined machine-readable data of this IP restriction. optional, max 4096 bytes. |
+| ip_restrictions.enforced | boolean | true if the IP restriction will be enforced. if false, only warnings will be issued |
+| ip_restrictions.type | string | the type of IP restriction. this defines what traffic will be restricted with the attached policies. four values are currently supported: `dashboard`, `api`, `agent`, and `endpoints` |
+| ip_restrictions.ip_policies.id | string | a resource identifier |
+| ip_restrictions.ip_policies.uri | string | a uri for locating a resource |
 | uri | string | URI of the IP restrictions list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ip-restriction.mdx
+++ b/snippets/obs/_ip-restriction.mdx
@@ -7,5 +7,5 @@
 | metadata | string | arbitrary user-defined machine-readable data of this IP restriction. optional, max 4096 bytes. |
 | enforced | boolean | true if the IP restriction will be enforced. if false, only warnings will be issued |
 | type | string | the type of IP restriction. this defines what traffic will be restricted with the attached policies. four values are currently supported: `dashboard`, `api`, `agent`, and `endpoints` |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| ip_policies.id | string | a resource identifier |
+| ip_policies.uri | string | a uri for locating a resource |

--- a/snippets/obs/_kubernetes-operator-binding.mdx
+++ b/snippets/obs/_kubernetes-operator-binding.mdx
@@ -1,7 +1,7 @@
 | Name | Type | Description |
 |---|---|---|
 | endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
-| cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
-| not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
-| not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
+| cert.cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
+| cert.not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
+| cert.not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
 | ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |

--- a/snippets/obs/_kubernetes-operator-create.mdx
+++ b/snippets/obs/_kubernetes-operator-create.mdx
@@ -4,10 +4,10 @@
 | metadata | string | arbitrary user-defined machine-readable data of this Kubernetes Operator. optional, max 4096 bytes. |
 | enabled_features | List&lt;string&gt; | features enabled for this Kubernetes Operator. a subset of "bindings", "ingress", and "gateway" |
 | region | string | the ngrok region in which the ingress for this operator is served. defaults to "global" |
-| name | string | the deployment name |
-| namespace | string | the namespace this Kubernetes Operator is deployed to |
-| version | string | the version of this Kubernetes Operator |
-| cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
-| endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
-| csr | string | CSR is supplied during initial creation to enable creating a mutual TLS secured connection between ngrok and the operator. This is an internal implementation detail and subject to change. |
-| ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
+| deployment.name | string | the deployment name |
+| deployment.namespace | string | the namespace this Kubernetes Operator is deployed to |
+| deployment.version | string | the version of this Kubernetes Operator |
+| deployment.cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
+| binding.endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
+| binding.csr | string | CSR is supplied during initial creation to enable creating a mutual TLS secured connection between ngrok and the operator. This is an internal implementation detail and subject to change. |
+| binding.ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |

--- a/snippets/obs/_kubernetes-operator-list.mdx
+++ b/snippets/obs/_kubernetes-operator-list.mdx
@@ -1,23 +1,23 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this Kubernetes Operator |
-| uri | string | URI of this Kubernetes Operator API resource |
-| created_at | string | timestamp when the Kubernetes Operator was created. RFC 3339 format |
-| updated_at | string | timestamp when the Kubernetes Operator was last updated. RFC 3339 format |
-| description | string | human-readable description of this Kubernetes Operator. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this Kubernetes Operator. optional, max 4096 bytes. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled_features | List&lt;string&gt; | features enabled for this Kubernetes Operator. a subset of "bindings", "ingress", and "gateway" |
-| region | string | the ngrok region in which the ingress for this operator is served. defaults to "global" |
-| name | string | the deployment name |
-| namespace | string | the namespace this Kubernetes Operator is deployed to |
-| version | string | the version of this Kubernetes Operator |
-| cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
-| endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
-| cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
-| not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
-| not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
-| ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
+| operators.id | string | unique identifier for this Kubernetes Operator |
+| operators.uri | string | URI of this Kubernetes Operator API resource |
+| operators.created_at | string | timestamp when the Kubernetes Operator was created. RFC 3339 format |
+| operators.updated_at | string | timestamp when the Kubernetes Operator was last updated. RFC 3339 format |
+| operators.description | string | human-readable description of this Kubernetes Operator. optional, max 255 bytes. |
+| operators.metadata | string | arbitrary user-defined machine-readable data of this Kubernetes Operator. optional, max 4096 bytes. |
+| operators.principal.id | string | a resource identifier |
+| operators.principal.uri | string | a uri for locating a resource |
+| operators.enabled_features | List&lt;string&gt; | features enabled for this Kubernetes Operator. a subset of "bindings", "ingress", and "gateway" |
+| operators.region | string | the ngrok region in which the ingress for this operator is served. defaults to "global" |
+| operators.deployment.name | string | the deployment name |
+| operators.deployment.namespace | string | the namespace this Kubernetes Operator is deployed to |
+| operators.deployment.version | string | the version of this Kubernetes Operator |
+| operators.deployment.cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
+| operators.binding.endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
+| operators.binding.cert.cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
+| operators.binding.cert.not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
+| operators.binding.cert.not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
+| operators.binding.ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
 | uri | string |  |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_kubernetes-operator-update.mdx
+++ b/snippets/obs/_kubernetes-operator-update.mdx
@@ -5,8 +5,8 @@
 | metadata | string | arbitrary user-defined machine-readable data of this Kubernetes Operator. optional, max 4096 bytes. |
 | enabled_features | List&lt;string&gt; | features enabled for this Kubernetes Operator. a subset of "bindings", "ingress", and "gateway" |
 | region | string | the ngrok region in which the ingress for this operator is served. defaults to "global" |
-| endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
-| csr | string | CSR is supplied during initial creation to enable creating a mutual TLS secured connection between ngrok and the operator. This is an internal implementation detail and subject to change. |
-| ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
-| name | string | the deployment name |
-| version | string | the version of this Kubernetes Operator |
+| binding.endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
+| binding.csr | string | CSR is supplied during initial creation to enable creating a mutual TLS secured connection between ngrok and the operator. This is an internal implementation detail and subject to change. |
+| binding.ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
+| deployment.name | string | the deployment name |
+| deployment.version | string | the version of this Kubernetes Operator |

--- a/snippets/obs/_kubernetes-operator.mdx
+++ b/snippets/obs/_kubernetes-operator.mdx
@@ -6,16 +6,16 @@
 | updated_at | string | timestamp when the Kubernetes Operator was last updated. RFC 3339 format |
 | description | string | human-readable description of this Kubernetes Operator. optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this Kubernetes Operator. optional, max 4096 bytes. |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| principal.id | string | a resource identifier |
+| principal.uri | string | a uri for locating a resource |
 | enabled_features | List&lt;string&gt; | features enabled for this Kubernetes Operator. a subset of "bindings", "ingress", and "gateway" |
 | region | string | the ngrok region in which the ingress for this operator is served. defaults to "global" |
-| name | string | the deployment name |
-| namespace | string | the namespace this Kubernetes Operator is deployed to |
-| version | string | the version of this Kubernetes Operator |
-| cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
-| endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
-| cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
-| not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
-| not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
-| ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |
+| deployment.name | string | the deployment name |
+| deployment.namespace | string | the namespace this Kubernetes Operator is deployed to |
+| deployment.version | string | the version of this Kubernetes Operator |
+| deployment.cluster_name | string | user-given name for the cluster the Kubernetes Operator is deployed to |
+| binding.endpoint_selectors | List&lt;string&gt; | the list of cel expressions that filter the k8s bound endpoints for this operator |
+| binding.cert.cert | string | the public client certificate generated for this Kubernetes Operator from the CSR supplied when enabling the Bindings feature |
+| binding.cert.not_before | string | timestamp when the certificate becomes valid. RFC 3339 format |
+| binding.cert.not_after | string | timestamp when the certificate becomes invalid. RFC 3339 format |
+| binding.ingress_endpoint | string | the public ingress endpoint for this Kubernetes Operator |

--- a/snippets/obs/_reserved-addr-list.mdx
+++ b/snippets/obs/_reserved-addr-list.mdx
@@ -1,11 +1,11 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique reserved address resource identifier |
-| uri | string | URI of the reserved address API resource |
-| created_at | string | timestamp when the reserved address was created, RFC 3339 format |
-| description | string | human-readable description of what this reserved address will be used for |
-| metadata | string | arbitrary user-defined machine-readable data of this reserved address. Optional, max 4096 bytes. |
-| addr | string | hostname:port of the reserved address that was assigned at creation time |
-| region | string | reserve the address in this geographic ngrok datacenter. Optional, default is us. (au, eu, ap, us, jp, in, sa) |
+| reserved_addrs.id | string | unique reserved address resource identifier |
+| reserved_addrs.uri | string | URI of the reserved address API resource |
+| reserved_addrs.created_at | string | timestamp when the reserved address was created, RFC 3339 format |
+| reserved_addrs.description | string | human-readable description of what this reserved address will be used for |
+| reserved_addrs.metadata | string | arbitrary user-defined machine-readable data of this reserved address. Optional, max 4096 bytes. |
+| reserved_addrs.addr | string | hostname:port of the reserved address that was assigned at creation time |
+| reserved_addrs.region | string | reserve the address in this geographic ngrok datacenter. Optional, default is us. (au, eu, ap, us, jp, in, sa) |
 | uri | string | URI of the reserved address list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_reserved-domain-cert-status.mdx
+++ b/snippets/obs/_reserved-domain-cert-status.mdx
@@ -1,7 +1,7 @@
 | Name | Type | Description |
 |---|---|---|
 | renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
+| provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| provisioning_job.msg | string | a message describing the current status or error |
+| provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |

--- a/snippets/obs/_reserved-domain-create.mdx
+++ b/snippets/obs/_reserved-domain-create.mdx
@@ -5,5 +5,5 @@
 | description | string | human-readable description of what this reserved domain will be used for |
 | metadata | string | arbitrary user-defined machine-readable data of this reserved domain. Optional, max 4096 bytes. |
 | certificate_id | string | ID of a user-uploaded TLS certificate to use for connections to targeting this domain. Optional, mutually exclusive with `certificate_management_policy`. |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |

--- a/snippets/obs/_reserved-domain-list.mdx
+++ b/snippets/obs/_reserved-domain-list.mdx
@@ -1,22 +1,22 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique reserved domain resource identifier |
-| uri | string | URI of the reserved domain API resource |
-| created_at | string | timestamp when the reserved domain was created, RFC 3339 format |
-| description | string | human-readable description of what this reserved domain will be used for |
-| metadata | string | arbitrary user-defined machine-readable data of this reserved domain. Optional, max 4096 bytes. |
-| domain | string | hostname of the reserved domain |
-| region | string | deprecated: With the launch of the ngrok Global Network domains traffic is now handled globally. This field applied only to endpoints. Note that agents may still connect to specific regions. Optional, null by default. (au, eu, ap, us, jp, in, sa) |
-| cname_target | string | DNS CNAME target for a custom hostname, or null if the reserved domain is a subdomain of an ngrok owned domain (e.g. *.ngrok.app) |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
-| renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
-| acme_challenge_cname_target | string | DNS CNAME target for the host _acme-challenge.example.com, where example.com is your reserved domain name. This is required to issue certificates for wildcard, non-ngrok reserved domains. Must be null for non-wildcard domains and ngrok subdomains. |
+| reserved_domains.id | string | unique reserved domain resource identifier |
+| reserved_domains.uri | string | URI of the reserved domain API resource |
+| reserved_domains.created_at | string | timestamp when the reserved domain was created, RFC 3339 format |
+| reserved_domains.description | string | human-readable description of what this reserved domain will be used for |
+| reserved_domains.metadata | string | arbitrary user-defined machine-readable data of this reserved domain. Optional, max 4096 bytes. |
+| reserved_domains.domain | string | hostname of the reserved domain |
+| reserved_domains.region | string | deprecated: With the launch of the ngrok Global Network domains traffic is now handled globally. This field applied only to endpoints. Note that agents may still connect to specific regions. Optional, null by default. (au, eu, ap, us, jp, in, sa) |
+| reserved_domains.cname_target | string | DNS CNAME target for a custom hostname, or null if the reserved domain is a subdomain of an ngrok owned domain (e.g. *.ngrok.app) |
+| reserved_domains.certificate.id | string | a resource identifier |
+| reserved_domains.certificate.uri | string | a uri for locating a resource |
+| reserved_domains.certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| reserved_domains.certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
+| reserved_domains.certificate_management_status.renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
+| reserved_domains.certificate_management_status.provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| reserved_domains.certificate_management_status.provisioning_job.msg | string | a message describing the current status or error |
+| reserved_domains.certificate_management_status.provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| reserved_domains.certificate_management_status.provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |
+| reserved_domains.acme_challenge_cname_target | string | DNS CNAME target for the host _acme-challenge.example.com, where example.com is your reserved domain name. This is required to issue certificates for wildcard, non-ngrok reserved domains. Must be null for non-wildcard domains and ngrok subdomains. |
 | uri | string | URI of the reserved domain list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_reserved-domain-update.mdx
+++ b/snippets/obs/_reserved-domain-update.mdx
@@ -4,5 +4,5 @@
 | description | string | human-readable description of what this reserved domain will be used for |
 | metadata | string | arbitrary user-defined machine-readable data of this reserved domain. Optional, max 4096 bytes. |
 | certificate_id | string | ID of a user-uploaded TLS certificate to use for connections to targeting this domain. Optional, mutually exclusive with `certificate_management_policy`. |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |

--- a/snippets/obs/_reserved-domain.mdx
+++ b/snippets/obs/_reserved-domain.mdx
@@ -8,13 +8,13 @@
 | domain | string | hostname of the reserved domain |
 | region | string | deprecated: With the launch of the ngrok Global Network domains traffic is now handled globally. This field applied only to endpoints. Note that agents may still connect to specific regions. Optional, null by default. (au, eu, ap, us, jp, in, sa) |
 | cname_target | string | DNS CNAME target for a custom hostname, or null if the reserved domain is a subdomain of an ngrok owned domain (e.g. *.ngrok.app) |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
-| private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
-| renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
-| error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
-| msg | string | a message describing the current status or error |
-| started_at | string | timestamp when the provisioning job started, RFC 3339 format |
-| retries_at | string | timestamp when the provisioning job will be retried |
+| certificate.id | string | a resource identifier |
+| certificate.uri | string | a uri for locating a resource |
+| certificate_management_policy.authority | string | certificate authority to request certificates from. The only supported value is letsencrypt. |
+| certificate_management_policy.private_key_type | string | type of private key to use when requesting certificates. Defaults to ecdsa, can be either rsa or ecdsa. |
+| certificate_management_status.renews_at | string | timestamp when the next renewal will be requested, RFC 3339 format |
+| certificate_management_status.provisioning_job.error_code | string | if present, an error code indicating why provisioning is failing. It may be either a temporary condition (INTERNAL_ERROR), or a permanent one the user must correct (DNS_ERROR). |
+| certificate_management_status.provisioning_job.msg | string | a message describing the current status or error |
+| certificate_management_status.provisioning_job.started_at | string | timestamp when the provisioning job started, RFC 3339 format |
+| certificate_management_status.provisioning_job.retries_at | string | timestamp when the provisioning job will be retried |
 | acme_challenge_cname_target | string | DNS CNAME target for the host _acme-challenge.example.com, where example.com is your reserved domain name. This is required to issue certificates for wildcard, non-ngrok reserved domains. Must be null for non-wildcard domains and ngrok subdomains. |

--- a/snippets/obs/_secret-list.mdx
+++ b/snippets/obs/_secret-list.mdx
@@ -1,18 +1,18 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | identifier for Secret |
-| uri | string | URI of this Secret API resource |
-| created_at | string | Timestamp when the Secret was created (RFC 3339 format) |
-| updated_at | string | Timestamp when the Secret was last updated (RFC 3339 format) |
-| name | string | Name of secret |
-| description | string | description of Secret |
-| metadata | string | Arbitrary user-defined metadata for this Secret |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| vault_name | string | Name of the vault the secret is stored in |
+| secrets.id | string | identifier for Secret |
+| secrets.uri | string | URI of this Secret API resource |
+| secrets.created_at | string | Timestamp when the Secret was created (RFC 3339 format) |
+| secrets.updated_at | string | Timestamp when the Secret was last updated (RFC 3339 format) |
+| secrets.name | string | Name of secret |
+| secrets.description | string | description of Secret |
+| secrets.metadata | string | Arbitrary user-defined metadata for this Secret |
+| secrets.created_by.id | string | a resource identifier |
+| secrets.created_by.uri | string | a uri for locating a resource |
+| secrets.last_updated_by.id | string | a resource identifier |
+| secrets.last_updated_by.uri | string | a uri for locating a resource |
+| secrets.vault.id | string | a resource identifier |
+| secrets.vault.uri | string | a uri for locating a resource |
+| secrets.vault_name | string | Name of the vault the secret is stored in |
 | uri | string |  |
 | next_page_uri | string | URI of the next page of results, or null if there is no next page |

--- a/snippets/obs/_secret.mdx
+++ b/snippets/obs/_secret.mdx
@@ -7,10 +7,10 @@
 | name | string | Name of secret |
 | description | string | description of Secret |
 | metadata | string | Arbitrary user-defined metadata for this Secret |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| created_by.id | string | a resource identifier |
+| created_by.uri | string | a uri for locating a resource |
+| last_updated_by.id | string | a resource identifier |
+| last_updated_by.uri | string | a uri for locating a resource |
+| vault.id | string | a resource identifier |
+| vault.uri | string | a uri for locating a resource |
 | vault_name | string | Name of the vault the secret is stored in |

--- a/snippets/obs/_self-response.mdx
+++ b/snippets/obs/_self-response.mdx
@@ -1,19 +1,19 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique API key resource identifier |
-| uri | string | URI to the API resource of this API key |
-| description | string | human-readable description of what uses the API key to authenticate. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined data of this API key. optional, max 4096 bytes |
-| created_at | string | timestamp when the api key was created, RFC 3339 format |
-| token | string | the bearer token that can be placed into the Authorization header to authenticate request to the ngrok API. **This value is only available one time, on the API response from key creation. Otherwise it is null.** |
-| owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
-| id | string | unique API key resource identifier |
-| name | string |  |
-| created_at | string |  |
-| suspended | boolean |  |
-| enforce_sso | boolean |  |
-| min_api_version | int64 |  |
-| min_agent_version | string |  |
-| user_mfa_required | boolean |  |
-| traffic_full_capture | boolean |  |
+| api_key.id | string | unique API key resource identifier |
+| api_key.uri | string | URI to the API resource of this API key |
+| api_key.description | string | human-readable description of what uses the API key to authenticate. optional, max 255 bytes. |
+| api_key.metadata | string | arbitrary user-defined data of this API key. optional, max 4096 bytes |
+| api_key.created_at | string | timestamp when the api key was created, RFC 3339 format |
+| api_key.token | string | the bearer token that can be placed into the Authorization header to authenticate request to the ngrok API. **This value is only available one time, on the API response from key creation. Otherwise it is null.** |
+| api_key.owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
+| account.id | string | unique API key resource identifier |
+| account.name | string |  |
+| account.created_at | string |  |
+| account.suspended | boolean |  |
+| account.enforce_sso | boolean |  |
+| account.min_api_version | int64 |  |
+| account.min_agent_version | string |  |
+| account.user_mfa_required | boolean |  |
+| account.traffic_full_capture | boolean |  |
 | user | string |  |

--- a/snippets/obs/_service-user-list.mdx
+++ b/snippets/obs/_service-user-list.mdx
@@ -1,9 +1,9 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique API key resource identifier |
-| uri | string | URI to the API resource of this service user |
-| name | string | human-readable name used to identify the service |
-| active | boolean | whether or not the service is active |
-| created_at | string | timestamp when the api key was created, RFC 3339 format |
+| service_users.id | string | unique API key resource identifier |
+| service_users.uri | string | URI to the API resource of this service user |
+| service_users.name | string | human-readable name used to identify the service |
+| service_users.active | boolean | whether or not the service is active |
+| service_users.created_at | string | timestamp when the api key was created, RFC 3339 format |
 | uri | string | URI of the service users list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ssh-certificate-authority-list.mdx
+++ b/snippets/obs/_ssh-certificate-authority-list.mdx
@@ -1,11 +1,11 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this SSH Certificate Authority |
-| uri | string | URI of the SSH Certificate Authority API resource |
-| created_at | string | timestamp when the SSH Certificate Authority API resource was created, RFC 3339 format |
-| description | string | human-readable description of this SSH Certificate Authority. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this SSH Certificate Authority. optional, max 4096 bytes. |
-| public_key | string | raw public key for this SSH Certificate Authority |
-| key_type | string | the type of private key for this SSH Certificate Authority |
+| ssh_certificate_authorities.id | string | unique identifier for this SSH Certificate Authority |
+| ssh_certificate_authorities.uri | string | URI of the SSH Certificate Authority API resource |
+| ssh_certificate_authorities.created_at | string | timestamp when the SSH Certificate Authority API resource was created, RFC 3339 format |
+| ssh_certificate_authorities.description | string | human-readable description of this SSH Certificate Authority. optional, max 255 bytes. |
+| ssh_certificate_authorities.metadata | string | arbitrary user-defined machine-readable data of this SSH Certificate Authority. optional, max 4096 bytes. |
+| ssh_certificate_authorities.public_key | string | raw public key for this SSH Certificate Authority |
+| ssh_certificate_authorities.key_type | string | the type of private key for this SSH Certificate Authority |
 | uri | string | URI of the certificates authorities list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ssh-credential-list.mdx
+++ b/snippets/obs/_ssh-credential-list.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique ssh credential resource identifier |
-| uri | string | URI of the ssh credential API resource |
-| created_at | string | timestamp when the ssh credential was created, RFC 3339 format |
-| description | string | human-readable description of who or what will use the ssh credential to authenticate. Optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this ssh credential. Optional, max 4096 bytes. |
-| public_key | string | the PEM-encoded public key of the SSH keypair that will be used to authenticate |
-| acl | List&lt;string&gt; | optional list of ACL rules. If unspecified, the credential will have no restrictions. The only allowed ACL rule at this time is the `bind` rule. The `bind` rule allows the caller to restrict what domains, addresses, and labels the token is allowed to bind. For example, to allow the token to open a tunnel on example.ngrok.io your ACL would include the rule `bind:example.ngrok.io`. Bind rules for domains may specify a leading wildcard to match multiple domains with a common suffix. For example, you may specify a rule of `bind:*.example.com` which will allow `x.example.com`, `y.example.com`, `*.example.com`, etc. Bind rules for labels may specify a wildcard key and/or value to match multiple labels. For example, you may specify a rule of `bind:*=example` which will allow `x=example`, `y=example`, etc. A rule of `'*'` is equivalent to no acl at all and will explicitly permit all actions. |
-| owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
+| ssh_credentials.id | string | unique ssh credential resource identifier |
+| ssh_credentials.uri | string | URI of the ssh credential API resource |
+| ssh_credentials.created_at | string | timestamp when the ssh credential was created, RFC 3339 format |
+| ssh_credentials.description | string | human-readable description of who or what will use the ssh credential to authenticate. Optional, max 255 bytes. |
+| ssh_credentials.metadata | string | arbitrary user-defined machine-readable data of this ssh credential. Optional, max 4096 bytes. |
+| ssh_credentials.public_key | string | the PEM-encoded public key of the SSH keypair that will be used to authenticate |
+| ssh_credentials.acl | List&lt;string&gt; | optional list of ACL rules. If unspecified, the credential will have no restrictions. The only allowed ACL rule at this time is the `bind` rule. The `bind` rule allows the caller to restrict what domains, addresses, and labels the token is allowed to bind. For example, to allow the token to open a tunnel on example.ngrok.io your ACL would include the rule `bind:example.ngrok.io`. Bind rules for domains may specify a leading wildcard to match multiple domains with a common suffix. For example, you may specify a rule of `bind:*.example.com` which will allow `x.example.com`, `y.example.com`, `*.example.com`, etc. Bind rules for labels may specify a wildcard key and/or value to match multiple labels. For example, you may specify a rule of `bind:*=example` which will allow `x=example`, `y=example`, etc. A rule of `'*'` is equivalent to no acl at all and will explicitly permit all actions. |
+| ssh_credentials.owner_id | string | If supplied at credential creation, ownership will be assigned to the specified User or Bot. Only admins may specify an owner other than themselves. Defaults to the authenticated User or Bot. |
 | uri | string | URI of the ssh credential list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ssh-host-certificate-list.mdx
+++ b/snippets/obs/_ssh-host-certificate-list.mdx
@@ -1,16 +1,16 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this SSH Host Certificate |
-| uri | string | URI of the SSH Host Certificate API resource |
-| created_at | string | timestamp when the SSH Host Certificate API resource was created, RFC 3339 format |
-| description | string | human-readable description of this SSH Host Certificate. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this SSH Host Certificate. optional, max 4096 bytes. |
-| public_key | string | a public key in OpenSSH Authorized Keys format that this certificate signs |
-| key_type | string | the key type of the `public_key`, one of `rsa`, `ecdsa` or `ed25519` |
-| ssh_certificate_authority_id | string | the ssh certificate authority that is used to sign this ssh host certificate |
-| principals | List&lt;string&gt; | the list of principals included in the ssh host certificate. This is the list of hostnames and/or IP addresses that are authorized to serve SSH traffic with this certificate. Dangerously, if no principals are specified, this certificate is considered valid for all hosts. |
-| valid_after | string | the time when the ssh host certificate becomes valid, in RFC 3339 format. |
-| valid_until | string | the time after which the ssh host certificate becomes invalid, in RFC 3339 format. the OpenSSH certificates RFC calls this `valid_before`. |
-| certificate | string | the signed SSH certificate in OpenSSH Authorized Keys format. this value should be placed in a `-cert.pub` certificate file on disk that should be referenced in your `sshd_config` configuration file with a `HostCertificate` directive |
+| ssh_host_certificates.id | string | unique identifier for this SSH Host Certificate |
+| ssh_host_certificates.uri | string | URI of the SSH Host Certificate API resource |
+| ssh_host_certificates.created_at | string | timestamp when the SSH Host Certificate API resource was created, RFC 3339 format |
+| ssh_host_certificates.description | string | human-readable description of this SSH Host Certificate. optional, max 255 bytes. |
+| ssh_host_certificates.metadata | string | arbitrary user-defined machine-readable data of this SSH Host Certificate. optional, max 4096 bytes. |
+| ssh_host_certificates.public_key | string | a public key in OpenSSH Authorized Keys format that this certificate signs |
+| ssh_host_certificates.key_type | string | the key type of the `public_key`, one of `rsa`, `ecdsa` or `ed25519` |
+| ssh_host_certificates.ssh_certificate_authority_id | string | the ssh certificate authority that is used to sign this ssh host certificate |
+| ssh_host_certificates.principals | List&lt;string&gt; | the list of principals included in the ssh host certificate. This is the list of hostnames and/or IP addresses that are authorized to serve SSH traffic with this certificate. Dangerously, if no principals are specified, this certificate is considered valid for all hosts. |
+| ssh_host_certificates.valid_after | string | the time when the ssh host certificate becomes valid, in RFC 3339 format. |
+| ssh_host_certificates.valid_until | string | the time after which the ssh host certificate becomes invalid, in RFC 3339 format. the OpenSSH certificates RFC calls this `valid_before`. |
+| ssh_host_certificates.certificate | string | the signed SSH certificate in OpenSSH Authorized Keys format. this value should be placed in a `-cert.pub` certificate file on disk that should be referenced in your `sshd_config` configuration file with a `HostCertificate` directive |
 | uri | string | URI of the ssh host certificates list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_ssh-user-certificate-list.mdx
+++ b/snippets/obs/_ssh-user-certificate-list.mdx
@@ -1,18 +1,18 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this SSH User Certificate |
-| uri | string | URI of the SSH User Certificate API resource |
-| created_at | string | timestamp when the SSH User Certificate API resource was created, RFC 3339 format |
-| description | string | human-readable description of this SSH User Certificate. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this SSH User Certificate. optional, max 4096 bytes. |
-| public_key | string | a public key in OpenSSH Authorized Keys format that this certificate signs |
-| key_type | string | the key type of the `public_key`, one of `rsa`, `ecdsa` or `ed25519` |
-| ssh_certificate_authority_id | string | the ssh certificate authority that is used to sign this ssh user certificate |
-| principals | List&lt;string&gt; | the list of principals included in the ssh user certificate. This is the list of usernames that the certificate holder may sign in as on a machine authorizing the signing certificate authority. Dangerously, if no principals are specified, this certificate may be used to log in as any user. |
-| critical_options | Map&lt;string, string&gt; | A map of critical options included in the certificate. Only two critical options are currently defined by OpenSSH: `force-command` and `source-address`. See [the OpenSSH certificate protocol spec](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys) for additional details. |
-| extensions | Map&lt;string, string&gt; | A map of extensions included in the certificate. Extensions are additional metadata that can be interpreted by the SSH server for any purpose. These can be used to permit or deny the ability to open a terminal, do port forwarding, x11 forwarding, and more. If unspecified, the certificate will include limited permissions with the following extension map: `{"permit-pty": "", "permit-user-rc": ""}` OpenSSH understands a number of predefined extensions. See [the OpenSSH certificate protocol spec](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys) for additional details. |
-| valid_after | string | the time when the ssh host certificate becomes valid, in RFC 3339 format. |
-| valid_until | string | the time after which the ssh host certificate becomes invalid, in RFC 3339 format. the OpenSSH certificates RFC calls this `valid_before`. |
-| certificate | string | the signed SSH certificate in OpenSSH Authorized Keys Format. this value should be placed in a `-cert.pub` certificate file on disk that should be referenced in your `sshd_config` configuration file with a `HostCertificate` directive |
+| ssh_user_certificates.id | string | unique identifier for this SSH User Certificate |
+| ssh_user_certificates.uri | string | URI of the SSH User Certificate API resource |
+| ssh_user_certificates.created_at | string | timestamp when the SSH User Certificate API resource was created, RFC 3339 format |
+| ssh_user_certificates.description | string | human-readable description of this SSH User Certificate. optional, max 255 bytes. |
+| ssh_user_certificates.metadata | string | arbitrary user-defined machine-readable data of this SSH User Certificate. optional, max 4096 bytes. |
+| ssh_user_certificates.public_key | string | a public key in OpenSSH Authorized Keys format that this certificate signs |
+| ssh_user_certificates.key_type | string | the key type of the `public_key`, one of `rsa`, `ecdsa` or `ed25519` |
+| ssh_user_certificates.ssh_certificate_authority_id | string | the ssh certificate authority that is used to sign this ssh user certificate |
+| ssh_user_certificates.principals | List&lt;string&gt; | the list of principals included in the ssh user certificate. This is the list of usernames that the certificate holder may sign in as on a machine authorizing the signing certificate authority. Dangerously, if no principals are specified, this certificate may be used to log in as any user. |
+| ssh_user_certificates.critical_options | Map&lt;string, string&gt; | A map of critical options included in the certificate. Only two critical options are currently defined by OpenSSH: `force-command` and `source-address`. See [the OpenSSH certificate protocol spec](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys) for additional details. |
+| ssh_user_certificates.extensions | Map&lt;string, string&gt; | A map of extensions included in the certificate. Extensions are additional metadata that can be interpreted by the SSH server for any purpose. These can be used to permit or deny the ability to open a terminal, do port forwarding, x11 forwarding, and more. If unspecified, the certificate will include limited permissions with the following extension map: `{"permit-pty": "", "permit-user-rc": ""}` OpenSSH understands a number of predefined extensions. See [the OpenSSH certificate protocol spec](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys) for additional details. |
+| ssh_user_certificates.valid_after | string | the time when the ssh host certificate becomes valid, in RFC 3339 format. |
+| ssh_user_certificates.valid_until | string | the time after which the ssh host certificate becomes invalid, in RFC 3339 format. the OpenSSH certificates RFC calls this `valid_before`. |
+| ssh_user_certificates.certificate | string | the signed SSH certificate in OpenSSH Authorized Keys Format. this value should be placed in a `-cert.pub` certificate file on disk that should be referenced in your `sshd_config` configuration file with a `HostCertificate` directive |
 | uri | string | URI of the ssh user certificates list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_static-backend-create.mdx
+++ b/snippets/obs/_static-backend-create.mdx
@@ -3,4 +3,4 @@
 | description | string | human-readable description of this backend. Optional |
 | metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
 | address | string | the address to forward to |
-| enabled | boolean | if TLS is checked |
+| tls.enabled | boolean | if TLS is checked |

--- a/snippets/obs/_static-backend-list.mdx
+++ b/snippets/obs/_static-backend-list.mdx
@@ -1,11 +1,11 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this static backend |
-| uri | string | URI of the StaticBackend API resource |
-| created_at | string | timestamp when the backend was created, RFC 3339 format |
-| description | string | human-readable description of this backend. Optional |
-| metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
-| address | string | the address to forward to |
-| enabled | boolean | if TLS is checked |
+| backends.id | string | unique identifier for this static backend |
+| backends.uri | string | URI of the StaticBackend API resource |
+| backends.created_at | string | timestamp when the backend was created, RFC 3339 format |
+| backends.description | string | human-readable description of this backend. Optional |
+| backends.metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
+| backends.address | string | the address to forward to |
+| backends.tls.enabled | boolean | if TLS is checked |
 | uri | string | URI of the static backends list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_static-backend-update.mdx
+++ b/snippets/obs/_static-backend-update.mdx
@@ -4,4 +4,4 @@
 | description | string | human-readable description of this backend. Optional |
 | metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
 | address | string | the address to forward to |
-| enabled | boolean | if TLS is checked |
+| tls.enabled | boolean | if TLS is checked |

--- a/snippets/obs/_static-backend.mdx
+++ b/snippets/obs/_static-backend.mdx
@@ -6,4 +6,4 @@
 | description | string | human-readable description of this backend. Optional |
 | metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
 | address | string | the address to forward to |
-| enabled | boolean | if TLS is checked |
+| tls.enabled | boolean | if TLS is checked |

--- a/snippets/obs/_tcp-edge-create.mdx
+++ b/snippets/obs/_tcp-edge-create.mdx
@@ -3,9 +3,9 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tcp-edge-list.mdx
+++ b/snippets/obs/_tcp-edge-list.mdx
@@ -1,18 +1,18 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier of this edge |
-| description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| created_at | string | timestamp when the edge was created, RFC 3339 format |
-| uri | string | URI of the edge API resource |
-| hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| tcp_edges.id | string | unique identifier of this edge |
+| tcp_edges.description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
+| tcp_edges.metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
+| tcp_edges.created_at | string | timestamp when the edge was created, RFC 3339 format |
+| tcp_edges.uri | string | URI of the edge API resource |
+| tcp_edges.hostports | List&lt;string&gt; | hostports served by this edge |
+| tcp_edges.backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tcp_edges.backend.backend.id | string | a resource identifier |
+| tcp_edges.backend.backend.uri | string | a uri for locating a resource |
+| tcp_edges.ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tcp_edges.ip_restriction.ip_policies.id | string | a resource identifier |
+| tcp_edges.ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| tcp_edges.traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tcp_edges.traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |
 | uri | string | URI of the TCP Edge list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tcp-edge-update.mdx
+++ b/snippets/obs/_tcp-edge-update.mdx
@@ -4,9 +4,9 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tcp-edge.mdx
+++ b/snippets/obs/_tcp-edge.mdx
@@ -6,11 +6,11 @@
 | created_at | string | timestamp when the edge was created, RFC 3339 format |
 | uri | string | URI of the edge API resource |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend.id | string | a resource identifier |
+| backend.backend.uri | string | a uri for locating a resource |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policies.id | string | a resource identifier |
+| ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tls-certificate-list.mdx
+++ b/snippets/obs/_tls-certificate-list.mdx
@@ -1,26 +1,26 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this TLS certificate |
-| uri | string | URI of the TLS certificate API resource |
-| created_at | string | timestamp when the TLS certificate was created, RFC 3339 format |
-| description | string | human-readable description of this TLS certificate. optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this TLS certificate. optional, max 4096 bytes. |
-| certificate_pem | string | chain of PEM-encoded certificates, leaf first. See [Certificate Bundles](https://ngrok.com/docs/cloud-edge/endpoints#certificate-chains). |
-| subject_common_name | string | subject common name from the leaf of this TLS certificate |
-| dns_names | List&lt;string&gt; | set of additional domains (including wildcards) this TLS certificate is valid for |
-| ips | List&lt;string&gt; | set of IP addresses this TLS certificate is also valid for |
-| issued_at | string | timestamp (in RFC 3339 format) when this TLS certificate was issued automatically, or null if this certificate was user-uploaded |
-| not_before | string | timestamp when this TLS certificate becomes valid, RFC 3339 format |
-| not_after | string | timestamp when this TLS certificate becomes invalid, RFC 3339 format |
-| key_usages | List&lt;string&gt; | set of actions the private key of this TLS certificate can be used for |
-| extended_key_usages | List&lt;string&gt; | extended set of actions the private key of this TLS certificate can be used for |
-| private_key_type | string | type of the private key of this TLS certificate. One of rsa, ecdsa, or ed25519. |
-| issuer_common_name | string | issuer common name from the leaf of this TLS certificate |
-| serial_number | string | serial number of the leaf of this TLS certificate |
-| subject_organization | string | subject organization from the leaf of this TLS certificate |
-| subject_organizational_unit | string | subject organizational unit from the leaf of this TLS certificate |
-| subject_locality | string | subject locality from the leaf of this TLS certificate |
-| subject_province | string | subject province from the leaf of this TLS certificate |
-| subject_country | string | subject country from the leaf of this TLS certificate |
+| tls_certificates.id | string | unique identifier for this TLS certificate |
+| tls_certificates.uri | string | URI of the TLS certificate API resource |
+| tls_certificates.created_at | string | timestamp when the TLS certificate was created, RFC 3339 format |
+| tls_certificates.description | string | human-readable description of this TLS certificate. optional, max 255 bytes. |
+| tls_certificates.metadata | string | arbitrary user-defined machine-readable data of this TLS certificate. optional, max 4096 bytes. |
+| tls_certificates.certificate_pem | string | chain of PEM-encoded certificates, leaf first. See [Certificate Bundles](https://ngrok.com/docs/cloud-edge/endpoints#certificate-chains). |
+| tls_certificates.subject_common_name | string | subject common name from the leaf of this TLS certificate |
+| tls_certificates.subject_alternative_names.dns_names | List&lt;string&gt; | set of additional domains (including wildcards) this TLS certificate is valid for |
+| tls_certificates.subject_alternative_names.ips | List&lt;string&gt; | set of IP addresses this TLS certificate is also valid for |
+| tls_certificates.issued_at | string | timestamp (in RFC 3339 format) when this TLS certificate was issued automatically, or null if this certificate was user-uploaded |
+| tls_certificates.not_before | string | timestamp when this TLS certificate becomes valid, RFC 3339 format |
+| tls_certificates.not_after | string | timestamp when this TLS certificate becomes invalid, RFC 3339 format |
+| tls_certificates.key_usages | List&lt;string&gt; | set of actions the private key of this TLS certificate can be used for |
+| tls_certificates.extended_key_usages | List&lt;string&gt; | extended set of actions the private key of this TLS certificate can be used for |
+| tls_certificates.private_key_type | string | type of the private key of this TLS certificate. One of rsa, ecdsa, or ed25519. |
+| tls_certificates.issuer_common_name | string | issuer common name from the leaf of this TLS certificate |
+| tls_certificates.serial_number | string | serial number of the leaf of this TLS certificate |
+| tls_certificates.subject_organization | string | subject organization from the leaf of this TLS certificate |
+| tls_certificates.subject_organizational_unit | string | subject organizational unit from the leaf of this TLS certificate |
+| tls_certificates.subject_locality | string | subject locality from the leaf of this TLS certificate |
+| tls_certificates.subject_province | string | subject province from the leaf of this TLS certificate |
+| tls_certificates.subject_country | string | subject country from the leaf of this TLS certificate |
 | uri | string | URI of the TLS certificates list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tls-certificate.mdx
+++ b/snippets/obs/_tls-certificate.mdx
@@ -7,8 +7,8 @@
 | metadata | string | arbitrary user-defined machine-readable data of this TLS certificate. optional, max 4096 bytes. |
 | certificate_pem | string | chain of PEM-encoded certificates, leaf first. See [Certificate Bundles](https://ngrok.com/docs/cloud-edge/endpoints#certificate-chains). |
 | subject_common_name | string | subject common name from the leaf of this TLS certificate |
-| dns_names | List&lt;string&gt; | set of additional domains (including wildcards) this TLS certificate is valid for |
-| ips | List&lt;string&gt; | set of IP addresses this TLS certificate is also valid for |
+| subject_alternative_names.dns_names | List&lt;string&gt; | set of additional domains (including wildcards) this TLS certificate is valid for |
+| subject_alternative_names.ips | List&lt;string&gt; | set of IP addresses this TLS certificate is also valid for |
 | issued_at | string | timestamp (in RFC 3339 format) when this TLS certificate was issued automatically, or null if this certificate was user-uploaded |
 | not_before | string | timestamp when this TLS certificate becomes valid, RFC 3339 format |
 | not_after | string | timestamp when this TLS certificate becomes invalid, RFC 3339 format |

--- a/snippets/obs/_tls-edge-create.mdx
+++ b/snippets/obs/_tls-edge-create.mdx
@@ -3,14 +3,14 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tls-edge-list.mdx
+++ b/snippets/obs/_tls-edge-list.mdx
@@ -1,24 +1,24 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier of this edge |
-| description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
-| metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
-| created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
-| uri | string | URI of the edge API resource |
-| hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| tls_edges.id | string | unique identifier of this edge |
+| tls_edges.description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
+| tls_edges.metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
+| tls_edges.created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
+| tls_edges.uri | string | URI of the edge API resource |
+| tls_edges.hostports | List&lt;string&gt; | hostports served by this edge |
+| tls_edges.backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_edges.backend.backend.id | string | a resource identifier |
+| tls_edges.backend.backend.uri | string | a uri for locating a resource |
+| tls_edges.ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_edges.ip_restriction.ip_policies.id | string | a resource identifier |
+| tls_edges.ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| tls_edges.mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_edges.mutual_tls.certificate_authorities.id | string | a resource identifier |
+| tls_edges.mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| tls_edges.tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_edges.tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_edges.tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| tls_edges.traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_edges.traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |
 | uri | string | URI of the TLS Edge list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tls-edge-update.mdx
+++ b/snippets/obs/_tls-edge-update.mdx
@@ -4,14 +4,14 @@
 | description | string | human-readable description of what this edge will be used for; optional, max 255 bytes. |
 | metadata | string | arbitrary user-defined machine-readable data of this edge. Optional, max 4096 bytes. |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| backend_id | string | backend to be used to back this endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend_id | string | backend to be used to back this endpoint |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policy_ids | List&lt;string&gt; | list of all IP policies that will be used to check if a source IP is allowed access to the endpoint |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authority_ids | List&lt;string&gt; | list of certificate authorities that will be used to validate the TLS client certificate presented by the initiator of the TLS connection |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tls-edge.mdx
+++ b/snippets/obs/_tls-edge.mdx
@@ -6,17 +6,17 @@
 | created_at | string | timestamp when the edge configuration was created, RFC 3339 format |
 | uri | string | URI of the edge API resource |
 | hostports | List&lt;string&gt; | hostports served by this edge |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
-| min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
-| enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
-| value | string | the traffic policy that should be applied to the traffic on your endpoint. |
+| backend.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| backend.backend.id | string | a resource identifier |
+| backend.backend.uri | string | a uri for locating a resource |
+| ip_restriction.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| ip_restriction.ip_policies.id | string | a resource identifier |
+| ip_restriction.ip_policies.uri | string | a uri for locating a resource |
+| mutual_tls.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| mutual_tls.certificate_authorities.id | string | a resource identifier |
+| mutual_tls.certificate_authorities.uri | string | a uri for locating a resource |
+| tls_termination.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| tls_termination.terminate_at | string | `edge` if the ngrok edge should terminate TLS traffic, `upstream` if TLS traffic should be passed through to the upstream ngrok agent / application server for termination. if `upstream` is chosen, most other modules will be disallowed because they rely on the ngrok edge being able to access the underlying traffic. |
+| tls_termination.min_version | string | The minimum TLS version used for termination and advertised to the client during the TLS handshake. if unspecified, ngrok will choose an industry-safe default. This value must be null if `terminate_at` is set to `upstream`. |
+| traffic_policy.enabled | boolean | `true` if the module will be applied to traffic, `false` to disable. default `true` if unspecified |
+| traffic_policy.value | string | the traffic policy that should be applied to the traffic on your endpoint. |

--- a/snippets/obs/_tunnel-group-backend-list.mdx
+++ b/snippets/obs/_tunnel-group-backend-list.mdx
@@ -1,12 +1,12 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this TunnelGroup backend |
-| uri | string | URI of the TunnelGroupBackend API resource |
-| created_at | string | timestamp when the backend was created, RFC 3339 format |
-| description | string | human-readable description of this backend. Optional |
-| metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
-| labels | Map&lt;string, string&gt; | labels to watch for tunnels on, e.g. app->foo, dc->bar |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| backends.id | string | unique identifier for this TunnelGroup backend |
+| backends.uri | string | URI of the TunnelGroupBackend API resource |
+| backends.created_at | string | timestamp when the backend was created, RFC 3339 format |
+| backends.description | string | human-readable description of this backend. Optional |
+| backends.metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
+| backends.labels | Map&lt;string, string&gt; | labels to watch for tunnels on, e.g. app->foo, dc->bar |
+| backends.tunnels.id | string | a resource identifier |
+| backends.tunnels.uri | string | a uri for locating a resource |
 | uri | string | URI of the TunnelGroup backends list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tunnel-group-backend.mdx
+++ b/snippets/obs/_tunnel-group-backend.mdx
@@ -6,5 +6,5 @@
 | description | string | human-readable description of this backend. Optional |
 | metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
 | labels | Map&lt;string, string&gt; | labels to watch for tunnels on, e.g. app->foo, dc->bar |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| tunnels.id | string | a resource identifier |
+| tunnels.uri | string | a uri for locating a resource |

--- a/snippets/obs/_tunnel-list.mdx
+++ b/snippets/obs/_tunnel-list.mdx
@@ -1,18 +1,18 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique tunnel resource identifier |
-| public_url | string | URL of the ephemeral tunnel's public endpoint |
-| started_at | string | timestamp when the tunnel was initiated in RFC 3339 format |
-| metadata | string | user-supplied metadata for the tunnel defined in the ngrok configuration file. See the tunnel [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#common-tunnel-configuration-properties) In API version 0, this value was instead pulled from the top-level [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#metadata). |
-| proto | string | tunnel protocol for ephemeral tunnels. one of `http`, `https`, `tcp` or `tls` |
-| region | string | identifier of tune region where the tunnel is running |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| labels | Map&lt;string, string&gt; | the labels the tunnel group backends will match against, if this is a backend tunnel |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| forwards_to | string | upstream address the ngrok agent forwards traffic over this tunnel to. this may be expressed as a URL or a network address. |
+| tunnels.id | string | unique tunnel resource identifier |
+| tunnels.public_url | string | URL of the ephemeral tunnel's public endpoint |
+| tunnels.started_at | string | timestamp when the tunnel was initiated in RFC 3339 format |
+| tunnels.metadata | string | user-supplied metadata for the tunnel defined in the ngrok configuration file. See the tunnel [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#common-tunnel-configuration-properties) In API version 0, this value was instead pulled from the top-level [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#metadata). |
+| tunnels.proto | string | tunnel protocol for ephemeral tunnels. one of `http`, `https`, `tcp` or `tls` |
+| tunnels.region | string | identifier of tune region where the tunnel is running |
+| tunnels.tunnel_session.id | string | a resource identifier |
+| tunnels.tunnel_session.uri | string | a uri for locating a resource |
+| tunnels.endpoint.id | string | a resource identifier |
+| tunnels.endpoint.uri | string | a uri for locating a resource |
+| tunnels.labels | Map&lt;string, string&gt; | the labels the tunnel group backends will match against, if this is a backend tunnel |
+| tunnels.backends.id | string | a resource identifier |
+| tunnels.backends.uri | string | a uri for locating a resource |
+| tunnels.forwards_to | string | upstream address the ngrok agent forwards traffic over this tunnel to. this may be expressed as a URL or a network address. |
 | uri | string | URI of the tunnels list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tunnel-session-list.mdx
+++ b/snippets/obs/_tunnel-session-list.mdx
@@ -1,15 +1,15 @@
 | Name | Type | Description |
 |---|---|---|
-| agent_version | string | version of the ngrok agent that started this ngrok tunnel session |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | unique tunnel session resource identifier |
-| ip | string | source ip address of the tunnel session |
-| metadata | string | arbitrary user-defined data specified in the metadata property in the ngrok configuration file. See the metadata configuration option |
-| os | string | operating system of the host the ngrok agent is running on |
-| region | string | the ngrok region identifier in which this tunnel session was started |
-| started_at | string | time when the tunnel session first connected to the ngrok servers |
-| transport | string | the transport protocol used to start the tunnel session. Either `ngrok/v2` or `ssh` |
-| uri | string | URI to the API resource of the tunnel session |
+| tunnel_sessions.agent_version | string | version of the ngrok agent that started this ngrok tunnel session |
+| tunnel_sessions.credential.id | string | a resource identifier |
+| tunnel_sessions.credential.uri | string | a uri for locating a resource |
+| tunnel_sessions.id | string | unique tunnel session resource identifier |
+| tunnel_sessions.ip | string | source ip address of the tunnel session |
+| tunnel_sessions.metadata | string | arbitrary user-defined data specified in the metadata property in the ngrok configuration file. See the metadata configuration option |
+| tunnel_sessions.os | string | operating system of the host the ngrok agent is running on |
+| tunnel_sessions.region | string | the ngrok region identifier in which this tunnel session was started |
+| tunnel_sessions.started_at | string | time when the tunnel session first connected to the ngrok servers |
+| tunnel_sessions.transport | string | the transport protocol used to start the tunnel session. Either `ngrok/v2` or `ssh` |
+| tunnel_sessions.uri | string | URI to the API resource of the tunnel session |
 | uri | string | URI to the API resource of the tunnel session list |
 | next_page_uri | string | URI of the next page, or null if there is no next page |

--- a/snippets/obs/_tunnel-session-user-agent.mdx
+++ b/snippets/obs/_tunnel-session-user-agent.mdx
@@ -1,5 +1,5 @@
 | Name | Type | Description |
 |---|---|---|
-| name | string | The product name |
-| version | string | The product version |
-| comment | string | An optional comment |
+| products.name | string | The product name |
+| products.version | string | The product version |
+| products.comment | string | An optional comment |

--- a/snippets/obs/_tunnel-session.mdx
+++ b/snippets/obs/_tunnel-session.mdx
@@ -1,8 +1,8 @@
 | Name | Type | Description |
 |---|---|---|
 | agent_version | string | version of the ngrok agent that started this ngrok tunnel session |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| credential.id | string | a resource identifier |
+| credential.uri | string | a uri for locating a resource |
 | id | string | unique tunnel session resource identifier |
 | ip | string | source ip address of the tunnel session |
 | metadata | string | arbitrary user-defined data specified in the metadata property in the ngrok configuration file. See the metadata configuration option |

--- a/snippets/obs/_tunnel.mdx
+++ b/snippets/obs/_tunnel.mdx
@@ -6,11 +6,11 @@
 | metadata | string | user-supplied metadata for the tunnel defined in the ngrok configuration file. See the tunnel [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#common-tunnel-configuration-properties) In API version 0, this value was instead pulled from the top-level [metadata configuration option](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config#metadata). |
 | proto | string | tunnel protocol for ephemeral tunnels. one of `http`, `https`, `tcp` or `tls` |
 | region | string | identifier of tune region where the tunnel is running |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| tunnel_session.id | string | a resource identifier |
+| tunnel_session.uri | string | a uri for locating a resource |
+| endpoint.id | string | a resource identifier |
+| endpoint.uri | string | a uri for locating a resource |
 | labels | Map&lt;string, string&gt; | the labels the tunnel group backends will match against, if this is a backend tunnel |
-| id | string | a resource identifier |
-| uri | string | a uri for locating a resource |
+| backends.id | string | a resource identifier |
+| backends.uri | string | a uri for locating a resource |
 | forwards_to | string | upstream address the ngrok agent forwards traffic over this tunnel to. this may be expressed as a URL or a network address. |

--- a/snippets/obs/_vault-list.mdx
+++ b/snippets/obs/_vault-list.mdx
@@ -1,13 +1,13 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | identifier for Vault |
-| uri | string | URI of this Vault API resource |
-| created_at | string | Timestamp when the Vault was created (RFC 3339 format) |
-| updated_at | string | Timestamp when the Vault was last updated (RFC 3339 format) |
-| name | string | Name of vault |
-| description | string | description of Vault |
-| metadata | string | Arbitrary user-defined metadata for this Vault |
-| created_by | string | Reference to who created this Vault |
-| last_updated_by | string | Reference to who created this Vault |
+| vaults.id | string | identifier for Vault |
+| vaults.uri | string | URI of this Vault API resource |
+| vaults.created_at | string | Timestamp when the Vault was created (RFC 3339 format) |
+| vaults.updated_at | string | Timestamp when the Vault was last updated (RFC 3339 format) |
+| vaults.name | string | Name of vault |
+| vaults.description | string | description of Vault |
+| vaults.metadata | string | Arbitrary user-defined metadata for this Vault |
+| vaults.created_by | string | Reference to who created this Vault |
+| vaults.last_updated_by | string | Reference to who created this Vault |
 | uri | string |  |
 | next_page_uri | string | URI of the next page of results, or null if there is no next page |

--- a/snippets/obs/_weighted-backend-list.mdx
+++ b/snippets/obs/_weighted-backend-list.mdx
@@ -1,10 +1,10 @@
 | Name | Type | Description |
 |---|---|---|
-| id | string | unique identifier for this Weighted backend |
-| uri | string | URI of the WeightedBackend API resource |
-| created_at | string | timestamp when the backend was created, RFC 3339 format |
-| description | string | human-readable description of this backend. Optional |
-| metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
-| backends | Map&lt;string, int64&gt; | the ids of the child backends to their weights [0-10000] |
+| backends.id | string | unique identifier for this Weighted backend |
+| backends.uri | string | URI of the WeightedBackend API resource |
+| backends.created_at | string | timestamp when the backend was created, RFC 3339 format |
+| backends.description | string | human-readable description of this backend. Optional |
+| backends.metadata | string | arbitrary user-defined machine-readable data of this backend. Optional |
+| backends.backends | Map&lt;string, int64&gt; | the ids of the child backends to their weights [0-10000] |
 | uri | string | URI of the Weighted backends list API resource |
 | next_page_uri | string | URI of the next page, or null if there is no next page |


### PR DESCRIPTION
- Fixes generated event logs docs.

In prod, we have what appear to be repeated fields:
<img width="1790" height="1242" alt="image" src="https://github.com/user-attachments/assets/138e6915-15ae-40b0-bb6c-3cf55d1da72c" />

They're actually different fields with different parent objects. For example, the two `id` fields in the image above are actually `session.id` and `credential.id`.

These generated docs fix that:

<img width="1770" height="900" alt="image" src="https://github.com/user-attachments/assets/87400e1f-8936-4c26-a149-e4371a80ce41" />

- Updates our `is-nav-updated` script to ignore the "errors" directory, since those files don't go in the sidebar


