### PR TITLE
Use --traffic-policy-url for SSH reverse tunnel docs

### DIFF
--- a/snippets/examples/ssh/http-oauth-authn.mdx
+++ b/snippets/examples/ssh/http-oauth-authn.mdx
@@ -1,6 +1,6 @@
 When creating a reverse tunnel, you must provide a publicly accessible URL to your traffic policy file, as shown in this example.
 
-Create the `oauth-policy.yml` file:
+First, create the `oauth-policy.yml` file:
 
 ```yaml
 on_http_request:
@@ -10,9 +10,9 @@ on_http_request:
           provider: google
 ```
 
-Store this file at a publicly accessible address online.
+Store this file at a publicly accessible address online. For example, you could add it to a github repository.
 
-Add it with the `--traffic-policy-url` flag.
+Finally, add your traffic policy to your reverse tunnel using the `--traffic-policy-url` flag.
 
 ```bash
 ssh -R 443:localhost:80 v2@connect.ngrok-agent.com http --traffic-policy-url=https://some-website/oauth-policy.yml


### PR DESCRIPTION
In https://ngrok.com/docs/agent/ssh-reverse-tunnel-agent#oauth we recommend using --traffic-policy-file which won't work with the reverse tunnel.

This PR:
- recommends --traffic-policy-url
- directs readers to host the traffic policy file somewhere publicly accessible