### PR TITLE
Add PostHog analytics integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -53,6 +53,10 @@
   "integrations": {
     "gtm": {
       "tagId": "GTM-P4F37ZW"
+    },
+    "posthog": {
+      "apiKey": "phc_mUGMN4JlTzthGcz0XNK0z6NKUqdeQMn7rPRAM3mifjQ",
+      "apiHost": "https://us.i.posthog.com"
     }
   },
   "footer": {


### PR DESCRIPTION
Adds PostHog analytics integration to ngrok-docs.

## Changes
- Added PostHog integration to docs.json with API key and host

Session recordings are enabled by default.