### PR TITLE
Tiny JSON fix (extra quote mark)

### DIFF
--- a/universal-gateway/region-pinning.mdx
+++ b/universal-gateway/region-pinning.mdx
@@ -183,7 +183,7 @@ You can include both, as shown in the example below.
 ```json
 {
   "ips": [
-    { "value": "us-ohio-1"" },
+    { "value": "us-ohio-1" },
     { "value": "203.0.113.10" }
   ]
 }


### PR DESCRIPTION
Removed extra quotation mark " that was breaking syntax highlighting in this code sample.