### PR TITLE
update agent release notes for 3.37.0

### DIFF
--- a/agent/changelog.mdx
+++ b/agent/changelog.mdx
@@ -8,7 +8,6 @@ sidebarTitle: Changelog
 
 ### ngrok Agent 3.37.0 \[2026-03-05\]
 
-- Temporarily excluded macOS (darwin) builds from distribution
 - Disable updates for Windows App Store builds
 - Fix config file location for Microsoft Store installs
 - Add `ai-gateway-api-keys` CLI commands


### PR DESCRIPTION
macOS is working now, we don't need this line in the release notes 