### PR TITLE
Restructure K8s sidebar IA

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .docusaurus
 .git
 .github
+.skills
 build
 dist
 node_modules

--- a/.skills/restructuring-ia/SKILL.md
+++ b/.skills/restructuring-ia/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: restructuring-ia
+description: Restructures Mintlify documentation information architecture in docs.json. Use when reorganizing sidebar navigation, improving content discoverability, or refactoring doc structure.
+---
+
+# Restructuring Information Architecture
+
+Guidelines for reorganizing Mintlify documentation navigation in `docs.json`.
+
+## Mintlify Navigation Structure
+
+Navigation is defined in `docs.json` under `navigation.tabs`. Each tab contains a `menu` with items:
+
+```json
+{
+  "tab": "Tab Name",
+  "menu": [
+    {
+      "item": "Section Name",
+      "pages": [
+        "path/to/page",
+        {
+          "group": "Group Name",
+          "pages": ["path/to/nested-page"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## IA Principles
+
+### 1. Progressive Disclosure
+- **Top level**: Overview, how it works, architecture (conceptual)
+- **Second level**: Quickstarts, installation, core concepts
+- **Third level**: Detailed guides, reference, integrations
+
+### 2. Clear Group Naming
+- Use action-oriented or noun-based names, not vague labels
+- Bad: "Manage", "Usage Guides", "Misc"
+- Good: "Installation & Management", "Traffic Policy Recipes", "Platform Integrations"
+
+### 3. Logical Grouping
+Avoid catch-all groups. Content should be grouped by:
+- **Task type**: Installation, Configuration, Troubleshooting
+- **Interface/API**: CRDs, CLI, Gateway API, Ingress
+- **Use case**: Security, Load Balancing, Routing
+
+### 4. Maximum Nesting Depth
+- Prefer 2 levels of nesting maximum
+- If content is buried 3+ levels deep, consider elevating it
+
+### 5. Placement Rules
+- Quickstarts near the top, after conceptual overview docs
+- Reference docs (API, CRDs, CLI) near the bottom
+- Integrations and platform-specific content at the end
+- Troubleshooting accessible but not prominent
+
+### 6. Avoid Root-Level Clutter
+Only these belong at the section root (before any groups):
+- Overview/Introduction
+- How It Works
+- Architecture
+- Quickstart link (if singular)
+
+Move operational content (releasing, local dev setup) into appropriate groups.
+
+## Checklist When Restructuring
+
+1. [ ] Read all pages in the section to understand content
+2. [ ] Identify content types: conceptual, tutorial, how-to, reference
+3. [ ] Check for orphaned pages not in navigation
+4. [ ] Ensure quickstarts are discoverable (near top)
+5. [ ] Ensure reference content is findable (clear group name)
+6. [ ] Verify no group has 15+ items (split if needed)
+7. [ ] Check nesting depth doesn't exceed 2-3 levels
+8. [ ] Verify page paths match actual file locations
+
+## Common Patterns
+
+### Product/Feature Section
+```
+Section
+├── Overview
+├── How It Works
+├── Architecture
+├── Quickstarts (group)
+├── Installation & Management (group)
+├── Core Concepts (group)
+├── Guides (group)
+├── Reference (group)
+└── Integrations (group)
+```
+
+### Interface-Heavy Section (like K8s Operator)
+```
+Section
+├── Overview
+├── How It Works
+├── Architecture
+├── Quickstarts (group)
+├── Installation & Management (group)
+├── Interfaces (group)
+│   ├── CRDs
+│   ├── Ingress
+│   └── Gateway API
+├── Guides (group)
+├── Task Recipes (group)  ← task-based how-tos
+├── Reference (group)
+└── Platform Integrations (group)
+```
+
+## Anti-Patterns
+
+- **Giant groups**: 20+ items in one group
+- **Vague names**: "Other", "More", "Advanced"
+- **Mixed content**: Conceptual docs mixed with how-tos in same group
+- **Buried essentials**: Troubleshooting nested 3 levels deep
+- **Duplicate paths**: Same page appearing multiple times in nav

--- a/docs.json
+++ b/docs.json
@@ -331,10 +331,6 @@
             "item": "Kubernetes Operator",
             "pages": [
               "k8s/index",
-              "k8s/how-it-works",
-              "k8s/installation/architecture",
-              "k8s/guides/local-cluster",
-              "k8s/releasing",
               {
                 "group": "Quickstarts",
                 "pages": [
@@ -345,71 +341,64 @@
                 ]
               },
               {
+                "group": "Guides",
+                "pages": [
+                  "k8s/guides/endpoint-types",
+                  "k8s/guides/bindings",
+                  "k8s/guides/pooling",
+                  "k8s/guides/custom-domain",
+                  {
+                    "group": "Traffic Policy",
+                    "pages": [
+                      "k8s/guides/how-to/basic-auth",
+                      "k8s/guides/how-to/circuit-breaking",
+                      "k8s/guides/how-to/compress-response",
+                      "k8s/guides/how-to/deny-requests",
+                      "k8s/guides/how-to/jwt-validation",
+                      "k8s/guides/how-to/manipulate-headers",
+                      "k8s/guides/how-to/oauth",
+                      "k8s/guides/how-to/oidc",
+                      "k8s/guides/how-to/rate-limiting",
+                      "k8s/guides/how-to/redirects",
+                      "k8s/guides/how-to/restrict-ips",
+                      "k8s/guides/how-to/request-routing",
+                      "k8s/guides/how-to/rewrite-url",
+                      "k8s/guides/how-to/static-response",
+                      "k8s/guides/how-to/tcp-routing",
+                      "k8s/guides/how-to/tls-routing",
+                      "k8s/guides/how-to/terminate-tls",
+                      "k8s/guides/how-to/upstream-tls"
+                    ]
+                  },
+                  "k8s/guides/customer-networks",
+                  {
+                    "group": "Running a Local Cluster",
+                    "pages": [
+                      "k8s/guides/local-cluster",
+                      "k8s/guides/local-projection"
+                    ]
+                  },
+                  {
+                    "group": "Load Balancing",
+                    "pages": [
+                      "k8s/load-balancing/load-balancing-kubernetes",
+                      "k8s/load-balancing/load-balancing-kubernetes-clusters",
+                      "k8s/guides/using-loadbalancers",
+                      "k8s/do-redirect"
+                    ]
+                  }
+                ]
+              },
+              {
                 "group": "Manage",
                 "pages": [
                   "k8s/installation/update",
                   "k8s/installation/helm",
                   "k8s/installation/observability",
+                  "k8s/guides/troubleshooting",
                   "k8s/installation/uninstall"
                 ]
-              },
-              {
-                "group": "Load Balancing",
-                "pages": [
-                  "k8s/load-balancing/load-balancing-kubernetes",
-                  "k8s/load-balancing/load-balancing-kubernetes-clusters",
-                  "k8s/guides/using-loadbalancers"
-                ]
-              },
-              {
-                "group": "Usage Guides",
-                "pages": [
-                  "k8s/guides/using-crds",
-                  "k8s/guides/endpoint-types",
-                  "k8s/guides/bindings",
-                  "k8s/guides/pooling",
-                  "k8s/guides/custom-domain",
-                  "k8s/guides/customer-networks",
-                  "k8s/guides/local-projection",
-                  "k8s/guides/using-gwapi",
-                  "k8s/guides/using-ingresses",
-                  "k8s/guides/annotations",
-                  "k8s/guides/managed-resources",
-                  "k8s/guides/finalizers",
-                  "k8s/guides/troubleshooting",
-                  "k8s/guides/how-to/request-routing",
-                  "k8s/guides/how-to/tls-routing",
-                  "k8s/guides/how-to/tcp-routing",
-                  "k8s/guides/how-to/manipulate-headers",
-                  "k8s/guides/how-to/redirects",
-                  "k8s/guides/how-to/rewrite-url",
-                  "k8s/guides/how-to/static-response",
-                  "k8s/guides/how-to/terminate-tls",
-                  "k8s/guides/how-to/upstream-tls",
-                  "k8s/guides/how-to/rate-limiting",
-                  "k8s/guides/how-to/deny-requests",
-                  "k8s/guides/how-to/basic-auth",
-                  "k8s/guides/how-to/oauth",
-                  "k8s/guides/how-to/oidc",
-                  "k8s/guides/how-to/jwt-validation",
-                  "k8s/guides/how-to/restrict-ips",
-                  "k8s/guides/how-to/circuit-breaking",
-                  "k8s/guides/how-to/compress-response"
-                ]
-              },
-              {
-                "group": "Custom Resources",
-                "pages": [
-                  "k8s/crds/index",
-                  "k8s/crds/agentendpoint",
-                  "k8s/crds/cloudendpoint",
-                  "k8s/crds/ngroktrafficpolicy",
-                  "k8s/crds/boundendpoint",
-                  "k8s/crds/domain",
-                  "k8s/crds/kubernetesoperator",
-                  "k8s/crds/ippolicy"
-                ]
-              },
+              },              
               {
                 "group": "Integrations & Platforms",
                 "pages": [
@@ -434,6 +423,38 @@
                   "integrations/kubernetes-ingress/rancher-k8s",
                   "integrations/kubernetes-ingress/spectro-cloud-k8s",
                   "integrations/kubernetes-ingress/vcluster-k8s"
+                ]
+              },
+{
+                "group": "References",
+                "pages": [
+                  {
+                    "group": "How the Operator Works",
+                    "pages": [
+                      "k8s/how-it-works",
+                      "k8s/installation/architecture",
+                      "k8s/guides/using-ingresses",
+                      "k8s/guides/annotations",
+                      "k8s/guides/managed-resources",
+                      "k8s/guides/finalizers",
+                      "k8s/releasing"
+                    ]
+                  },
+                  {
+                    "group": "Custom Resources",
+                    "pages": [
+                      "k8s/crds/index",
+                      "k8s/guides/using-crds",
+                      "k8s/guides/using-gwapi",
+                      "k8s/crds/agentendpoint",
+                      "k8s/crds/cloudendpoint",
+                      "k8s/crds/ngroktrafficpolicy",
+                      "k8s/crds/boundendpoint",
+                      "k8s/crds/domain",
+                      "k8s/crds/kubernetesoperator",
+                      "k8s/crds/ippolicy"
+                    ]
+                  }
                 ]
               }
             ]
@@ -2884,6 +2905,10 @@
     {
       "source": "/traffic-policy/actions/ai-gateway",
       "destination": "/ai-gateway/overview/"
+    },
+    {
+      "source": "/k8s/do-redirect",
+      "destination": "/integrations/kubernetes-ingress/gslb"
     }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -328,7 +328,7 @@
             ]
           },
           {
-            "item": "Kubernetes",
+            "item": "Kubernetes Operator",
             "pages": [
               "k8s/index",
               "k8s/how-it-works",

--- a/k8s/do-redirect.mdx
+++ b/k8s/do-redirect.mdx
@@ -1,0 +1,6 @@
+---
+title: Digital Ocean Global Server Load Balancing 
+sidebarTitle: With Digital Ocean
+description: A page that redirects to the digital ocean load balancing docs.
+noindex: true
+---

--- a/k8s/guides/bindings.mdx
+++ b/k8s/guides/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Binding Endpoints in the ngrok Kubernetes Operator
-sidebarTitle: Bindings
+sidebarTitle: Binding Endpoints
 description: Learn about ngrok's endpoint bindings and how to use them in the ngrok Kubernetes Operator.
 ---
 

--- a/k8s/guides/custom-domain.mdx
+++ b/k8s/guides/custom-domain.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Custom White-Label Domains
-sidebarTitle: Custom Domains
+sidebarTitle: Custom White-label Domains
 description: Learn how to use custom domains with the ngrok Kubernetes Operator.
 ---
 

--- a/k8s/guides/endpoint-types.mdx
+++ b/k8s/guides/endpoint-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to create endpoints in the ngrok Kubernetes Operator
-sidebarTitle: Endpoint Types
+sidebarTitle: Creating Endpoints
 description: Learn how to create endpoints that accept `http://`, `https://`, `tcp://`, and `tls://` requests using the ngrok Kubernetes Operator.
 ---
 

--- a/k8s/guides/local-cluster.mdx
+++ b/k8s/guides/local-cluster.mdx
@@ -1,11 +1,8 @@
 ---
 title: Running a Local Kubernetes Cluster
-sidebarTitle: Local Cluster Options
+sidebarTitle: Overview
 description: Learn how to set up a local Kubernetes cluster for development and testing with the ngrok Kubernetes Operator.
 ---
-
-
-
 
 You can install the ngrok Kubernetes Operator in a locally running Kubernetes cluster rather than paying for one from a cloud provider.
 

--- a/k8s/guides/local-projection.mdx
+++ b/k8s/guides/local-projection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Projecting Local Services into Remote Clusters
-sidebarTitle: Local Projection
+sidebarTitle: Projecting Local Services
 description: Learn how to use Kubernetes bindings to instantly test local services against remote staging or production-like clusters without slow CI/CD loops.
 ---
 

--- a/k8s/guides/pooling.mdx
+++ b/k8s/guides/pooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pooling Endpoints in the ngrok Kubernetes Operator
-sidebarTitle: Pooling
+sidebarTitle: Endpoint Pooling
 description: Learn how to load balance traffic between endpoints using the ngrok Kubernetes Operator.
 ---
 

--- a/k8s/guides/using-crds.mdx
+++ b/k8s/guides/using-crds.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using ngrok Custom Resources
-sidebarTitle: Using CRDs
+sidebarTitle: Using ngrok Custom Resources
 description: Learn how to use ngrok's custom resources with the ngrok Kubernetes Operator.
 ---
 

--- a/k8s/how-it-works.mdx
+++ b/k8s/how-it-works.mdx
@@ -1,6 +1,6 @@
 ---
 title: How the ngrok Kubernetes Operator Works
-sidebarTitle: How it Works
+sidebarTitle: Overview
 description: Learn how the ngrok Kubernetes Operator uses secure outbound connections to provide public endpoints for your Kubernetes services.
 ---
 

--- a/k8s/installation/uninstall.mdx
+++ b/k8s/installation/uninstall.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to uninstall the ngrok Kubernetes Operator
-sidebarTitle: Uninstall
+sidebarTitle: Uninstalling
 description: Step-by-step guide for uninstalling the ngrok Kubernetes Operator from your Kubernetes cluster using Helm.
 ---
 

--- a/universal-gateway/custom-domains.mdx
+++ b/universal-gateway/custom-domains.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to Use A Custom Domain
+title: Using a Custom Domain with the Kubernetes Operator
 sidebarTitle: Using Custom Domains
 description: Learn how to use your own custom domain with your ngrok endpoints.
 ---


### PR DESCRIPTION
This PR restructures the K8s sidebar IA. The prod sidebar is super long and overwhelming. This is an attempt to not only shorten it, but to group things in a way that makes sense and makes it easier to find what you're looking for. It also reorders things to put more high-demand content higher up in the structure

- [Preview](https://ngrok-shaquil-doc-526-restructure-k8s-sidebar-ia.mintlify.app/k8s)