### PR TITLE
Update due to operator changed for useExperimentalGatewayApi and endpoindURI

### DIFF
--- a/k8s/crds/boundendpoint.mdx
+++ b/k8s/crds/boundendpoint.mdx
@@ -42,7 +42,7 @@ metadata:
   name: <string>
   namespace: <string>
 spec:
-  endpointURI: <string>                # required
+  endpointURL: <string>                # required
   scheme: <string>                     # required
   port: <uint16>                       # required
   target:                              # required
@@ -73,14 +73,14 @@ The following sections outline each field of the `BoundEndpoint` custom resource
 
 | Field Name                             | Type            | Required | Default | Description                                                                                             |
 | -------------------------------------- | --------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| [`spec.endpointURI`](#specendpointuri) | `string`        | yes      | none    | The unique identifier representing the BoundEndpoint, format: `<scheme>://<service>.<namespace>:<port>` |
+| [`spec.endpointURL`](#specendpointurl) | `string`        | yes      | none    | The unique identifier representing the BoundEndpoint, format: `<scheme>://<service>.<namespace>:<port>` |
 | [`spec.scheme`](#specscheme)           | `string` (enum) | yes      | none    | Describes how the data packets are framed by the pod forwarders mTLS connection                         |
 | [`spec.port`](#specport)               | `uint16`        | yes      | none    | The Service port this Endpoint uses internally to communicate with its Upstream Service                 |
 | [`spec.target`](#spectarget)           | `Object`        | yes      | none    | The target Service that this Endpoint projects                                                          |
 
-### `spec.endpointURI`
+### `spec.endpointURL`
 
-The endpointURI is the unique identifier representing the BoundEndpoint + its Endpoints
+The endpointURL is the unique identifier representing the BoundEndpoint + its Endpoints
 
 - Format: `<scheme>://<service>.<namespace>:<port>`
 
@@ -474,7 +474,7 @@ metadata:
   name: ngrok-22680758-eb09-576e-a7ac-dc3728458dfc
   namespace: ngrok-operator
 spec:
-  endpointURI: http://my-service.my-namespace:80
+  endpointURL: http://my-service.my-namespace:80
   port: 10001
   scheme: http
   target:

--- a/k8s/guides/bindings.mdx
+++ b/k8s/guides/bindings.mdx
@@ -148,7 +148,7 @@ metadata:
   name: ngrok-22680758-eb09-576e-a7ac-dc3728458dfc
   namespace: ngrok-operator
 spec:
-  endpointURI: http://my-bound-service.my-namespace:80
+  endpointURL: http://my-bound-service.my-namespace:80
   port: 10001
   scheme: http
   target:

--- a/snippets/examples/k8s/install-gateway-api.mdx
+++ b/snippets/examples/k8s/install-gateway-api.mdx
@@ -22,7 +22,7 @@ helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
   --create-namespace \
   --set credentials.apiKey=$NGROK_API_KEY \
   --set credentials.authtoken=$NGROK_AUTHTOKEN \
-  --set useExperimentalGatewayApi=true
+  --set gateway.enabled=true
 ```
 
 Install the GatewayClass object:


### PR DESCRIPTION
Changes in the operator:

- useExperimentalGatewayApi deprecated to gateway.enabled ([PR](https://github.com/ngrok/ngrok-operator/pull/778))
- endpointURI fix to endpointURL ([PR](https://github.com/ngrok/ngrok-operator/pull/779))