### PR TITLE
Fix floating items in the Guides sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -544,17 +544,14 @@
                 ]
               },
               {
-                "group": "Identity Aware Proxy",
-                "pages": [
-                  "guides/identity-aware-proxy/securing-with-oauth"
-                ]
-              },
-              {
                 "group": "Security Best Practices",
                 "pages": [
                   "guides/security-dev-productivity/index",
                   "guides/security-dev-productivity/securing-your-tunnels",
-                  "guides/security-dev-productivity/hipaa-compliance"
+                  "guides/security-dev-productivity/hipaa-compliance",
+                  "guides/identity-aware-proxy/securing-with-oauth",
+                  "guides/ssh-rdp/index",
+                  "guides/running-behind-firewalls"
                 ]
               },
               {
@@ -564,8 +561,6 @@
                   "guides/site-to-site-connectivity/end-customers"
                 ]
               },
-              "guides/running-behind-firewalls",
-              "guides/ssh-rdp/index",
               {
                 "group": "Using ngrok with",
                 "pages": [


### PR DESCRIPTION
- We have two floating items in the guides sidebar
- "Identity Aware Proxy" is a category with one item. Seems better to just slip that into security, since that doc is related to using oauth for security

<img width="610" height="1130" alt="image" src="https://github.com/user-attachments/assets/1dec8508-ebd9-41c6-b76c-31ae42c05c99" />
