### PR TITLE
Add notices to features deprecated in Agent Config v3

### DIFF
--- a/agent/api.mdx
+++ b/agent/api.mdx
@@ -54,6 +54,12 @@ Examples of non-breaking changes to the API that will not be opt-in include:
 
 ## List tunnels
 
+<Warning>
+
+This API is deprecated. Use the [list endpoints API](#list-endpoints) instead.
+
+</Warning>
+
 Returns a list of running tunnels with status and metrics information.
 
 ### Request

--- a/agent/config/v3.mdx
+++ b/agent/config/v3.mdx
@@ -38,19 +38,21 @@ tunnels:
     addr: 80
 ```
 
-For v3, you need to update the `version` and introduce the `agent` field:
+For v3, you need to update the `version`, introduce the `agent` field,
+and convert from `tunnels` to `endpoints`:
 
-```yaml {1,3-5}
+```yaml
 version: 3
 
 agent:
   authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
   api_key: 24yRd5U3DestCQapJrrVHLOqiAC_7RviwRqpd3wc9dKLujQZN
 
-tunnels:
-  basic:
-    proto: http
-    addr: 80
+endpoints:
+  - name: http
+    url: http://demo.ngrok.app
+    upstream:
+      url: 80
 ```
 
 You will also need to adjust the following fields if you are using them:


### PR DESCRIPTION
Also updated the configuration migration example to demonstrate the new `endpoints` field.

Part of AGENT-196