### PR TITLE
Fix typo and clean up language a little

### DIFF
--- a/universal-gateway/cloud-endpoints/index.mdx
+++ b/universal-gateway/cloud-endpoints/index.mdx
@@ -4,12 +4,8 @@ sidebarTitle: Overview
 description: Create and manage persistent, always-on endpoints in the cloud.
 ---
 
-
-## Overview
-
 Cloud Endpoints are persistent, always-on endpoints whose creation, deletion, and configuration is managed centrally via the Dashboard or API. 
-They exist pemanently until they are explicitly deleted. 
-Cloud Endpoints do not forward their traffic to an agent by default and instead only use their attached Traffic Policy to handle connections.
+They exist permanently until they are explicitly deleted, and can be configured to filter, route, load-balance, or authenticate traffic to endpoints running on your servers or local machines. 
 
 ## Get started
 


### PR DESCRIPTION
In the cloud endpoints docs, there's a typo, and the language feels a bit weird and indirect in the intro