### PR TITLE
Restructure provider docs and add BYOK note to quickstart

### DIFF
--- a/ai-gateway/providers/anthropic.mdx
+++ b/ai-gateway/providers/anthropic.mdx
@@ -7,13 +7,9 @@ description: Use Anthropic Claude models through the ngrok AI Gateway.
 
 Anthropic models can be called using either the **OpenAI-compatible API** (chat completions format) or the **native Anthropic API** (messages format). Both are supported.
 
-## Using with ngrok-managed keys
+## Managed keys setup
 
-No Anthropic account needed. [AI Gateway API Keys](/ai-gateway/concepts/api-keys) include access to Claude models—ngrok manages authentication automatically.
-
-**Prerequisites:**
-- An AI Gateway endpoint ([quickstart](/ai-gateway/quickstart))
-- An [AI Gateway API Key](/ai-gateway/concepts/api-keys)
+No Anthropic account needed. Follow the [quickstart](/ai-gateway/quickstart) to create your gateway and API key, then point your SDK at the gateway:
 
 <CodeGroup>
 ```python Python (OpenAI SDK)
@@ -122,217 +118,251 @@ curl https://your-ai-gateway.ngrok.app/v1/messages \
 ```
 </CodeGroup>
 
-## Using your own Anthropic key (BYOK)
+## Bring your own key
 
-Store your Anthropic key in the gateway and use it centrally across all clients, or forward your key directly in passthrough mode.
+Use your own Anthropic API key. Pass it directly—the gateway forwards it to Anthropic.
 
-### Option A: Store key in the gateway (recommended)
+<Steps>
+  <Step title="Create an AI Gateway">
+    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint.
+  </Step>
 
-**1. Store your key in ngrok secrets**
+  <Step title="Get an Anthropic API key">
+    Create an account at [console.anthropic.com](https://console.anthropic.com) and generate an API key. Keys start with `sk-ant-`.
+  </Step>
 
-```bash
-ngrok api secrets create \
-  --name anthropic \
-  --secret-data '{"api-key": "sk-ant-..."}'
-```
+  <Step title="Make a request">
+    Pass your key directly—the gateway forwards it to Anthropic.
 
-Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
+    <CodeGroup>
+    ```python Python (OpenAI SDK)
+    from openai import OpenAI
 
-**2. Configure your Traffic Policy**
+    client = OpenAI(
+        base_url="https://your-ai-gateway.ngrok.app/v1",
+        api_key="sk-ant-..."  # Your Anthropic key, forwarded by gateway
+    )
 
-```yaml
-on_http_request:
-  - type: ai-gateway
-    config:
-      providers:
-        - id: "anthropic"
-          api_keys:
-            - value: ${secrets.get('anthropic', 'api-key')}
-```
+    response = client.chat.completions.create(
+        model="claude-opus-4-6",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-**3. Make a request**
+    print(response.choices[0].message.content)
+    ```
 
-<CodeGroup>
-```python Python (OpenAI SDK)
-from openai import OpenAI
+    ```python Python (Anthropic SDK)
+    import anthropic
 
-client = OpenAI(
-    base_url="https://your-ai-gateway.ngrok.app/v1",
-    api_key="unused"  # Gateway injects your Anthropic key
-)
+    client = anthropic.Anthropic(
+        base_url="https://your-ai-gateway.ngrok.app",
+        api_key="sk-ant-..."  # Your Anthropic key, forwarded by gateway
+    )
 
-response = client.chat.completions.create(
-    model="claude-opus-4-6",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
+    message = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-print(response.choices[0].message.content)
-```
+    print(message.content[0].text)
+    ```
 
-```python Python (Anthropic SDK)
-import anthropic
+    ```typescript TypeScript (OpenAI SDK)
+    import OpenAI from "openai";
 
-client = anthropic.Anthropic(
-    base_url="https://your-ai-gateway.ngrok.app",
-    api_key="unused"  # Gateway injects your Anthropic key
-)
+    const client = new OpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
+    });
 
-message = client.messages.create(
-    model="claude-opus-4-6",
-    max_tokens=1024,
-    messages=[{"role": "user", "content": "Hello!"}]
-)
+    const response = await client.chat.completions.create({
+      model: "claude-opus-4-6",
+      messages: [{ role: "user", content: "Hello!" }],
+    });
 
-print(message.content[0].text)
-```
+    console.log(response.choices[0].message.content);
+    ```
 
-```typescript TypeScript (OpenAI SDK)
-import OpenAI from "openai";
+    ```typescript TypeScript (Anthropic SDK)
+    import Anthropic from "@anthropic-ai/sdk";
 
-const client = new OpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "unused",  // Gateway injects your Anthropic key
-});
+    const client = new Anthropic({
+      baseURL: "https://your-ai-gateway.ngrok.app",
+      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
+    });
 
-const response = await client.chat.completions.create({
-  model: "claude-opus-4-6",
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
+    const message = await client.messages.create({
+      model: "claude-opus-4-6",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "Hello!" }],
+    });
 
-```typescript TypeScript (Anthropic SDK)
-import Anthropic from "@anthropic-ai/sdk";
+    console.log(message.content[0].text);
+    ```
 
-const client = new Anthropic({
-  baseURL: "https://your-ai-gateway.ngrok.app",
-  apiKey: "unused",  // Gateway injects your Anthropic key
-});
+    ```typescript Vercel AI SDK
+    import { generateText } from "ai";
+    import { createOpenAI } from "@ai-sdk/openai";
 
-const message = await client.messages.create({
-  model: "claude-opus-4-6",
-  max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
+    const gateway = createOpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
+    });
 
-```typescript Vercel AI SDK
-import { generateText } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
+    const { text } = await generateText({
+      model: gateway("claude-opus-4-6"),
+      prompt: "Hello!",
+    });
 
-const gateway = createOpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "unused",  // Gateway injects your Anthropic key
-});
+    console.log(text);
+    ```
 
-const { text } = await generateText({
-  model: gateway("claude-opus-4-6"),
-  prompt: "Hello!",
-});
+    ```bash cURL
+    curl https://your-ai-gateway.ngrok.app/v1/messages \
+      -H "Content-Type: application/json" \
+      -H "x-api-key: sk-ant-..." \
+      -H "anthropic-version: 2023-06-01" \
+      -d '{
+        "model": "claude-opus-4-6",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
 
-console.log(text);
-```
+## Store key in the gateway
 
-```bash cURL
-curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer unused" \
-  -d '{
-    "model": "claude-opus-4-6",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-</CodeGroup>
+Instead of each client passing their own key, you can store it once in ngrok Secrets and have the gateway inject it automatically.
 
-### Option B: Passthrough (each client uses their own key)
+<Warning>
+Storing your provider key in the gateway makes your endpoint publicly accessible. You must add authorization to prevent unauthorized use and unexpected charges. See [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints).
+</Warning>
 
-No Traffic Policy configuration needed. Each client sends their own Anthropic key and the gateway forwards it.
+<Steps>
+  <Step title="Store your key in ngrok secrets">
+    ```bash
+    ngrok api secrets create \
+      --name anthropic \
+      --secret-data '{"api-key": "sk-ant-..."}'
+    ```
 
-<CodeGroup>
-```python Python (OpenAI SDK)
-from openai import OpenAI
+    Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
+  </Step>
 
-client = OpenAI(
-    base_url="https://your-ai-gateway.ngrok.app/v1",
-    api_key="sk-ant-..."  # Client's own Anthropic key
-)
+  <Step title="Configure your Traffic Policy">
+    ```yaml
+    on_http_request:
+      - type: ai-gateway
+        config:
+          providers:
+            - id: "anthropic"
+              api_keys:
+                - value: ${secrets.get('anthropic', 'api-key')}
+    ```
+  </Step>
 
-response = client.chat.completions.create(
-    model="claude-opus-4-6",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-```
+  <Step title="Make a request">
+    Clients no longer need an Anthropic key—pass any value for `api_key`.
 
-```python Python (Anthropic SDK)
-import anthropic
+    <CodeGroup>
+    ```python Python (OpenAI SDK)
+    from openai import OpenAI
 
-client = anthropic.Anthropic(
-    base_url="https://your-ai-gateway.ngrok.app",
-    api_key="sk-ant-..."  # Client's own Anthropic key
-)
+    client = OpenAI(
+        base_url="https://your-ai-gateway.ngrok.app/v1",
+        api_key="unused"  # Gateway injects your Anthropic key
+    )
 
-message = client.messages.create(
-    model="claude-opus-4-6",
-    max_tokens=1024,
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-```
+    response = client.chat.completions.create(
+        model="claude-opus-4-6",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-```typescript TypeScript (OpenAI SDK)
-import OpenAI from "openai";
+    print(response.choices[0].message.content)
+    ```
 
-const client = new OpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "sk-ant-...",  // Client's own Anthropic key
-});
+    ```python Python (Anthropic SDK)
+    import anthropic
 
-const response = await client.chat.completions.create({
-  model: "claude-opus-4-6",
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
+    client = anthropic.Anthropic(
+        base_url="https://your-ai-gateway.ngrok.app",
+        api_key="unused"  # Gateway injects your Anthropic key
+    )
 
-```typescript TypeScript (Anthropic SDK)
-import Anthropic from "@anthropic-ai/sdk";
+    message = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-const client = new Anthropic({
-  baseURL: "https://your-ai-gateway.ngrok.app",
-  apiKey: "sk-ant-...",  // Client's own Anthropic key
-});
+    print(message.content[0].text)
+    ```
 
-const message = await client.messages.create({
-  model: "claude-opus-4-6",
-  max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
+    ```typescript TypeScript (OpenAI SDK)
+    import OpenAI from "openai";
 
-```typescript Vercel AI SDK
-import { generateText } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
+    const client = new OpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "unused",  // Gateway injects your Anthropic key
+    });
 
-const gateway = createOpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "sk-ant-...",  // Client's own Anthropic key
-});
+    const response = await client.chat.completions.create({
+      model: "claude-opus-4-6",
+      messages: [{ role: "user", content: "Hello!" }],
+    });
 
-const { text } = await generateText({
-  model: gateway("claude-opus-4-6"),
-  prompt: "Hello!",
-});
-```
+    console.log(response.choices[0].message.content);
+    ```
 
-```bash cURL
-curl https://your-ai-gateway.ngrok.app/v1/messages \
-  -H "Content-Type: application/json" \
-  -H "x-api-key: sk-ant-..." \
-  -H "anthropic-version: 2023-06-01" \
-  -d '{
-    "model": "claude-opus-4-6",
-    "max_tokens": 1024,
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-</CodeGroup>
+    ```typescript TypeScript (Anthropic SDK)
+    import Anthropic from "@anthropic-ai/sdk";
+
+    const client = new Anthropic({
+      baseURL: "https://your-ai-gateway.ngrok.app",
+      apiKey: "unused",  // Gateway injects your Anthropic key
+    });
+
+    const message = await client.messages.create({
+      model: "claude-opus-4-6",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "Hello!" }],
+    });
+
+    console.log(message.content[0].text);
+    ```
+
+    ```typescript Vercel AI SDK
+    import { generateText } from "ai";
+    import { createOpenAI } from "@ai-sdk/openai";
+
+    const gateway = createOpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "unused",  // Gateway injects your Anthropic key
+    });
+
+    const { text } = await generateText({
+      model: gateway("claude-opus-4-6"),
+      prompt: "Hello!",
+    });
+
+    console.log(text);
+    ```
+
+    ```bash cURL
+    curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer unused" \
+      -d '{
+        "model": "claude-opus-4-6",
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
 
 ## Explicit provider routing
 

--- a/ai-gateway/providers/openai.mdx
+++ b/ai-gateway/providers/openai.mdx
@@ -5,13 +5,9 @@ description: Use OpenAI models through the ngrok AI Gateway.
 
 [OpenAI](https://openai.com) provides GPT and o-series models. The AI Gateway supports OpenAI as a **managed provider**—no OpenAI account needed—and also works with your own OpenAI API key.
 
-## Using with ngrok-managed keys
+## Managed keys setup
 
-No OpenAI account needed. [AI Gateway API Keys](/ai-gateway/concepts/api-keys) include access to OpenAI models—ngrok manages authentication automatically.
-
-**Prerequisites:**
-- An AI Gateway endpoint ([quickstart](/ai-gateway/quickstart))
-- An [AI Gateway API Key](/ai-gateway/concepts/api-keys)
+No OpenAI account needed. Follow the [quickstart](/ai-gateway/quickstart) to create your gateway and API key, then point your SDK at the gateway:
 
 <CodeGroup>
 ```python Python
@@ -74,159 +70,181 @@ curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
 ```
 </CodeGroup>
 
-## Using your own OpenAI key (BYOK)
+## Bring your own key
 
-Store your OpenAI key in the gateway and use it centrally across all clients, or forward your key directly in passthrough mode.
+Use your own OpenAI API key. Pass it directly—the gateway forwards it to OpenAI.
 
-### Option A: Store key in the gateway (recommended)
+<Steps>
+  <Step title="Create an AI Gateway">
+    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint.
+  </Step>
 
-Your clients authenticate with the gateway; the gateway injects your OpenAI key on their behalf.
+  <Step title="Get an OpenAI API key">
+    Create an account at [platform.openai.com](https://platform.openai.com) and generate an API key. Keys start with `sk-proj-`.
+  </Step>
 
-**1. Store your key in ngrok secrets**
+  <Step title="Make a request">
+    Pass your key directly—the gateway forwards it to OpenAI.
 
-```bash
-ngrok api secrets create \
-  --name openai \
-  --secret-data '{"api-key": "sk-proj-..."}'
-```
+    <CodeGroup>
+    ```python Python
+    from openai import OpenAI
 
-Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
+    client = OpenAI(
+        base_url="https://your-ai-gateway.ngrok.app/v1",
+        api_key="sk-proj-..."  # Your OpenAI key, forwarded by gateway
+    )
 
-**2. Configure your Traffic Policy**
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-```yaml
-on_http_request:
-  - type: ai-gateway
-    config:
-      providers:
-        - id: "openai"
-          api_keys:
-            - value: ${secrets.get('openai', 'api-key')}
-```
+    print(response.choices[0].message.content)
+    ```
 
-**3. Make a request**
+    ```typescript TypeScript
+    import OpenAI from "openai";
 
-Your clients send any key (or `"unused"`)—the gateway substitutes your stored OpenAI key.
+    const client = new OpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "sk-proj-...",  // Your OpenAI key, forwarded by gateway
+    });
 
-<CodeGroup>
-```python Python
-from openai import OpenAI
+    const response = await client.chat.completions.create({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello!" }],
+    });
 
-client = OpenAI(
-    base_url="https://your-ai-gateway.ngrok.app/v1",
-    api_key="unused"  # Gateway injects your OpenAI key
-)
+    console.log(response.choices[0].message.content);
+    ```
 
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
+    ```typescript Vercel AI SDK
+    import { generateText } from "ai";
+    import { createOpenAI } from "@ai-sdk/openai";
 
-print(response.choices[0].message.content)
-```
+    const gateway = createOpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "sk-proj-...",  // Your OpenAI key, forwarded by gateway
+    });
 
-```typescript TypeScript
-import OpenAI from "openai";
+    const { text } = await generateText({
+      model: gateway("gpt-4o"),
+      prompt: "Hello!",
+    });
 
-const client = new OpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "unused",  // Gateway injects your OpenAI key
-});
+    console.log(text);
+    ```
 
-const response = await client.chat.completions.create({
-  model: "gpt-4o",
-  messages: [{ role: "user", content: "Hello!" }],
-});
+    ```bash cURL
+    curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer sk-proj-..." \
+      -d '{
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
 
-console.log(response.choices[0].message.content);
-```
+## Store key in the gateway
 
-```typescript Vercel AI SDK
-import { generateText } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
+Instead of each client passing their own key, you can store it once in ngrok Secrets and have the gateway inject it automatically.
 
-const gateway = createOpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "unused",  // Gateway injects your OpenAI key
-});
+<Warning>
+Storing your provider key in the gateway makes your endpoint publicly accessible. You must add authorization to prevent unauthorized use and unexpected charges. See [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints).
+</Warning>
 
-const { text } = await generateText({
-  model: gateway("gpt-4o"),
-  prompt: "Hello!",
-});
+<Steps>
+  <Step title="Store your key in ngrok secrets">
+    ```bash
+    ngrok api secrets create \
+      --name openai \
+      --secret-data '{"api-key": "sk-proj-..."}'
+    ```
 
-console.log(text);
-```
+    Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
+  </Step>
 
-```bash cURL
-curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer unused" \
-  -d '{
-    "model": "gpt-4o",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-</CodeGroup>
+  <Step title="Configure your Traffic Policy">
+    ```yaml
+    on_http_request:
+      - type: ai-gateway
+        config:
+          providers:
+            - id: "openai"
+              api_keys:
+                - value: ${secrets.get('openai', 'api-key')}
+    ```
+  </Step>
 
-### Option B: Passthrough (each client uses their own key)
+  <Step title="Make a request">
+    Clients no longer need an OpenAI key—pass any value for `api_key`.
 
-No Traffic Policy configuration needed. Each client sends their own OpenAI key and the gateway forwards it.
+    <CodeGroup>
+    ```python Python
+    from openai import OpenAI
 
-<CodeGroup>
-```python Python
-from openai import OpenAI
+    client = OpenAI(
+        base_url="https://your-ai-gateway.ngrok.app/v1",
+        api_key="unused"  # Gateway injects your OpenAI key
+    )
 
-client = OpenAI(
-    base_url="https://your-ai-gateway.ngrok.app/v1",
-    api_key="sk-proj-..."  # Client's own OpenAI key, forwarded by gateway
-)
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
 
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-```
+    print(response.choices[0].message.content)
+    ```
 
-```typescript TypeScript
-import OpenAI from "openai";
+    ```typescript TypeScript
+    import OpenAI from "openai";
 
-const client = new OpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "sk-proj-...",  // Client's own OpenAI key, forwarded by gateway
-});
+    const client = new OpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "unused",  // Gateway injects your OpenAI key
+    });
 
-const response = await client.chat.completions.create({
-  model: "gpt-4o",
-  messages: [{ role: "user", content: "Hello!" }],
-});
-```
+    const response = await client.chat.completions.create({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello!" }],
+    });
 
-```typescript Vercel AI SDK
-import { generateText } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
+    console.log(response.choices[0].message.content);
+    ```
 
-const gateway = createOpenAI({
-  baseURL: "https://your-ai-gateway.ngrok.app/v1",
-  apiKey: "sk-proj-...",  // Client's own OpenAI key, forwarded by gateway
-});
+    ```typescript Vercel AI SDK
+    import { generateText } from "ai";
+    import { createOpenAI } from "@ai-sdk/openai";
 
-const { text } = await generateText({
-  model: gateway("gpt-4o"),
-  prompt: "Hello!",
-});
-```
+    const gateway = createOpenAI({
+      baseURL: "https://your-ai-gateway.ngrok.app/v1",
+      apiKey: "unused",  // Gateway injects your OpenAI key
+    });
 
-```bash cURL
-curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-proj-..." \
-  -d '{
-    "model": "gpt-4o",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-</CodeGroup>
+    const { text } = await generateText({
+      model: gateway("gpt-4o"),
+      prompt: "Hello!",
+    });
+
+    console.log(text);
+    ```
+
+    ```bash cURL
+    curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer unused" \
+      -d '{
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
 
 ## Explicit provider routing
 

--- a/ai-gateway/quickstart.mdx
+++ b/ai-gateway/quickstart.mdx
@@ -4,6 +4,10 @@ icon: rocket
 description: Get your AI Gateway running in minutes.
 ---
 
+<Note>
+This quickstart uses AI Gateway API Keys with ngrok-managed credits. If you'd rather bring your own OpenAI, Anthropic, or other provider keys, see [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys).
+</Note>
+
 ## Before you start
 
 You'll need an [ngrok account](https://dashboard.ngrok.com/signup) on the [Pay-as-you-go](https://ngrok.com/pricing) plan.


### PR DESCRIPTION
## Summary

- Restructures Anthropic and OpenAI provider pages to simplify managed keys setup and BYOK sections
- Adds a BYOK note to the quickstart directing users to the bring-your-own-keys doc