### PR TITLE
Use ipv4 address in on_tcp_connect example

### DIFF
--- a/traffic-policy/actions/restrict-ips.mdx
+++ b/traffic-policy/actions/restrict-ips.mdx
@@ -107,7 +107,7 @@ on_tcp_connect:
           allow:
             - 1.1.1.1/32
           deny:
-            - e680:5791:be4c:5739:d959:7b94:6d54:d4b4/128
+            - 110.0.0.0/8
 ```
 
 ```json policy.json
@@ -123,7 +123,7 @@ on_tcp_connect:
               "1.1.1.1/32"
             ],
             "deny": [
-              "e680:5791:be4c:5739:d959:7b94:6d54:d4b4/128"
+              "110.0.0.0/8"
             ]
           }
         }
@@ -135,7 +135,7 @@ on_tcp_connect:
 </CodeGroup>
 
 This configuration will ensure that only requests from the IP `1.1.1.1` are
-allowed, while requests from the IP `e680:5791:be4c:5739:d959:7b94:6d54:d4b4`
+allowed, while requests from the IP `110.0.0.0`
 are denied.
 
 #### Example request


### PR DESCRIPTION
The example on this page
- https://ngrok.com/docs/traffic-policy/actions/restrict-ips#examples-on-tcp-connect

uses an ipv6 address, but we don't support that for TCP connections. This PR changes the address to ipv4