### PR TITLE
Correct pod metadata field naming

### DIFF
--- a/snippets/traffic-policy/variables/conn.k8s.mdx
+++ b/snippets/traffic-policy/variables/conn.k8s.mdx
@@ -69,7 +69,7 @@ expressions:
 
 ### `conn.k8s.pod.metadata.annotations`
 
-A map of pod annotations prefixed with `k8s.ngrok.com/`. Only annotations with the `k8s.ngrok.com/` prefix are included. The combined size of all included annotations must not exceed 1024 bytes. If the limit is exceeded, `conn.k8s.pod.metadata.error_code` will be set to `ERR_NGROK_28000` instead.
+A map of pod annotations prefixed with `k8s.ngrok.com/`. Only annotations with the `k8s.ngrok.com/` prefix are included. The combined size of all included annotations must not exceed 1024 bytes. If the limit is exceeded, `conn.k8s.pod.metadata.error_code` will be set to `ERR_NGROK_28000` and a truncated annotation map being returned.
 
 <CodeGroup>
 ```yaml policy.yml


### PR DESCRIPTION
Docs previously incorrectly documented field prefixes