### PR TITLE
Remove tunnels from API docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -931,13 +931,6 @@
                     ]
                   },
                   {
-                    "group": "Tunnels",
-                    "pages": [
-                      "api-reference/tunnels/list",
-                      "api-reference/tunnels/get"
-                    ]
-                  },
-                  {
                     "group": "Tunnel Sessions",
                     "pages": [
                       "api-reference/tunnelsessions/list",


### PR DESCRIPTION
It's duplicated currently in `docs.json`, one under "Deprecated" and one under "Secure Tunnels".

"Tunnels" is deprecated, so I'm deleting it form "Secure Tunnels" in this PR