### PR TITLE
Improve navbar active underline style

### DIFF
--- a/style.css
+++ b/style.css
@@ -197,18 +197,6 @@ footer#footer a {
   }
 }
 
-/* Custom tab spacing for Mintlify tabs */
-/* Override the tab container height to reduce space between tab text and indicator line */
-[role="tablist"].h-9 {
-  height: 2rem !important; /* Change from default h-9 (2.25rem) to smaller height */
-}
-
 .nav-tabs-item > div.absolute.bottom-0 {
   height: 2px !important;
-}
-
-[class*="hidden"][class*="lg:flex"][class*="px-12"][class*="h-12"] {
-  height: 2.25rem !important;
-  min-height: 2.25rem !important;
-  max-height: 2.25rem !important;
 }


### PR DESCRIPTION
This PR tweaks the top-level nav bar styles to make the active underline slightly thicker than before. Subtle but effective!

BEFORE
<img width="453" height="184" alt="Screenshot 2026-02-24 at 8 10 49 AM" src="https://github.com/user-attachments/assets/42bb1171-1b0e-4280-94a8-5a09a7d9c8e9" />

AFTER

<img width="405" height="171" alt="Screenshot 2026-02-24 at 8 22 31 AM" src="https://github.com/user-attachments/assets/13ee465c-b0a7-4440-8f84-bf3f524ade24" />


https://linear.app/ngrok/issue/DOC-443/improve-navbar-active-underline-style