### PR TITLE
Break up the "Using ngrok with" section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -558,14 +558,14 @@
                 "pages": [
                   "agent/ssh-reverse-tunnel-agent",
                   "agent/connect-url",
-              {
-                "group": "Docker",
-                "pages": [
-                  "using-ngrok-with/docker/index",
-                  "using-ngrok-with/docker/compose",
-                  "using-ngrok-with/docker/desktop"
-                ]
-              }
+                  {
+                    "group": "Docker",
+                    "pages": [
+                      "using-ngrok-with/docker/index",
+                      "using-ngrok-with/docker/compose",
+                      "using-ngrok-with/docker/desktop"
+                    ]
+                  }
                 ]
               },
               {
@@ -660,53 +660,6 @@
               "guides/site-to-site-connectivity/index",
               "guides/site-to-site-connectivity/end-customers"
             ]
-          },
-          {
-            "item": "Using ngrok with",
-            "pages": [
-              {
-                "group": "Frameworks",
-                "pages": [
-                  "using-ngrok-with/fastAPI",
-                  "using-ngrok-with/flask",
-                  "using-ngrok-with/laravel"
-                ]
-              },
-              {
-                "group": "Protocols",
-                "pages": [
-                  "using-ngrok-with/ssh",
-                  "using-ngrok-with/ftp",
-                  "using-ngrok-with/websockets",
-                  "using-ngrok-with/rtmp"
-                ]
-              },
-              {
-                "group": "Web Servers",
-                "pages": [
-                  "using-ngrok-with/smtp",
-                  "using-ngrok-with/nginx",
-                  "using-ngrok-with/outboundProxy",
-                  "using-ngrok-with/virtualHosts",
-                  "using-ngrok-with/gRPC"
-                ]
-              },
-              {
-                "group": "Other",
-                "pages": [
-                  "using-ngrok-with/cgnat",
-                  "using-ngrok-with/using-mcp",
-                  "using-ngrok-with/godaddy",
-                  "using-ngrok-with/googleColab",
-                  "using-ngrok-with/java",
-                  "using-ngrok-with/minecraft",
-                  "using-ngrok-with/openvpn",
-                  "using-ngrok-with/puppet",
-                  "using-ngrok-with/visualStudio",
-                  "using-ngrok-with/vsCode"
-                ]
-              }
-            ]
           }
         ]
       },
@@ -718,7 +671,17 @@
             "group": "General Guides",
             "pages": [
               "integrations/guides/home-assistant-with-ngrok",
-              "integrations/guides/mqtt"
+              "integrations/guides/mqtt",
+              "using-ngrok-with/cgnat",
+              "using-ngrok-with/using-mcp",
+              "using-ngrok-with/godaddy",
+              "using-ngrok-with/googleColab",
+              "using-ngrok-with/java",
+              "using-ngrok-with/minecraft",
+              "using-ngrok-with/openvpn",
+              "using-ngrok-with/puppet",
+              "using-ngrok-with/visualStudio",
+              "using-ngrok-with/vsCode"
             ]
           },
           {
@@ -778,6 +741,14 @@
             ]
           },
           {
+            "group": "Frameworks",
+            "pages": [
+              "using-ngrok-with/fastAPI",
+              "using-ngrok-with/flask",
+              "using-ngrok-with/laravel"
+            ]
+          },
+          {
             "group": "JWT Validation",
             "pages": [
               "integrations/jwt-validation/auth0"
@@ -814,6 +785,15 @@
               "integrations/oauth/microsoft-oauth",
               "integrations/oauth/oauth",
               "integrations/oauth/twitch-oauth"
+            ]
+          },
+          {
+            "group": "Protocols",
+            "pages": [
+              "using-ngrok-with/ssh",
+              "using-ngrok-with/ftp",
+              "using-ngrok-with/websockets",
+              "using-ngrok-with/rtmp"
             ]
           },
           {
@@ -886,6 +866,16 @@
               "integrations/webhooks/xero-webhooks",
               "integrations/webhooks/zendesk-webhooks",
               "integrations/webhooks/zoom-webhooks"
+            ]
+          },
+          {
+            "group": "Web Servers",
+            "pages": [
+              "using-ngrok-with/smtp",
+              "using-ngrok-with/nginx",
+              "using-ngrok-with/outboundProxy",
+              "using-ngrok-with/virtualHosts",
+              "using-ngrok-with/gRPC"
             ]
           }
         ]


### PR DESCRIPTION
This PR breaks up the "Using ngrok with" section at the request of @nijikokun. The guides are put under Integrations. The Docker guides are the one exception. They go under Secure Tunnels

- [Preview](https://ngrok-shaquil-doc-505-break-up-guides.mintlify.app/integrations)
