### PR TITLE
Replace ingress as a service with all-in-one cloud networking platform

### DIFF
--- a/guides/device-gateway/linux.mdx
+++ b/guides/device-gateway/linux.mdx
@@ -6,7 +6,7 @@ description: Learn how to install ngrok on a remote Linux device to provide secu
 
 ngrok allows you to create secure ingress to any app, device, or service without spending hours learning arcane networking technologies. You can get started with a single command or a single line of code.
 
-What is ngrok? ngrok is an ingress-as-a-service platform that removes the hassle of getting code online from developers’ plates by decoupling ingress from infrastructure with one line of code, all without provisioning proxies or VPNs.
+What is ngrok? ngrok is an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
 In this guide, you'll walk through the process of installing the ngrok agent on a remote Linux device, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
 

--- a/guides/device-gateway/raspberry-pi.mdx
+++ b/guides/device-gateway/raspberry-pi.mdx
@@ -6,7 +6,7 @@ description: Learn how to install ngrok on a Raspberry Pi running Linux to provi
 
 ngrok allows you to create secure ingress to any app, device, or service without spending hours learning arcane networking technologies. You can get started with a single command or a single line of code.
 
-What is ngrok? ngrok is an ingress-as-a-service platform that removes the hassle of getting code online from developers’ plates by decoupling ingress from infrastructure with one line of code, all without provisioning proxies or VPNs.
+What is ngrok? ngrok is an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
 In this guide, you'll walk through the process of installing the ngrok agent on a remote Raspberry Pi device running Linux, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
 

--- a/guides/device-gateway/raspbian.mdx
+++ b/guides/device-gateway/raspbian.mdx
@@ -6,7 +6,7 @@ description: Learn how to install ngrok on a Raspberry Pi OS (formerly Raspbian)
 
 ngrok allows you to create secure ingress to any app, device, or service without spending hours learning arcane networking technologies. You can get started with a single command or a single line of code.
 
-What is ngrok? ngrok is an ingress-as-a-service platform that removes the hassle of getting code online from developers’ plates by decoupling ingress from infrastructure with one line of code, all without provisioning proxies or VPNs.
+What is ngrok? ngrok is an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
 In this guide, you'll walk through the process of installing the ngrok agent on a remote Raspberry Pi OS (formerly Raspbian) device, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
 

--- a/guides/device-gateway/windows.mdx
+++ b/guides/device-gateway/windows.mdx
@@ -6,7 +6,7 @@ description: Learn how to install ngrok on a remote Windows device to provide se
 
 ngrok allows you to create secure ingress to any app, device, or service without spending hours learning arcane networking technologies. You can get started with a single command or a single line of code.
 
-What is ngrok? ngrok is an ingress-as-a-service platform that removes the hassle of getting code online from developers’ plates by decoupling ingress from infrastructure with one line of code, all without provisioning proxies or VPNs.
+What is ngrok? ngrok is an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
 In this guide, you'll walk through the process of installing the ngrok agent on a remote Windows device, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
 

--- a/guides/identity-aware-proxy/securing-with-oauth.mdx
+++ b/guides/identity-aware-proxy/securing-with-oauth.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Adding OAuth 2.0 to Endpoints
 description: Learn how to secure your ngrok endpoints with OAuth 2.0.
 ---
 
-ngrok simplifies networking by creating secure ingress to any app, device, or service with a single command or line of code. It's an ingress-as-a-service platform that decouples ingress from infrastructure, removing the hassle of getting code online without provisioning proxies or VPNs.
+ngrok simplifies networking by creating secure ingress to any app, device, or service with a single command or line of code. It's an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
 If you're exposing endpoints with ngrok, it's important to keep them safe and secure. One way to protect them is by using OAuth, which requires visitors to sign in to view your app or webpage. This guide will walk you through the process of securing your ngrok endpoints with OAuth 2.0.
 

--- a/guides/index.mdx
+++ b/guides/index.mdx
@@ -5,7 +5,7 @@ description: Explore practical guides to help you integrate ngrok into your work
 mode: center
 ---
 
-These guides walk you through concrete scenarios where you can successfully integrate ngrok into your workflow. Whether you need to create [ingress to remote Windows devices](/guides/device-gateway/windows), accept traffic from [behind a corporate firewall](/guides/running-behind-firewalls), or you just need [an ingress-as-a-service solution](/guides/identity-aware-proxy/securing-with-oauth), guides are available to help you get started.
+These guides walk you through concrete scenarios where you can successfully integrate ngrok into your workflow. Whether you need to create [ingress to remote Windows devices](/guides/device-gateway/windows), accept traffic from [behind a corporate firewall](/guides/running-behind-firewalls), or you just need [an All in One Cloud Networking Platform](/guides/identity-aware-proxy/securing-with-oauth), guides are available to help you get started.
 
 
 ## Get started


### PR DESCRIPTION
@samcrichard noticed the ai helper kept referring to ngrok as ingress-as-a-service which was an old term we used a while ago. This PR replaces those isntances with some new verbiage. 