### PR TITLE
Add a link to the pricing docs in tp examples

### DIFF
--- a/traffic-policy/examples/index.mdx
+++ b/traffic-policy/examples/index.mdx
@@ -7,6 +7,8 @@ mode: wide
 
 import {ExampleHub} from "/snippets/ExampleHub.jsx";
 
-<p className="lg:text-lg">Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.</p>
+Whether you need an API gateway, multicloud failover, or want to integrate ngrok with your stack, these examples help you compose endpoints and Traffic Policy to orchestrate traffic for common jobs to be done and problems to be solve. Wire it up, secure it, and *ship it already*.
+
+See [the Traffic Policy pricing docs](/pricing-limits/traffic-policy-unit-pricing) for a detailed pricing breakdown.
 
 <ExampleHub parentDir="traffic-policy" />


### PR DESCRIPTION
In the dashboard, we tell users "See examples and pricing in the docs", then link them to the tp example hub. There's nothing about pricing there.

This fixes that.