### PR TITLE
[agent] Use `%LocalAppData%` instead of `%HOMEPATH%\AppData\Local`

### DIFF
--- a/agent/config/index.mdx
+++ b/agent/config/index.mdx
@@ -24,7 +24,8 @@ For the main operating systems supported, their default file locations are:
 
 - Linux: `~/.config/ngrok/ngrok.yml`
 - MacOS (Darwin): `~/Library/Application Support/ngrok/ngrok.yml`
-- Windows: `"%HOMEPATH%\AppData\Local\ngrok\ngrok.yml"`
+- Windows: `"%LocalAppData%\ngrok\ngrok.yml"`
+  (`%LocalAppData` is usually `%UserProfile%\AppData\Local`.)
 
 ## Config file merging
 

--- a/guides/device-gateway/windows.mdx
+++ b/guides/device-gateway/windows.mdx
@@ -114,12 +114,12 @@ endpoints:
 
 **Note**: Make sure to replace **NGROK_TCP_ADDRESS** with the address you reserved earlier in the ngrok dashboard (that is, `1.tcp.ngrok.io:12345`) and **ALLOWED_IP_ADDRESS_CIDR** with the CIDR notation of the allowed IP Address(es) (that is, `123.123.123.0/24`).
 
-**Note**: Make note of the location of the `ngrok.yml` file (that is, `%HOMEPATH%\AppData\Local\ngrok\`).
+**Note**: Make note of the location of the `ngrok.yml` file (that is, `%LocalAppData%\ngrok\`).
 
 1. Enable ngrok in service mode:
 
 ```bash
-ngrok service install --config "%HOMEPATH%\AppData\Local\ngrok\ngrok.yml"
+ngrok service install --config "%LocalAppData%\ngrok\ngrok.yml"
 ```
 
 <Note>


### PR DESCRIPTION
`%LocalAppData%` is the environment variable that the agent uses, and could be theoretically set to a different value.