### PR TITLE
docs: Fix typo in TCP Endpoints documentation causing broken link

### DIFF
--- a/universal-gateway/tcp.mdx
+++ b/universal-gateway/tcp.mdx
@@ -300,7 +300,7 @@ handling errors.
 ## API
 
 TCP Endpoints can be created programmatically. Consult the documentation on
-[Endpoint APIs](/api-reference/endpoints/list.
+[Endpoint APIs](/api-reference/endpoints/list).
 
 ## Pricing
 


### PR DESCRIPTION
Minor Bug Fix in Documentation that causes broken link, fixes #2056 