### PR TITLE
Fix busted Vale CI check

### DIFF
--- a/using-ngrok-with/puppet.mdx
+++ b/using-ngrok-with/puppet.mdx
@@ -5,9 +5,3 @@ description: Learn how to use the ngrok Puppet module to install and configure n
 ---
 
 Use Gabe's puppet module for installing and configuring ngrok resources and ensure the ngrok agent process is running: [ngrok module for Puppet](https://forge.puppet.com/gabe/ngrok)
-
-I'm breaking multiple rules!
-
-Hey look at me.There are multiple errors here.
-
-# This Is All Wrong Man


### PR DESCRIPTION
This PR fixes the Vale CI check by replacing the hardcoded version with a script to fetch the latest version so ideally we won't have to do this again.