### PR TITLE
changing hobbyist HTTP request limit

### DIFF
--- a/pricing-limits/index.mdx
+++ b/pricing-limits/index.mdx
@@ -18,7 +18,7 @@ For the most complete limits and pricing information, please see the [ngrok Pric
 
 | Feature                       | Free Users                                            | Hobbyist                                              | Pay-as-You-Go                                             |
 | ----------------------------- | ----------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------- |
-| **Domains**                   | 1 dev domain                                          | 1                                                     | No limit, priced on-demand                                |
+| **Domains**                   | 1 dev domain                                          | 1 dev domain                                          | No limit, priced on-demand                                |
 | **Endpoints**                 | 3                                                     | 3                                                     | No limit, priced on-demand                                |
 | **Cloud Endpoints**           | 3                                                     | 3                                                     | No limit, priced on-demand                                |
 | **TCP Endpoints**             | 3                                                     | 3                                                     | No limit, priced on-demand                                |
@@ -28,7 +28,7 @@ For the most complete limits and pricing information, please see the [ngrok Pric
 | **TCP Connections**           | 2,000 connections                                     | 5,000 then charged against credit                     | 5,000 then charged against credit                         |
 | **TLS Connections**           | Not Available                                         | 5,000 then charged against credit                     | 5,000 then charged against credit                         |
 | **Data Transfer Out**         | 1 GB                                                  | 5GB then charged against credit                       | 5 GB then charged against credit                          |
-| **Request Rate limit HTTP**   | 120 per min                                           | 360 per min                                           | 1200 per min. Contact ngrok to increase.                     |
+| **Request Rate limit HTTP**   | 120 per min                                           | 600 per min                                           | 1200 per min. Contact ngrok to increase.                     |
 | **TCP Connection Rate Limit** | 100 per min                                           | 150 per min                                           | 600 per min. Contact ngrok to increase.                      |
 | **Traffic Policy Actions**    | Charged against credit                                | Charged against credit                                | Charged against credit                                    |
 | **Concurrent Tunnels**        | 3                                                     | 3                                                     | No limit (Note that this counts towards active endpoints) |


### PR DESCRIPTION
in corp, limit is set to 600, this also needs to be reflected on our pricing page. 