### PR TITLE
Prevent unwanted scripts from running in the client

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,1 @@
+custom/scripts/


### PR DESCRIPTION
In an effort to prevent the definition-wrapper from running in the client, I discovered all our scripts in custom/scripts/ seem to be running, which is bad. This will prevent that, and stop definition-wrapper.

We want to stop definition-wrapper from running to improve our CLS problem

Before:
<img width="1542" height="1332" alt="image" src="https://github.com/user-attachments/assets/1dc512ff-b2e0-41f7-9ad8-eeb3cb228fce" />


After:
<img width="1474" height="836" alt="image" src="https://github.com/user-attachments/assets/c5a09e66-6070-48d1-bd05-ac553ee8a0f3" />
