### PR TITLE
Fix vale action

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VALE_URL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/errata-ai/vale/releases/latest" \
+            "https://api.github.com/repos/vale-cli/vale/releases/latest" \
             | jq -r '.assets[] | select(.name | contains("Linux_64-bit")) | .browser_download_url')
           wget -q "$VALE_URL" -O vale.tar.gz
           tar -xzf vale.tar.gz -C /usr/local/bin


### PR DESCRIPTION
Fix vale CI

This curls for a release that isn't present anymore https://github.com/errata-ai 

Everything got moved to https://github.com/vale-cli/vale

There is also a vale action now, but i don't know enough about this to want to bite off refactoring this. Maybe something we can throw copilot at