### PR TITLE
Pricing Correction for BYOD

### DIFF
--- a/universal-gateway/domains.mdx
+++ b/universal-gateway/domains.mdx
@@ -213,6 +213,6 @@ the [Pricing page](https://ngrok.com/pricing) for details.
 | Feature                | Plans                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------- |
 | Domains                | All plans. The Domain name is automatically assigned on Free; you may choose it on paid plans. |
-| Bring-your-own domains | Personal, Hobbyist, Pay-as-you-go                                       |
+| Bring-your-own domains | Pay-as-you-go                                       |
 | Wildcard endpoints     | Pay-as-you-go                                                                     |
 | Random domain generation | Paid plans only                                                                |


### PR DESCRIPTION
`domains.mdx` says Hobbyist plans get BYOD but they don't according to our pricing page and `how-ngrok-charges.mdx`