### PR TITLE
Fix docker desktop video

### DIFF
--- a/using-ngrok-with/docker/desktop.mdx
+++ b/using-ngrok-with/docker/desktop.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Docker Desktop
 description: Learn how to use ngrok with Docker Desktop.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 The ngrok Docker Desktop Extension allows you to use ngrok's API Gateway cloud service to forward traffic from internet-accessible endpoint URLs to your local Docker containers.
 
 The extension provides tools to:
@@ -12,6 +14,9 @@ The extension provides tools to:
 - Apply Traffic Policy
 - Configure custom URLs and endpoint binding type
 - Enable endpoint pooling for load balancing scenarios
+
+<YouTubeEmbed videoId="v5SlQXRouPs" title="ngrok's Docker Extension" />
+
 
 ## Installation
 
@@ -24,9 +29,3 @@ Click [here](https://open.docker.com/extensions/marketplace?extensionId=ngrok/ng
 3. Optionally specify a custom URL and [traffic policy](/traffic-policy/).
 
 You now have an endpoint URL for your container that you can share.
-
-## Video demo: Using ngrok with Docker Desktop
-
-We'll demonstrate the ngrok Docker extension by walking through its core capabilities using n8n and Ollama containers as examples. You'll see how the extension integrates seamlessly into Docker Desktop's interface, automatically detecting all running containers and letting you create public URLs with a single click.
-
-<YouTubeEmbed videoId="v5SlQXRouPs" title="ngrok's Docker Extension" />


### PR DESCRIPTION
The video was not rendering on the page in prod. This fixes it (and also moves the video above the fold)