### PR TITLE
Update Request Rate Limit HTTP details on Pricing and Limits page

### DIFF
--- a/pricing-limits/index.mdx
+++ b/pricing-limits/index.mdx
@@ -27,7 +27,7 @@ For the most complete limits and pricing information, please see the [ngrok Pric
 | **TCP Connections**           | 2,000 connections                                     | 5,000 then charged against credit                     | 5,000 then charged against credit                         |
 | **TLS Connections**           | Not Available                                         | 5,000 then charged against credit                     | 5,000 then charged against credit                         |
 | **Data Transfer Out**         | 1 GB                                                  | 5GB then charged against credit                       | 5 GB then charged against credit                          |
-| **Request Rate limit HTTP**   | 120 per min                                           | 600 per min                                           | 1200 per min. Contact ngrok to increase.                     |
+| **Request Rate limit HTTP**   | 4,000 per min                                         | 20,000 per min                                        | 20,000 per min. Contact ngrok to increase.         |
 | **TCP Connection Rate Limit** | 100 per min                                           | 150 per min                                           | 600 per min. Contact ngrok to increase.                      |
 | **Traffic Policy Actions**    | Charged against credit                                | Charged against credit                                | Charged against credit                                    |
 | **Concurrent Tunnels**        | 3                                                     | 3                                                     | No limit (Note that this counts towards active endpoints) |


### PR DESCRIPTION
Fixed rate limits per https://linear.app/ngrok/issue/GTM-341/http-request-limits-feel-low-raise-rate-limits-on-free-and-paid-plans