### PR TITLE
feat: document supported/unsupported params for ai-gateway

### DIFF
--- a/ai-gateway/custom-providers/index.mdx
+++ b/ai-gateway/custom-providers/index.mdx
@@ -115,6 +115,76 @@ providers:
           max_context: 8192
 ```
 
+## Parameter filtering
+
+By default, no parameter filtering occurs for custom providers or models. Every parameter your client sends is forwarded as-is. If your provider or model rejects parameters that clients commonly include, you can opt into filtering using either or both of the mechanisms below.
+
+### Provider surface allowlist
+
+Use `supported_params` on a `supported_api_surfaces` entry to declare the exact set of parameters the provider accepts for that surface. Any top-level request body parameter not on this list will be removed before the request is forwarded.
+
+```yaml
+providers:
+  - id: "my-provider"
+    base_url: "https://my-service.internal"
+    supported_api_surfaces:
+      - format: openai
+        surface: chat-completions
+        supported_params:
+          - name: model
+          - name: messages
+          - name: temperature
+          - name: max_tokens
+          - name: stream
+```
+
+With this configuration, a request that includes `logit_bias` or `parallel_tool_calls` will have those fields removed before being forwarded to `my-provider`.
+
+<Note>
+`supported_params` only takes effect when the gateway has matched a known surface (`chat-completions`, `responses`, or `messages`). The list must be non-empty to activate filtering.
+</Note>
+
+### Model-specific denylist
+
+Use `unsupported_params` on a model to declare parameters that model doesn't accept. These are removed regardless of what the provider surface allows, and regardless of which surface was matched.
+
+```yaml
+providers:
+  - id: "my-provider"
+    base_url: "https://my-service.internal"
+    models:
+      - id: "my-model"
+        unsupported_params:
+          - name: parallel_tool_calls
+          - name: response_format
+```
+
+### Combining both
+
+The two mechanisms are independent and can be used together. Provider-level filtering (allowlist) runs first, then model-level filtering (denylist) runs second. A common pattern is to set `supported_params` at the provider level for all models, then use `unsupported_params` on individual models that have additional restrictions:
+
+```yaml
+providers:
+  - id: "my-provider"
+    base_url: "https://my-service.internal"
+    supported_api_surfaces:
+      - format: openai
+        surface: chat-completions
+        supported_params:
+          - name: model
+          - name: messages
+          - name: temperature
+          - name: max_tokens
+          - name: stream
+    models:
+      - id: "my-base-model"
+        # No extra filtering needed — provider surface allowlist is sufficient
+      - id: "my-limited-model"
+        # This model additionally can't handle temperature even though the surface allows it
+        unsupported_params:
+          - name: temperature
+```
+
 ## Authentication
 
 ### With provider API keys

--- a/ai-gateway/how-it-works.mdx
+++ b/ai-gateway/how-it-works.mdx
@@ -26,9 +26,10 @@ sequenceDiagram
 1. **Your app sends a request** with your [AI Gateway API Key](/ai-gateway/concepts/api-keys) to your ngrok endpoint
 2. **The gateway validates your key** and injects ngrok's managed provider keys
 3. **The gateway selects which models to try** based on your configuration and the request
-4. **The request is forwarded** to the provider with the appropriate provider API key
-5. **If it fails, the gateway retries** with the next model or key in the list
-6. **The response is returned** to your app
+4. **Unsupported parameters are stripped if needed** from the request body based on the selected provider/model
+5. **The request is forwarded** to the provider with the appropriate provider API key
+6. **If it fails, the gateway retries** with the next model or key in the list
+7. **The response is returned** to your app
 
 ## Authentication
 
@@ -123,6 +124,55 @@ Common routing patterns:
 <Tip>
 Use `ngrok/auto` as the model name to let your selection strategy choose entirely. See [Model Selection Strategies](/ai-gateway/guides/model-selection-strategies) for detailed examples.
 </Tip>
+
+## Parameter compatibility
+
+Different AI providers and models support different sets of request parameters. The gateway can remove parameters that a provider or model doesn't support before forwarding the request, preventing errors caused by unsupported fields.
+
+### How it works
+
+Parameter removal happens in two independent passes before each request is forwarded. Each pass only runs if the relevant configuration is present. If neither is configured, no filtering occurs.
+
+1. **Provider-level (allowlist)**: If the matched surface entry has a non-empty `supported_params` list, any top-level request body parameters not on that list are stripped.
+2. **Model-level (denylist)**: If the model has `unsupported_params` entries, those specific parameters are stripped regardless of what the provider surface allows.
+
+You can configure either mechanism independently or use both together.
+
+<Note>
+Parameter removal only applies to top-level request body fields. Nested structures are not inspected.
+</Note>
+
+### Official providers
+
+For official (built-in) providers and models in the ngrok model catalog, parameter compatibility information is maintained automatically. No configuration is required.
+
+### Custom providers and models
+
+Custom providers and models have no parameter compatibility information by default, so no filtering occurs unless you configure it. You can opt in using either or both mechanisms:
+
+```yaml title="traffic-policy.yaml"
+providers:
+  - id: "my-provider"
+    base_url: "https://my-service.internal"
+    supported_api_surfaces:
+      - format: openai
+        surface: chat-completions
+        # Allowlist: only these params are forwarded for this surface
+        supported_params:
+          - name: model
+          - name: messages
+          - name: temperature
+          - name: max_tokens
+          - name: stream
+    models:
+      - id: "my-model"
+        # Denylist: these params are always stripped for this model
+        unsupported_params:
+          - name: parallel_tool_calls
+          - name: response_format
+```
+
+See the [Custom Providers guide](/ai-gateway/custom-providers) and the [Configuration Schema](/ai-gateway/reference/configuration-schema) for full details.
 
 ## Failover
 

--- a/ai-gateway/reference/configuration-schema.mdx
+++ b/ai-gateway/reference/configuration-schema.mdx
@@ -251,13 +251,37 @@ Each provider in the `providers` array supports these fields:
 </ConfigField>
 
 <ConfigField title="providers[].supported_api_surfaces" type="array">
-  <p>List of API formats this provider supports. Possible values are `openai`, `anthropic`.  Default is `openai`.</p>
-    ```yaml
+  <p>List of API formats this provider supports. Possible values are <code>openai</code> and <code>anthropic</code>. Default is <code>openai</code>.</p>
+  <p>Each entry optionally includes a <code>surface</code> (the specific endpoint, such as <code>chat-completions</code> or <code>responses</code>) and a <code>supported_params</code> list. When <code>supported_params</code> is non-empty, any top-level request body parameter not on the list is automatically removed before the request is forwarded to the provider. For official providers, this information is maintained automatically.</p>
+  
+<ConfigField title="providers[].supported_api_surfaces" type="array<object>">
+  <p>Lists the API surfaces supported by this provider.</p>
+  <p>Each entry must include <code>format</code>, and may include <code>surface</code> and <code>supported_params</code>.</p>
+
+  <ConfigField title="providers[].supported_api_surfaces[].format" type="string" required>
+    <p>The API format for this entry. Allowed values: <code>openai</code>, <code>anthropic</code>.</p>
+  </ConfigField>
+
+  <ConfigField title="providers[].supported_api_surfaces[].surface" type="string">
+    <p>Optional endpoint surface for this format entry (for example <code>chat-completions</code>, <code>responses</code>, or <code>messages</code>).</p>
+  </ConfigField>
+
+  <ConfigField title="providers[].supported_api_surfaces[].supported_params" type="array<string>">
+    <p>Optional allowlist of top-level request body keys.  You must set <code>surface</code> in order to set this field.</p>
+  </ConfigField>
+</ConfigField>
+
+  ```yaml
   supported_api_surfaces:
     - format: openai
+      surface: chat-completions
+      supported_params:
+        - name: model
+        - name: messages
+        - name: temperature
+        - name: stream
     - format: anthropic
   ```
-
 </ConfigField>
 
 ## API key configuration
@@ -350,6 +374,20 @@ Each model in `providers[].models` supports:
   <p>Features supported by the model (for example, "tool-calling", "coding").</p>
 </ConfigField>
 
+<ConfigField title="providers[].models[].unsupported_params" type="array of objects">
+  <p>A denylist of top-level request body parameters that this model does not support. When a request is forwarded to this model, any listed parameters are automatically removed from the request body before it is sent to the provider.</p>
+  <p>Each entry requires a <code>name</code> field with the parameter name. This is useful for custom models that reject parameters that clients commonly include.</p>
+  <p>For official models in the ngrok model catalog, this information is maintained automatically—no configuration required.</p>
+
+  ```yaml
+  models:
+    - id: "my-model"
+      unsupported_params:
+        - name: parallel_tool_calls
+        - name: response_format
+  ```
+</ConfigField>
+
 ## Complete example
 
 ```yaml
@@ -406,4 +444,3 @@ on_http_request:
           # Fall back to all keys
           - "ai.keys"
 ```
-


### PR DESCRIPTION
resolves https://linear.app/ngrok/issue/AIG-634/add-docs-for-parameter-filtering

Adds docs around ai-gateway unsupported parameter filtering