### PR TITLE
Change 'Provider priority' to 'Provider order'

### DIFF
--- a/ai-gateway/examples/multi-provider-failover.mdx
+++ b/ai-gateway/examples/multi-provider-failover.mdx
@@ -61,7 +61,7 @@ providers:
 
 ## Provider order
 
-Providers are  tried in alphabetical order, not the order they are configured.
+Providers are tried in alphabetical order, not the order they are configured.
 
 ## Combining multi-key and multi-provider
 


### PR DESCRIPTION
Updated the section to clarify that providers are tried in alphabetical order instead of the configured order.