### PR TITLE
Remove all TL;DR callouts

### DIFF
--- a/integrations/cli-credentials/1password.mdx
+++ b/integrations/cli-credentials/1password.mdx
@@ -4,19 +4,6 @@ sidebarTitle: 1Password
 description: Secure your ngrok CLI credentials with 1Password.
 ---
 
-<Tip>
-**TL;DR**
-
-To activate the 1Password ngrok shell plugin:
-
-1. [Sign up for 1Password](https://1password.com/sign-up/)
-1. Install and sign in to [1Password](https://support.1password.com/get-the-apps/) on your machine
-1. Install the [1Password CLI](https://app-updates.agilebits.com/product_history/CLI2) on your machine
-1. [Integrate the 1Password CLI with the 1Password desktop app](https://developer.1password.com/docs/cli/app-integration)
-1. Import your ngrok credentials into 1Password
-1. Launch ngrok
-</Tip>
-
 This guide covers how to set up the 1Password CLI with the ngrok shell extension to store and access your ngrok credentials via 1Password. This combination gives you the speed and simplicity of ngrok protected by the power of 1Password’s vault.
 
 By integrating ngrok with 1Password, you can:

--- a/integrations/event-destinations/amazon-cloudwatch-event-destination.mdx
+++ b/integrations/event-destinations/amazon-cloudwatch-event-destination.mdx
@@ -4,18 +4,6 @@ sidebarTitle: AWS CloudWatch
 description: Send network traffic logs from ngrok to AWS CloudWatch.
 ---
 
-<Tip>
-**TL;DR**
-
-
-
-To send ngrok events to CloudWatch:
-
-1. [Obtain CloudWatch log group ARN](#obtain-cloudwatch-arn)
-1. [Create Log Export](#create-log-export)
-1. [Create Event Destination](#create-destination)
-</Tip>
-
 This guide covers how to send ngrok events including network traffic logs into AWS CloudWatch.
 You may want to keep an audit log of configuration changes within your ngrok
 account, record all traffic to your endpoints for active monitoring/troubleshooting, or

--- a/integrations/event-destinations/amazon-firehose-event-destination.mdx
+++ b/integrations/event-destinations/amazon-firehose-event-destination.mdx
@@ -4,18 +4,6 @@ sidebarTitle: AWS Firehose
 description: Send network traffic logs from ngrok to AWS Firehose.
 ---
 
-<Tip>
-**TL;DR**
-
-
-
-To send ngrok events to Firehose:
-
-1. [Obtain Firehose Delivery Stream ARN](#obtain-firehose-arn)
-1. [Create Log Export](#create-log-export)
-1. [Create Event Destination](#create-destination)
-</Tip>
-
 This guide covers how to send ngrok events including network traffic logs into AWS Firehose.
 You may want to keep an audit log of configuration changes within your ngrok
 account, record all traffic to your endpoints for active monitoring/troubleshooting, or

--- a/integrations/event-destinations/amazon-kinesis-event-destination.mdx
+++ b/integrations/event-destinations/amazon-kinesis-event-destination.mdx
@@ -4,18 +4,6 @@ sidebarTitle: AWS Kinesis
 description: Send network traffic logs from ngrok to AWS Kinesis.
 ---
 
-<Tip>
-**TL;DR**
-
-
-
-To send ngrok events to Kinesis:
-
-1. [Obtain Kinesis Data Stream ARN](#obtain-kinesis-arn)
-1. [Create Log Export](#create-log-export)
-1. [Create Event Destination](#create-destination)
-</Tip>
-
 This guide covers how to send ngrok events including network traffic logs into AWS Kinesis.
 You may want to keep an audit log of configuration changes within your ngrok
 account, record all traffic to your endpoints for active monitoring/troubleshooting, or

--- a/integrations/event-destinations/datadog-event-destination.mdx
+++ b/integrations/event-destinations/datadog-event-destination.mdx
@@ -4,18 +4,6 @@ sidebarTitle: Datadog
 description: Send network traffic logs from ngrok to Datadog.
 ---
 
-<Tip>
-**TL;DR**
-
-
-
-To send ngrok events to Datadog:
-
-1. [Get prerequisite information](#prerequisites)
-1. [Create Log Export](#create-log-export)
-1. [Create Event Destination](#create-destination)
-</Tip>
-
 This guide covers how to send ngrok events including network traffic logs into Datadog.
 You may want to keep an audit log of configuration changes within your ngrok
 account, record all traffic to your endpoints for active monitoring/troubleshooting, or

--- a/integrations/guides/home-assistant-with-ngrok.mdx
+++ b/integrations/guides/home-assistant-with-ngrok.mdx
@@ -4,16 +4,6 @@ sidebarTitle: Home Assistant
 description: Learn how to use ngrok to expose your Home Assistant instance to the internet and access your dashboard remotely.
 ---
 
-<Tip>
-**TL;DR**
-
-To put your Home Assistant instance online with ngrok:
-
-1. Start Home Assistant locally in a Docker container
-2. Add ngrok to the Docker container
-3. Allow trusted proxies in Home Assistant
-</Tip>
-
 This guide covers how to set up Home Assistant with ngrok.
 This combination lets you access your Home Assistant dashboard over the public internet.
 

--- a/integrations/guides/linode-gslb_edges.mdx
+++ b/integrations/guides/linode-gslb_edges.mdx
@@ -4,20 +4,6 @@ sidebarTitle: Linode
 description: Learn how to layer load balancing between three or more globally distributed, cloud-based virtual machines in Linode.
 ---
 
-<Tip>
-**TL;DR**
-
-To use ngrok's [Global Load Balancer](/universal-gateway/global-load-balancer/) with Linode:
-
-1. [Reserve your ngrok domain](#reserve-domain)
-2. [Create your ngrok Edge](#create-edge)
-3. [Create Tunnel Group backends for your VMs](#create-tunnel-group-backends)
-4. [Create a Weighted Backend and Route on your Edge](#create-weighted-backend)
-5. [Install the ngrok agent and an example workload on each VM](#install-ngrok-agent)
-6. [Test out ngrok's Global Server Load Balancing](#test-gslb)
-7. [(optional) Enable the Traffic Policy module for API gateway features](#enable-traffic-policy)
-</Tip>
-
 In this guide, you'll learn how to layer ngrok's [Global Load Balancer](/universal-gateway/global-load-balancer/) (GSLB) on top of a VM-based deployment on Linode.
 
 GSLB improves the performance and resiliency for your apps by distributing traffic to the nearest Point of Prescence (PoP) and the upstream service.

--- a/integrations/guides/mqtt.mdx
+++ b/integrations/guides/mqtt.mdx
@@ -3,16 +3,6 @@ title: MQTT
 description: Learn how to expose your MQTT server to the internet using ngrok TCP tunnels and connect remotely with MQTT Explorer.
 ---
 
-<Tip>
-**TL;DR**
-
-To publish your MQTT server with ngrok:
-
-1. [Start an MQTT server.](#start-mqtt-server) `mosquitto`
-2. [Launch ngrok.](#start-ngrok) `ngrok tcp 1883`
-3. [Configure MQTT Explorer with your ngrok URL.](#setup-mqtt-explorer)
-</Tip>
-
 This guide shows you how to expose your MQTT server to the internet using ngrok.
 It covers setting up a local MQTT server, creating an ngrok TCP tunnel, and connecting to it using MQTT Explorer.
 

--- a/integrations/kubernetes-ingress/azure-ad-k8s.mdx
+++ b/integrations/kubernetes-ingress/azure-ad-k8s.mdx
@@ -4,19 +4,6 @@ description: Add ingress to any app running in Kubernetes, then restrict access 
 sidebarTitle: Microsoft Entra ID
 ---
 
-<Tip>
-**TL;DR**
-
-To use the ngrok Kubernetes Operator with Microsoft Entra ID:
-
-1. [Create a cluster and deploy an example app](#create-cluster-deploy-example-app)
-2. [Add the ngrok Kubernetes Operator](#add-the-ngrok-kubernetes-operator)
-3. [Update your ngrok Edge to enable SAML](#update-your-ngrok-edge-to-enable-SAML)
-4. [Create an enterprise app in Microsoft Entra ID](#create-an-enterprise-app)
-5. [Finish adding Microsoft Entra ID authorization to your ngrok Edge](#finish-adding-entra-ID-authorization-ngrok-edge)
-6. [Test authorization to your app using Microsoft Entra ID](#test-authorization-using-microsoft-entra-id)
-</Tip>
-
 The [ngrok Kubernetes Operator](/k8s) is ngrok's official controller for adding secure public ingress and middleware execution to your Kubernetes apps with ngrok's cloud service. With ngrok, you can manage and secure traffic to your apps at every stage of the development lifecycle while also benefitting from simpler configurations, security, and edge acceleration.
 
 Microsoft Azure Active Directory (AD)—now known as [Microsoft Entra ID](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id) (see the tip below)—is an identity and access management platform that helps administrators and DevOps engineers safeguard their organization's multicloud environment with strong authentication and unified identity management, whether they operate in Azure cloud or on-premises.

--- a/integrations/kubernetes-ingress/gslb.mdx
+++ b/integrations/kubernetes-ingress/gslb.mdx
@@ -3,22 +3,6 @@ title: Use ngrok's Global Server Load Balancing with DigitalOcean
 sidebarTitle: Global Server Load Balancing
 description: In this guide, you'll learn how to layer load balancing between three or more globally distributed, cloud-based virtual machines in DigitalOcean.
 ---
-<Tip>
-**TL;DR**
-
-
-
-To use ngrok's [Global Server Load Balancing](/universal-gateway/global-load-balancer/) with DigitalOcean:
-
-1. [Reserve your ngrok domain](#reserve-domain)
-2. [Create your ngrok Edge](#create-edge)
-3. [Create tunnel group backends for your VMs](#create-tunnel-group-backends)
-4. [Create a weighted backend and route on your edge](#create-weighted-backend)
-5. [Install the ngrok Agent and an example workload on each VM](#install-ngrok-agent)
-6. [Test out ngrok's Global Server Load Balancing](#test-gslb)
-7. [(optional) Enable the Traffic Policy module for API gateway features](#enable-traffic-policy)
-</Tip>
-
 In this guide, you'll learn how to layer ngrok's [Global Server Load Balancing](/universal-gateway/global-load-balancer/) (GSLB) on top of a VM-based deployment on DigitalOcean.
 
 GLSB improves the performance and resiliency for your apps by distributing traffic to the nearest Point of Prescence (PoP) and the upstream service. Unlike a traditional GSLB deployment, ngrok automatically routes traffic without requiring you to deploy new infrastructure, provision IPs, or change DNS records. All you have to do is configure your ngrok agents for a simple path to high availability, horizontal scaling, A/B testing, and more.

--- a/integrations/kubernetes-ingress/spectro-cloud-k8s.mdx
+++ b/integrations/kubernetes-ingress/spectro-cloud-k8s.mdx
@@ -3,19 +3,6 @@ title: Ingress to Kubernetes apps deployed on Spectro Cloud Palette
 sidebarTitle: Spectro Cloud Palette
 description: Add ingress to any app running in a Kubernetes cluster managed by Spectro Cloud's Palette platform using the ngrok Kubernetes Operator.
 ---
-<Tip>
-**TL;DR**
-
-
-
-To use the ngrok Kubernetes Operator with Spectro Cloud Palette:
-
-1. [Create an add-on cluster profile for the ngrok Kubernetes Operator](#create-a-cluster-profile-in-palette)
-2. [Create your cluster with Palette](#create-your-cluster-with-palette)
-3. [Create an add-on cluster profile for an example app and ngrok Kubernetes Operator](#create-add-on-cluster-profile-ngrok)
-4. [Create your cluster with Palette](#create-your-cluster-with-palette)
-</Tip>
-
 The [ngrok Kubernetes Operator](https://ngrok.com/blog-post/ngrok-k8s) is the official controller for adding public and secure ingress traffic to your k8s services. This open source Operator works with any cloud, locally hosted, or on-premises Kubernetes cluster to provide ingress to your applications, APIs, or other services while also offloading network ingress and middleware execution to ngrok's platform.
 
 Palette, from [Spectro Cloud](https://www.spectrocloud.com/), is a profile-based Kubernetes management platform. It gives IT teams the control and visibility to create Kubernetes stacks for their developers with all the granular governance and security they need.

--- a/integrations/webhooks/aftership-webhooks.mdx
+++ b/integrations/webhooks/aftership-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test AfterShip webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate AfterShip webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure AfterShip webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with AfterShip by using Webhooks.
 AfterShip webhooks can be used to notify an external application whenever specific events occur in your AfterShip account.
 

--- a/integrations/webhooks/airship-webhooks.mdx
+++ b/integrations/webhooks/airship-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Airship webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Airship webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Airship webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Airship by using Webhooks.
 You can configure an open channel to deliver notifications to any device through webhooks.
 

--- a/integrations/webhooks/alchemy-webhooks.mdx
+++ b/integrations/webhooks/alchemy-webhooks.mdx
@@ -6,17 +6,6 @@ description: Develop and test Alchemy webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-To integrate Alchemy webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Alchemy webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Alchemy by using Webhooks.
 Alchemy webhooks can be used to notify an external application whenever specific events occur in your Alchemy account.
 

--- a/integrations/webhooks/amazon-sns-webhooks.mdx
+++ b/integrations/webhooks/amazon-sns-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Amazon SNS webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Amazon SNS webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Amazon SNS webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Amazon SNS by using Webhooks.
 Amazon SNS webhooks can be used to notify an external application whenever a message is published to a topic.
 

--- a/integrations/webhooks/autodesk-webhooks.mdx
+++ b/integrations/webhooks/autodesk-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Autodesk webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Autodesk Platform Services webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Autodesk webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Autodesk Platform Services by using Webhooks.
 Autodesk Platform Services webhooks can be used to notify an external application whenever specific events occur in your Autodesk account.
 

--- a/integrations/webhooks/bitbucket-webhooks.mdx
+++ b/integrations/webhooks/bitbucket-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Bitbucket webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Bitbucket webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Bitbucket webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Bitbucket to allow Bitbucket to send notifications to your app anytime an event takes place in a Bitbucket repository.
 
 By integrating ngrok with Bitbucket, you can:

--- a/integrations/webhooks/box-webhooks.mdx
+++ b/integrations/webhooks/box-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Box webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Box webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Box webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Box by using Webhooks.
 Box webhooks can be used to notify an external application whenever specific events occur in your Box account.
 

--- a/integrations/webhooks/brex-webhooks.mdx
+++ b/integrations/webhooks/brex-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Brex webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Brex webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Brex webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Brex by using Webhooks.
 Brex webhooks can be used to notify an external application whenever specific events occur in your Brex account.
 

--- a/integrations/webhooks/buildkite-webhooks.mdx
+++ b/integrations/webhooks/buildkite-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Buildkite webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Buildkite webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Buildkite webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Buildkite by using Webhooks.
 Buildkite webhooks can be used to notify an external application whenever specific events occur in your Buildkite account.
 

--- a/integrations/webhooks/calendly-webhooks.mdx
+++ b/integrations/webhooks/calendly-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Calendly webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Calendly webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Calendly webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Calendly by using Webhooks.
 Calendly webhooks can be used to notify an external application whenever specific events occur in your Calendly account.
 

--- a/integrations/webhooks/castle-webhooks.mdx
+++ b/integrations/webhooks/castle-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Castle webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Castle webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Castle webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Castle by using Webhooks.
 Castle webhooks can be used to notify an external application whenever specific events occur in your Castle account.
 

--- a/integrations/webhooks/chargify-webhooks.mdx
+++ b/integrations/webhooks/chargify-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Chargify webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Chargify webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Chargify webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Chargify by using Webhooks.
 Chargify webhooks can be used to notify an external application whenever specific events occur in your Chargify account.
 

--- a/integrations/webhooks/circleci-webhooks.mdx
+++ b/integrations/webhooks/circleci-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test CircleCI webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate CircleCI webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure CircleCI webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with CircleCI by using Webhooks.
 CircleCI webhooks can be used to notify an external application whenever specific events occur in your CircleCI account.
 

--- a/integrations/webhooks/clearbit-webhooks.mdx
+++ b/integrations/webhooks/clearbit-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Clearbit webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Clearbit webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Clearbit webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Clearbit by using Webhooks.
 Clearbit webhooks can be used to notify an external application whenever specific events occur in your Clearbit account.
 

--- a/integrations/webhooks/clerk-webhooks.mdx
+++ b/integrations/webhooks/clerk-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Clerk webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Clerk webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Clerk webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Clerk by using Webhooks.
 Clerk webhooks can be used to notify an external application whenever specific events occur in your Clerk account.
 

--- a/integrations/webhooks/coinbase-webhooks.mdx
+++ b/integrations/webhooks/coinbase-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Coinbase webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Coinbase webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Coinbase webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Coinbase by using Webhooks.
 Coinbase webhooks can be used to notify an external application whenever specific events occur in your Coinbase account.
 

--- a/integrations/webhooks/contentful-webhooks.mdx
+++ b/integrations/webhooks/contentful-webhooks.mdx
@@ -6,18 +6,6 @@ description: "Learn how to integrate Contentful webhooks with ngrok to route web
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Contentful webhooks with ngrok:
-
-1. [Launch your local app that will process Contentful webhook requests](#start-your-app) `npm start`
-1. [Launch ngrok](#start-ngrok) `ngrok http 3000`
-1. [Configure Contentful webhooks with your ngrok URL](#setup-webhook)
-</Tip>
-
 This guide covers how to use ngrok to route Contentful Webhooks to your localhost app for development and integration testing.
 Contentful webhooks can be used to notify an external application whenever specific events occur in your Contentful account.
 

--- a/integrations/webhooks/docusign-webhooks.mdx
+++ b/integrations/webhooks/docusign-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test DocuSign webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate DocuSign webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure DocuSign webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with DocuSign by using Webhooks.
 DocuSign webhooks can be used to notify an external application whenever specific events occur in your DocuSign account.
 

--- a/integrations/webhooks/dropbox-webhooks.mdx
+++ b/integrations/webhooks/dropbox-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Dropbox webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Dropbox webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Dropbox webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Dropbox by using Webhooks.
 Dropbox webhooks can be used to notify an external application whenever specific events occur in your Dropbox account.
 

--- a/integrations/webhooks/facebook-messenger-webhooks.mdx
+++ b/integrations/webhooks/facebook-messenger-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Facebook Messenger webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Facebook Messenger webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `node appFB`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000 --url myexample.ngrok.app`
-1. [Configure Facebook webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Facebook by using Webhooks.
 Facebook webhooks can be used to notify an external application whenever specific events occur in your Facebook account.
 

--- a/integrations/webhooks/facebook-webhooks.mdx
+++ b/integrations/webhooks/facebook-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Facebook webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Facebook webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm run startFacebook`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000 --url myexample.ngrok.app`
-1. [Configure Facebook webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Facebook by using Webhooks.
 Facebook webhooks can be used to notify an external application whenever page or account events occur in your Facebook account.
 

--- a/integrations/webhooks/frameio-webhooks.mdx
+++ b/integrations/webhooks/frameio-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Frame.io webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Frame.io webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Frame.io webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Frame.io by using Webhooks.
 Frame.io webhooks can be used to notify an external application whenever specific events occur in your Frame.io account.
 

--- a/integrations/webhooks/github-webhooks.mdx
+++ b/integrations/webhooks/github-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test GitHub webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate GitHub webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure GitHub webhook with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with GitHub to allow GitHub to send notifications to your localhost app anytime an event takes place in a GitHub repository.
 
 By integrating ngrok with GitHub, you can:

--- a/integrations/webhooks/gitlab-webhooks.mdx
+++ b/integrations/webhooks/gitlab-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test GitLab webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate GitLab webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure GitLab webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with GitLab to allow GitLab to send notifications to your app anytime an event takes place in a GitLab repository.
 
 By integrating ngrok with GitLab, you can:

--- a/integrations/webhooks/heroku-webhooks.mdx
+++ b/integrations/webhooks/heroku-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Heroku webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Heroku webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Heroku webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Heroku by using Webhooks.
 Heroku webhooks can be used to notify an external application whenever specific events occur in your Heroku account.
 

--- a/integrations/webhooks/hostedhooks-webhooks.mdx
+++ b/integrations/webhooks/hostedhooks-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test HostedHooks webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate HostedHooks webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure HostedHooks webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with HostedHooks by using Webhooks.
 HostedHooks webhooks can be used to route requests to HostedHooks servers to your localhost app.
 

--- a/integrations/webhooks/hubspot-webhooks.mdx
+++ b/integrations/webhooks/hubspot-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test HubSpot webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate HubsSpot webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure HubSpot webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with HubSpot by using Webhooks.
 HubSpot webhooks can be used to notify an external application whenever specific events occur in your HubSpot account.
 

--- a/integrations/webhooks/hygraph-webhooks.mdx
+++ b/integrations/webhooks/hygraph-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Hygraph webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Hygraph webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Hygraph webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Hygraph by using Webhooks.
 Hygraph webhooks can be used to notify an external application whenever specific events occur in your Hygraph account.
 

--- a/integrations/webhooks/instagram-webhooks.mdx
+++ b/integrations/webhooks/instagram-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Instagram webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Instagram webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm run startFacebook`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000 --url myexample.ngrok.app`
-1. [Configure Instagram webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Instagram by using Webhooks.
 Instagram webhooks can be used to notify an external application whenever specific events occur in your Instagram account.
 

--- a/integrations/webhooks/intercom-webhooks.mdx
+++ b/integrations/webhooks/intercom-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Intercom webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Intercom webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Intercom webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Intercom by using Webhooks.
 Intercom webhooks can be used to notify an external application whenever specific events occur in your Intercom account.
 

--- a/integrations/webhooks/jira-webhooks.mdx
+++ b/integrations/webhooks/jira-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Jira webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Jira webhooks with ngrok:
-
-1. [Launch your local webhook.](#1-start-your-app) `npm start`
-1. [Launch ngrok.](#2-launch-ngrok) `ngrok http 3000`
-1. [Configure Jira webhooks with your ngrok URL.](#3-integrate-jira)
-1. [Secure your webhook requests with verification.](#secure-webhook-requests)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Jira by using Webhooks.
 Jira webhooks can be used to notify an external application whenever specific events occur in your Jira instance.
 

--- a/integrations/webhooks/launchdarkly-webhooks.mdx
+++ b/integrations/webhooks/launchdarkly-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test LaunchDarkly webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate LaunchDarkly webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure LaunchDarkly webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with LaunchDarkly by using Webhooks.
 LaunchDarkly webhooks can be used to notify an external application whenever specific events occur in your LaunchDarkly account.
 

--- a/integrations/webhooks/linear-webhooks.mdx
+++ b/integrations/webhooks/linear-webhooks.mdx
@@ -6,17 +6,6 @@ description: Develop and test Linear webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-To integrate Linear webhooks with ngrok:
-
-1. [Launch your local webhook.](#1-start-your-app) `npm start`
-1. [Launch ngrok.](#1-launch-ngrok) `ngrok http 3000`
-1. [Configure Linear webhooks with your ngrok URL.](#run-webhooks-with-linear-and-ngrok)
-1. [Secure your webhook requests with verification.](#secure-webhook-requests)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Linear by using Webhooks.
 Linear webhooks can be used to notify an external application whenever specific events occur in your Linear workspace.
 

--- a/integrations/webhooks/mailchimp-webhooks.mdx
+++ b/integrations/webhooks/mailchimp-webhooks.mdx
@@ -6,18 +6,6 @@ description: Develop and test Mailchimp webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Mailchimp webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Mailchimp webhooks with your ngrok URL.](#setup-webhook)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Mailchimp by using Webhooks.
 Mailchimp webhooks can be used to notify an external application whenever specific events occur in your Mailchimp account.
 

--- a/integrations/webhooks/mailgun-webhooks.mdx
+++ b/integrations/webhooks/mailgun-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Mailgun webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Mailgun webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Mailgun webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Mailgun by using Webhooks.
 Mailgun webhooks can be used to notify an external application whenever specific events occur in your Mailgun account.
 

--- a/integrations/webhooks/modern-treasury-webhooks.mdx
+++ b/integrations/webhooks/modern-treasury-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Modern Treasury webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Modern Treasury webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Modern Treasury webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Modern Treasury by using Webhooks.
 Modern Treasury webhooks can be used to notify an external application whenever specific events occur in your Modern Treasury account.
 

--- a/integrations/webhooks/mongodb-webhooks.mdx
+++ b/integrations/webhooks/mongodb-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test MongoDB webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate MongoDB webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure MongoDB webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with MongoDB Atlas by using Webhooks.
 MongoDB webhooks can be used to notify an external application whenever specific events occur in your MongoDB account.
 

--- a/integrations/webhooks/mux-webhooks.mdx
+++ b/integrations/webhooks/mux-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Mux webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Mux webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Mux webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Mux by using Webhooks.
 Mux webhooks can be used to notify an external application whenever specific events occur in your Mux account.
 

--- a/integrations/webhooks/okta-webhooks.mdx
+++ b/integrations/webhooks/okta-webhooks.mdx
@@ -6,18 +6,6 @@ description: Develop and test Okta webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Okta webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Okta webhooks with your ngrok URL.](#setup-webhook)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Okta by using Webhooks.
 Okta webhooks can be used to notify an external application whenever specific events occur in your Okta account.
 

--- a/integrations/webhooks/orbit-webhooks.mdx
+++ b/integrations/webhooks/orbit-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Orbit webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Orbit webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Orbit webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Orbit by using Webhooks.
 Orbit webhooks can be used to notify an external application whenever specific events occur in your Orbit account.
 

--- a/integrations/webhooks/pagerduty-webhooks.mdx
+++ b/integrations/webhooks/pagerduty-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test PagerDuty webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate PagerDuty webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure PagerDuty webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with PagerDuty by using Webhooks.
 PagerDuty webhooks can be used to notify an external application whenever specific events occur in your PagerDuty account.
 

--- a/integrations/webhooks/pinwheel-webhooks.mdx
+++ b/integrations/webhooks/pinwheel-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Pinwheel webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Pinwheel webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Pinwheel webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Pinwheel by using Webhooks.
 Pinwheel webhooks can be used to notify an external application whenever specific events occur in your Pinwheel account.
 

--- a/integrations/webhooks/plivo-webhooks.mdx
+++ b/integrations/webhooks/plivo-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Plivo webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Plivo webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Plivo webhooks with your ngrok URL.](#setup-webhook)
-1. **Bonus!** [Use ngrok like a PRO.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Plivo by using Webhooks.
 Plivo webhooks can be used to notify an external application whenever SMS and MMS messages are sent to your Plivo numbers.
 

--- a/integrations/webhooks/pusher-webhooks.mdx
+++ b/integrations/webhooks/pusher-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Pusher webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Pusher webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Pusher webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Pusher by using Webhooks.
 Pusher webhooks can be used to notify an external application whenever specific events occur in your Pusher channel.
 

--- a/integrations/webhooks/sendgrid-webhooks.mdx
+++ b/integrations/webhooks/sendgrid-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test SendGrid webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate SendGrid webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure SendGrid webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with SendGrid by using Webhooks.
 SendGrid webhooks can be used to notify an external application with information about events that occur as SendGrid processes your email.
 

--- a/integrations/webhooks/sentry-webhooks.mdx
+++ b/integrations/webhooks/sentry-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Sentry webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Sentry webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Sentry webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Sentry by using Webhooks.
 Sentry webhooks can be used to notify an external application whenever specific events occur in your Sentry projects.
 

--- a/integrations/webhooks/shopify-webhooks.mdx
+++ b/integrations/webhooks/shopify-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Shopify webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Shopify webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Shopify webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Shopify by using Webhooks.
 Shopify webhooks can be used to notify an external application whenever specific events occur in your Shopify store.
 
@@ -28,17 +15,6 @@ By integrating ngrok with Shopify, you can:
 - **Inspect and troubleshoot requests from Shopify** in real-time via the inspection UI and API.
 - **Modify and Replay Shopify Webhook requests** with a single click and without spending time reproducing events manually in your Shopify store.
 - **Secure your app with Shopify validation provided by ngrok**. Invalid requests are blocked by ngrok before reaching your app.
-<Tip>
-**TL;DR**
-
-
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-2. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-3. [Configure Shopify webhooks with your ngrok URL.](#setup-webhook)
-
-4. **Bonus!** [Secure your webhook requests with verification.](#security)
-</Tip>
 
 ## 1. Start your app 
 

--- a/integrations/webhooks/signalsciences-webhooks.mdx
+++ b/integrations/webhooks/signalsciences-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Signal Sciences webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Signal Sciences webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Signal Sciences webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Signal Sciences by using Webhooks.
 Signal Sciences webhooks can be used to notify an external application whenever specific events occur in your Signal Sciences account.
 

--- a/integrations/webhooks/slack-webhooks.mdx
+++ b/integrations/webhooks/slack-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Slack webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Slack webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Slack webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Slack using Webhooks.
 Slack webhooks can be used to notify an external application whenever specific events occur in your Slack account.
 Slack requires your application to be available through an HTTPS endpoint.

--- a/integrations/webhooks/sonatype-nexus-webhooks.mdx
+++ b/integrations/webhooks/sonatype-nexus-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Sonatype Nexus webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Sonatype Nexus webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Sonatype Nexus webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Sonatype Nexus by using Webhooks.
 Sonatype Nexus webhooks can be used to notify an external application whenever specific events occur in your Sonatype Nexus account.
 

--- a/integrations/webhooks/square-webhooks.mdx
+++ b/integrations/webhooks/square-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Square webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Square webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Square webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Square by using Webhooks.
 Square webhooks can be used to notify an external application whenever specific events occur in your Square account.
 

--- a/integrations/webhooks/stripe-webhooks.mdx
+++ b/integrations/webhooks/stripe-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Stripe webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Stripe webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Stripe webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Stripe webhooks.
 Stripe webhooks can be used to notify an external application whenever specific events occur in your Stripe account. Stripe requires your application to be available through an HTTPS endpoint.
 

--- a/integrations/webhooks/svix-webhooks.mdx
+++ b/integrations/webhooks/svix-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Svix webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Svix webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Svix webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Svix by using Webhooks.
 Svix incoming webhooks can be used to notify an external application whenever specific events occur in your Svix account.
 

--- a/integrations/webhooks/teams-webhooks.mdx
+++ b/integrations/webhooks/teams-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Microsoft Teams webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Microsoft Teams webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000 --url myexample.ngrok.app`
-1. [Configure Microsoft Teams webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Microsoft Teams by using Webhooks.
 Microsoft Teams webhooks can be used to notify an external application whenever page or account events occur in your Microsoft Teams account.
 

--- a/integrations/webhooks/terraform-webhooks.mdx
+++ b/integrations/webhooks/terraform-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Terraform webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Terraform Cloud webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Terraform Cloud webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Terraform Cloud by using Webhooks.
 Terraform Cloud webhooks can be used to notify an external application whenever specific events occur in your Terraform Cloud account.
 

--- a/integrations/webhooks/tiktok-webhooks.mdx
+++ b/integrations/webhooks/tiktok-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test TikTok webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate TikTok webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure TikTok webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with TikTok by using Webhooks.
 TikTok webhooks can be used to notify an external application whenever specific events occur in your TikTok app.
 

--- a/integrations/webhooks/trendmicro-webhooks.mdx
+++ b/integrations/webhooks/trendmicro-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Trend Micro webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Trend Micro webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Trend Micro webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Trend Micro by using Webhooks.
 Trend Micro webhooks can be used to notify an external application whenever specific events occur in your Trend Micro account.
 

--- a/integrations/webhooks/twilio-webhooks.mdx
+++ b/integrations/webhooks/twilio-webhooks.mdx
@@ -6,16 +6,6 @@ description: Develop and test Twilio webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-To integrate Twilio webhooks with ngrok:
-
-1. [Start your local twillio webhook app.](#start-your-app) `npm start`
-1. [Start ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Twilio with your ngrok URL and start testing.](#setup-twilio)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with [Twilio SMS webhooks](https://www.twilio.com/docs/usage/webhooks/sms-webhooks). By integrating ngrok with Twilio, you can:
 
 - **Develop and test Twilio webhooks locally**, eliminating the time in deploying your development code to a public environment

--- a/integrations/webhooks/twitter-webhooks.mdx
+++ b/integrations/webhooks/twitter-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test X (formerly Twitter) webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate X (formerly Twitter) webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure X webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with X by using Webhooks.
 X webhooks can be used to notify an external application whenever specific events occur in your X account.
 

--- a/integrations/webhooks/typeform-webhooks.mdx
+++ b/integrations/webhooks/typeform-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Typeform webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Typeform webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Typeform webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Typeform by using Webhooks.
 Typeform webhooks can be used to notify an external application whenever specific events occur in your Typeform account.
 

--- a/integrations/webhooks/vmware-webhooks.mdx
+++ b/integrations/webhooks/vmware-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test VMware webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate VMware Workspace ONE webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure VMware Workspace ONE webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with VMware Workspace ONE by using Webhooks.
 VMware Workspace ONE webhooks can be used to notify an external application whenever specific events occur in your VMware Workspace ONE account.
 

--- a/integrations/webhooks/webex-webhooks.mdx
+++ b/integrations/webhooks/webex-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Webex webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Cisco Webex webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Cisco Webex webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Cisco Webex by using Webhooks.
 Cisco Webex webhooks can be used to notify an external application whenever specific events occur in your Cisco Webex account.
 

--- a/integrations/webhooks/whatsapp-webhooks.mdx
+++ b/integrations/webhooks/whatsapp-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test WhatsApp webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate WhatsApp webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm run startFacebook`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000 --url myexample.ngrok.app`
-1. [Configure WhatsApp webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with WhatsApp by using Webhooks.
 WhatsApp webhooks can be used to notify an external application whenever specific events occur in your WhatsApp account.
 

--- a/integrations/webhooks/worldline-webhooks.mdx
+++ b/integrations/webhooks/worldline-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Worldline webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Worldline webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Worldline webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Worldline by using Webhooks.
 Worldline webhooks can be used to notify an external application whenever specific events occur in your Worldline account.
 

--- a/integrations/webhooks/xero-webhooks.mdx
+++ b/integrations/webhooks/xero-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Xero webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Xero webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Xero webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Xero by using Webhooks.
 Xero webhooks can be used to notify an external application whenever specific events occur in your Xero account.
 

--- a/integrations/webhooks/zendesk-webhooks.mdx
+++ b/integrations/webhooks/zendesk-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Zendesk webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Zendesk webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Zendesk webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Zendesk by using Webhooks.
 Zendesk webhooks can be used to notify an external application whenever specific events occur in your Zendesk account.
 

--- a/integrations/webhooks/zoom-webhooks.mdx
+++ b/integrations/webhooks/zoom-webhooks.mdx
@@ -6,19 +6,6 @@ description: Develop and test Zoom webhooks from localhost.
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
 
-<Tip>
-**TL;DR**
-
-
-
-To integrate Zoom webhooks with ngrok:
-
-1. [Launch your local webhook.](#start-your-app) `npm start`
-1. [Launch ngrok.](#start-ngrok) `ngrok http 3000`
-1. [Configure Zoom webhooks with your ngrok URL.](#setup-webhook)
-1. [Secure your webhook requests with verification.](#security)
-</Tip>
-
 This guide covers how to use ngrok to integrate your localhost app with Zoom using webhooks.
 Zoom webhooks can send notifications to external apps whenever specific events occur in your Zoom account.
 


### PR DESCRIPTION
These are redundant because we have the "On this page" TOC nav, and most/all of these callouts currently have broken links anyway. 