### PR TITLE
Fix Yaml Indentation P2

### DIFF
--- a/k8s/installation/observability.mdx
+++ b/k8s/installation/observability.mdx
@@ -57,7 +57,7 @@ The log level can be configured through Helm value overrides, allowing you to de
 
 To override the log level, specify the configuration in your `values.yaml` file and pass the file to `helm` using the `--values` option ([more info](https://helm.sh/docs/helm/helm_install/#options)).
 
-```yml
+```yaml
 log:
   level: debug
   format: json

--- a/traffic-policy/actions/redirect.mdx
+++ b/traffic-policy/actions/redirect.mdx
@@ -117,7 +117,7 @@ on_http_request:
     actions:
       - type: redirect
         config:
-		  from: /api/v1/
+      from: /api/v1/
           to: /api/v2/
 ```
 

--- a/traffic-policy/concepts/ip-policies.mdx
+++ b/traffic-policy/concepts/ip-policies.mdx
@@ -17,32 +17,32 @@ The contents of the policy file should be the following:
 <CodeGroup>
 ```yaml policy.yml
 on_http_request:
-	# Only allow requests from trusted IPs
-	- actions:
-			- type: restrict-ips
-				config:
-					allow:
-						- 203.0.113.0/24
-						- 198.51.100.42/32
+  # Only allow requests from trusted IPs
+  - actions:
+      - type: restrict-ips
+        config:
+          allow:
+            - 203.0.113.0/24
+            - 198.51.100.42/32
 ```
 
 ```json policy.json
 {
-	"on_http_request": [
-		{
-			"actions": [
-				{
-					"type": "restrict-ips",
-					"config": {
-						"allow": [
-							"203.0.113.0/24",
-							"198.51.100.42/32"
-						]
-					}
-				}
-			]
-		}
-	]
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "restrict-ips",
+          "config": {
+            "allow": [
+              "203.0.113.0/24",
+              "198.51.100.42/32"
+            ]
+          }
+        }
+      ]
+    }
+  ]
 }
 ```
 </CodeGroup>

--- a/universal-gateway/examples/multiplex.mdx
+++ b/universal-gateway/examples/multiplex.mdx
@@ -51,57 +51,57 @@ While still viewing your new Cloud Endpoint in the dashboard, copy one of the th
 The choice depends on whether you want to route by hostname/subdomain, header value, or with global variables that are accessed at runtime.
 
 <Tabs>
-	<Tab title="By subdomain">
-		```yaml
-		on_http_request:
-			- actions:
+  <Tab title="By subdomain">
+    ```yaml
+    on_http_request:
+      - actions:
           - type: forward-internal
-						config:
-							url: https://${req.host.split(".$NGROK_DOMAIN")[0]}.internal 
-		```
+            config:
+              url: https://${req.host.split(".$NGROK_DOMAIN")[0]}.internal 
+    ```
 
-    	**What's happening here?**
-    	This policy forwards every HTTP request to one of your internal Agent Endpoints, which in turn forward traffic to your internal services.
-    	The [`split` macro](/traffic-policy/macros/#stringsplit---list) dynamically routes traffic based on the incoming hostname so that the policy forwards requests to the `foo` subdomain to `https://foo.internal`, and so on.
+      **What's happening here?**
+      This policy forwards every HTTP request to one of your internal Agent Endpoints, which in turn forward traffic to your internal services.
+      The [`split` macro](/traffic-policy/macros/#stringsplit---list) dynamically routes traffic based on the incoming hostname so that the policy forwards requests to the `foo` subdomain to `https://foo.internal`, and so on.
     </Tab>
     <Tab title="By header">
-    	```yaml
-    	on_http_request:
-    	  - actions:
-    				- type: forward-internal
-    					config:
-    						url: https://${getReqHeader('x-service')[0]}.internal
-    	```
+      ```yaml
+      on_http_request:
+        - actions:
+            - type: forward-internal
+              config:
+                url: https://${getReqHeader('x-service')[0]}.internal
+      ```
 
-    	**What's happening here?**
-    	This policy forwards every HTTP request to one of your internal Agent Endpoints, which in turn forward traffic to your internal services.
-    	The [`split` macro](/traffic-policy/macros/#stringsplit---list) dynamically routes traffic based on the `x-service` header so that the policy forwards requests with the `x-service: foo` header to `https://foo.internal`, and so on.
+      **What's happening here?**
+      This policy forwards every HTTP request to one of your internal Agent Endpoints, which in turn forward traffic to your internal services.
+      The [`split` macro](/traffic-policy/macros/#stringsplit---list) dynamically routes traffic based on the `x-service` header so that the policy forwards requests with the `x-service: foo` header to `https://foo.internal`, and so on.
     </Tab>
     <Tab title="By allowed subdomains">
-    	```yaml
-    	on_http_request:
-    		- actions:
-    				- type: set-vars
-    					config:
-    						allowed_subdomains:
-    							- user3
-    							- user2
-    							- user1
-    						subdomain: ${getReqHeader('host')[0].split('.', 1)[0]}
-    		- expressions:
-    				- "!(vars.subdomain in vars.allowed_subdomains)"
-    			actions:
-    				- type: custom-response
-    					config:
-    						body: 'Denied.'
-    		- actions:
-    				- type: forward-internal
-    					config:
-    						url: 'http://${vars.subdomain}.internal'
-    	```
-    	**What's happening here?**
-    	This policy first sets a variable `allowed_subdomains` to a list of subdomains that are allowed to access the service.
-    	Then it checks if the incoming request's subdomain is in that list. If not, it returns a custom response with a `Denied` message. If the subdomain is allowed, it forwards the request to the corresponding internal Agent Endpoint.
+      ```yaml
+      on_http_request:
+        - actions:
+            - type: set-vars
+              config:
+                allowed_subdomains:
+                  - user3
+                  - user2
+                  - user1
+                subdomain: ${getReqHeader('host')[0].split('.', 1)[0]}
+        - expressions:
+            - "!(vars.subdomain in vars.allowed_subdomains)"
+          actions:
+            - type: custom-response
+              config:
+                body: 'Denied.'
+        - actions:
+            - type: forward-internal
+              config:
+                url: 'http://${vars.subdomain}.internal'
+      ```
+      **What's happening here?**
+      This policy first sets a variable `allowed_subdomains` to a list of subdomains that are allowed to access the service.
+      Then it checks if the incoming request's subdomain is in that list. If not, it returns a custom response with a `Denied` message. If the subdomain is allowed, it forwards the request to the corresponding internal Agent Endpoint.
     </Tab>
 
     </Tabs>

--- a/using-ngrok-with/using-mcp.mdx
+++ b/using-ngrok-with/using-mcp.mdx
@@ -29,7 +29,7 @@ After installing the ngrok agent, define an internal endpoint inside the ngrok c
 ```yaml
 version: 3
 agent:
-	authtoken: <your_ngrok_authtoken>
+  authtoken: <your_ngrok_authtoken>
 endpoints:
   - name: Internal Endpoint for MCP Server
     url: https://mcp.example.internal


### PR DESCRIPTION
This PR fixes yaml indentation in the rest of the snippets in our docs. Yaml needs to have spaces, not tabs. This replaces all the tabs with spaces in the yaml snippets.