### PR TITLE
Mark tunnels as deprecated in CLI reference

### DIFF
--- a/agent/cli.mdx
+++ b/agent/cli.mdx
@@ -690,7 +690,7 @@ ngrok tls --url=t.co --crt=/path/to/t.co.crt --key=/path/to/t.co.key 443
 <Tip>
 The `tunnel` command has been deprecated. Please use `http`, `tcp`, or `tls` instead.
 
-For migration help, please see [Migrating ngrok Edges to Cloud Endpoints → Tunnel Group Backends](/guides/migration/edges-to-endpoints#tunnel-group-backends)
+For help migrating, please see [Migrating ngrok Edges to Cloud Endpoints → Tunnel Group Backends](/guides/migration/edges-to-endpoints#tunnel-group-backends)
 </Tip>
 
 Starts a tunnel with labels so that it can be part of a tunnel-group.


### PR DESCRIPTION
Updates the agent CLI reference to capture that `tunnel` is now deprecated. This `<Tip>` steers users towards the best available migration guide