### PR TITLE
Add deprecated indicator to all deprecated API reference pages

### DIFF
--- a/api-reference/botusers/create.mdx
+++ b/api-reference/botusers/create.mdx
@@ -3,6 +3,6 @@ openapi: post /bot_users
 description: "Create a new bot user for programmatic API access. Note: Bot Users are deprecated in favor of Service Users."
 ---
 
-<Tip>
-Use the [Service Users](/api-reference/service-users) endpoints instead. Bot Users will soon be deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/botusers/delete.mdx
+++ b/api-reference/botusers/delete.mdx
@@ -3,6 +3,6 @@ openapi: delete /bot_users/{id}
 description: "Delete a specific bot user by its unique identifier. Note: Bot Users are deprecated in favor of Service Users."
 ---
 
-<Tip>
-Use the [Service User](/api-reference/service-users) endpoints instead. Bot Users will soon be deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/botusers/get.mdx
+++ b/api-reference/botusers/get.mdx
@@ -3,6 +3,6 @@ openapi: get /bot_users/{id}
 description: "Retrieve details about a specific bot user. Note: Bot Users are deprecated in favor of Service Users."
 ---
 
-<Tip>
-Use the [Service User](/api-reference/service-users) endpoints instead. Bot Users will soon be deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/botusers/list.mdx
+++ b/api-reference/botusers/list.mdx
@@ -3,6 +3,6 @@ openapi: get /bot_users
 description: "List all bot users in your ngrok account. Note: Bot Users are deprecated in favor of Service Users."
 ---
 
-<Tip>
-Use the [Service User](/api-reference/service-users) endpoints instead. Bot Users will soon be deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/botusers/update.mdx
+++ b/api-reference/botusers/update.mdx
@@ -3,6 +3,6 @@ openapi: patch /bot_users/{id}
 description: "Update an existing bot user's configuration. Note: Bot Users are deprecated in favor of Service Users."
 ---
 
-<Tip>
-Use the [Service Users](/api-reference/service-users) endpoints instead. Bot Users will soon be deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutebackendmodule/delete.mdx
+++ b/api-reference/edgeroutebackendmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/backend
 description: Remove the backend module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutebackendmodule/get.mdx
+++ b/api-reference/edgeroutebackendmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/backend
 description: Retrieve the backend module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutebackendmodule/replace.mdx
+++ b/api-reference/edgeroutebackendmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/backend
 description: Replace or configure the backend module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecircuitbreakermodule/delete.mdx
+++ b/api-reference/edgeroutecircuitbreakermodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/circuit_breaker
 description: Remove the circuit breaker module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecircuitbreakermodule/get.mdx
+++ b/api-reference/edgeroutecircuitbreakermodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/circuit_breaker
 description: Retrieve the circuit breaker module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecircuitbreakermodule/replace.mdx
+++ b/api-reference/edgeroutecircuitbreakermodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/circuit_breaker
 description: Replace or configure the circuit breaker module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecompressionmodule/delete.mdx
+++ b/api-reference/edgeroutecompressionmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/compression
 description: Remove the compression module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecompressionmodule/get.mdx
+++ b/api-reference/edgeroutecompressionmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/compression
 description: Retrieve the compression module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutecompressionmodule/replace.mdx
+++ b/api-reference/edgeroutecompressionmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/compression
 description: Replace or configure the compression module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteiprestrictionmodule/delete.mdx
+++ b/api-reference/edgerouteiprestrictionmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/ip_restriction
 description: Remove the IP restriction module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteiprestrictionmodule/get.mdx
+++ b/api-reference/edgerouteiprestrictionmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/ip_restriction
 description: Retrieve the IP restriction module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteiprestrictionmodule/replace.mdx
+++ b/api-reference/edgerouteiprestrictionmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/ip_restriction
 description: Replace or configure the IP restriction module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoauthmodule/delete.mdx
+++ b/api-reference/edgerouteoauthmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/oauth
 description: Remove the OAuth authentication module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoauthmodule/get.mdx
+++ b/api-reference/edgerouteoauthmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/oauth
 description: Retrieve the OAuth authentication module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoauthmodule/replace.mdx
+++ b/api-reference/edgerouteoauthmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/oauth
 description: Replace or configure the OAuth authentication module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoidcmodule/delete.mdx
+++ b/api-reference/edgerouteoidcmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/oidc
 description: Remove the OIDC authentication module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoidcmodule/get.mdx
+++ b/api-reference/edgerouteoidcmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/oidc
 description: Retrieve the OIDC authentication module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteoidcmodule/replace.mdx
+++ b/api-reference/edgerouteoidcmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/oidc
 description: Replace or configure the OIDC authentication module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouterequestheadersmodule/delete.mdx
+++ b/api-reference/edgerouterequestheadersmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/request_headers
 description: Remove the request headers module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouterequestheadersmodule/get.mdx
+++ b/api-reference/edgerouterequestheadersmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/request_headers
 description: Retrieve the request headers module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouterequestheadersmodule/replace.mdx
+++ b/api-reference/edgerouterequestheadersmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/request_headers
 description: Replace or configure the request headers module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteresponseheadersmodule/delete.mdx
+++ b/api-reference/edgerouteresponseheadersmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/response_headers
 description: Remove the response headers module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteresponseheadersmodule/get.mdx
+++ b/api-reference/edgerouteresponseheadersmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/response_headers
 description: Retrieve the response headers module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteresponseheadersmodule/replace.mdx
+++ b/api-reference/edgerouteresponseheadersmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/response_headers
 description: Replace or configure the response headers module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutesamlmodule/delete.mdx
+++ b/api-reference/edgeroutesamlmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/saml
 description: Remove the SAML authentication module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutesamlmodule/get.mdx
+++ b/api-reference/edgeroutesamlmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/saml
 description: Retrieve the SAML authentication module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutesamlmodule/replace.mdx
+++ b/api-reference/edgeroutesamlmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/saml
 description: Replace or configure the SAML authentication module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutetrafficpolicymodule/delete.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/delete.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: delete /edges/https/{edge_id}/routes/{id}/traffic_policy
-description: Remove the traffic policy module configuration from a specific HTTPS edge route.
+description: Remove the Traffic Policy module configuration from a specific HTTPS edge route.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/edgeroutetrafficpolicymodule/delete.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/traffic_policy
 description: Remove the traffic policy module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutetrafficpolicymodule/get.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/traffic_policy
 description: Retrieve the traffic policy module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutetrafficpolicymodule/get.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/get.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: get /edges/https/{edge_id}/routes/{id}/traffic_policy
-description: Retrieve the traffic policy module configuration for a specific HTTPS edge route.
+description: Retrieve the Traffic Policy module configuration for a specific HTTPS edge route.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/edgeroutetrafficpolicymodule/replace.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/replace.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: put /edges/https/{edge_id}/routes/{id}/traffic_policy
-description: Replace or configure the traffic policy module for a specific HTTPS edge route.
+description: Replace or configure the Traffic Policy module for a specific HTTPS edge route.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/edgeroutetrafficpolicymodule/replace.mdx
+++ b/api-reference/edgeroutetrafficpolicymodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/traffic_policy
 description: Replace or configure the traffic policy module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteuseragentfiltermodule/delete.mdx
+++ b/api-reference/edgerouteuseragentfiltermodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/user_agent_filter
 description: Remove the user agent filter module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteuseragentfiltermodule/get.mdx
+++ b/api-reference/edgerouteuseragentfiltermodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/user_agent_filter
 description: Retrieve the user agent filter module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgerouteuseragentfiltermodule/replace.mdx
+++ b/api-reference/edgerouteuseragentfiltermodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/user_agent_filter
 description: Replace or configure the user agent filter module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebhookverificationmodule/delete.mdx
+++ b/api-reference/edgeroutewebhookverificationmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/webhook_verification
 description: Remove the webhook verification module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebhookverificationmodule/get.mdx
+++ b/api-reference/edgeroutewebhookverificationmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/webhook_verification
 description: Retrieve the webhook verification module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebhookverificationmodule/replace.mdx
+++ b/api-reference/edgeroutewebhookverificationmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/webhook_verification
 description: Replace or configure the webhook verification module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebsockettcpconvertermodule/delete.mdx
+++ b/api-reference/edgeroutewebsockettcpconvertermodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}/websocket_tcp_converter
 description: Remove the WebSocket to TCP converter module configuration from a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebsockettcpconvertermodule/get.mdx
+++ b/api-reference/edgeroutewebsockettcpconvertermodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}/websocket_tcp_converter
 description: Retrieve the WebSocket to TCP converter module configuration for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeroutewebsockettcpconvertermodule/replace.mdx
+++ b/api-reference/edgeroutewebsockettcpconvertermodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{edge_id}/routes/{id}/websocket_tcp_converter
 description: Replace or configure the WebSocket to TCP converter module for a specific HTTPS edge route.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttps/create.mdx
+++ b/api-reference/edgeshttps/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /edges/https
 description: Create a new HTTPS edge configuration for routing and managing HTTPS traffic with advanced features.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttps/delete.mdx
+++ b/api-reference/edgeshttps/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{id}
 description: Delete a specific HTTPS edge configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttps/get.mdx
+++ b/api-reference/edgeshttps/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{id}
 description: Retrieve details about a specific HTTPS edge configuration including its routes and modules.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttps/list.mdx
+++ b/api-reference/edgeshttps/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https
 description: List all HTTPS edge configurations in your ngrok account with optional filtering and pagination.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttps/update.mdx
+++ b/api-reference/edgeshttps/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /edges/https/{id}
 description: Update an existing HTTPS edge configuration with new settings, domains, or modules.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttpsroutes/create.mdx
+++ b/api-reference/edgeshttpsroutes/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /edges/https/{edge_id}/routes
 description: Create a new route on a specific HTTPS edge for matching and processing incoming requests.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttpsroutes/delete.mdx
+++ b/api-reference/edgeshttpsroutes/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{edge_id}/routes/{id}
 description: Delete a specific route from an HTTPS edge by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttpsroutes/get.mdx
+++ b/api-reference/edgeshttpsroutes/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{edge_id}/routes/{id}
 description: Retrieve details about a specific route on an HTTPS edge including its match rules and modules.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgeshttpsroutes/update.mdx
+++ b/api-reference/edgeshttpsroutes/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /edges/https/{edge_id}/routes/{id}
 description: Update an existing route on an HTTPS edge with new match rules or module configurations.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestcp/create.mdx
+++ b/api-reference/edgestcp/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /edges/tcp
 description: Create a new TCP edge configuration for routing and managing raw TCP traffic connections.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestcp/delete.mdx
+++ b/api-reference/edgestcp/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tcp/{id}
 description: Delete a specific TCP edge configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestcp/get.mdx
+++ b/api-reference/edgestcp/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tcp/{id}
 description: Retrieve details about a specific TCP edge configuration including its backend and settings.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestcp/list.mdx
+++ b/api-reference/edgestcp/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tcp
 description: List all TCP edge configurations in your ngrok account with optional filtering and pagination.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestcp/update.mdx
+++ b/api-reference/edgestcp/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /edges/tcp/{id}
 description: Update an existing TCP edge configuration with new backend settings or connection parameters.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestls/create.mdx
+++ b/api-reference/edgestls/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /edges/tls
 description: Create a new TLS edge configuration for routing and managing TLS-terminated traffic.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestls/delete.mdx
+++ b/api-reference/edgestls/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}
 description: Delete a specific TLS edge configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestls/get.mdx
+++ b/api-reference/edgestls/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}
 description: Retrieve details about a specific TLS edge configuration including its certificates and backend.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestls/list.mdx
+++ b/api-reference/edgestls/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls
 description: List all TLS edge configurations in your ngrok account with optional filtering and pagination.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/edgestls/update.mdx
+++ b/api-reference/edgestls/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /edges/tls/{id}
 description: Update an existing TLS edge configuration with new certificates, backend settings, or modules.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/failoverbackends/create.mdx
+++ b/api-reference/failoverbackends/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /backends/failover
 description: Create a new failover backend for automatically switching between primary and secondary backends based on health.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/failoverbackends/delete.mdx
+++ b/api-reference/failoverbackends/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /backends/failover/{id}
 description: Delete a specific failover backend configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/failoverbackends/get.mdx
+++ b/api-reference/failoverbackends/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/failover/{id}
 description: Retrieve details about a specific failover backend including its primary and secondary backends.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/failoverbackends/list.mdx
+++ b/api-reference/failoverbackends/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/failover
 description: List all failover backend configurations in your ngrok account with optional filtering and pagination.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/failoverbackends/update.mdx
+++ b/api-reference/failoverbackends/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /backends/failover/{id}
 description: Update an existing failover backend with new primary or secondary backend configurations.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpresponsebackends/create.mdx
+++ b/api-reference/httpresponsebackends/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /backends/http_response
 description: Create a new HTTP response backend for returning custom HTTP responses without forwarding requests.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpresponsebackends/delete.mdx
+++ b/api-reference/httpresponsebackends/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /backends/http_response/{id}
 description: Delete a specific HTTP response backend configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpresponsebackends/get.mdx
+++ b/api-reference/httpresponsebackends/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/http_response/{id}
 description: Retrieve details about a specific HTTP response backend including its response configuration.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpresponsebackends/list.mdx
+++ b/api-reference/httpresponsebackends/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/http_response
 description: List all HTTP response backend configurations in your ngrok account with optional filtering.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpresponsebackends/update.mdx
+++ b/api-reference/httpresponsebackends/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /backends/http_response/{id}
 description: Update an existing HTTP response backend with new response settings or metadata.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgemutualtlsmodule/delete.mdx
+++ b/api-reference/httpsedgemutualtlsmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{id}/mutual_tls
 description: Remove the mutual TLS module configuration from a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgemutualtlsmodule/get.mdx
+++ b/api-reference/httpsedgemutualtlsmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{id}/mutual_tls
 description: Retrieve the mutual TLS module configuration for a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgemutualtlsmodule/replace.mdx
+++ b/api-reference/httpsedgemutualtlsmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{id}/mutual_tls
 description: Replace or configure the mutual TLS module for a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgetlsterminationmodule/delete.mdx
+++ b/api-reference/httpsedgetlsterminationmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/https/{id}/tls_termination
 description: Remove the TLS termination module configuration from a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgetlsterminationmodule/get.mdx
+++ b/api-reference/httpsedgetlsterminationmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/https/{id}/tls_termination
 description: Retrieve the TLS termination module configuration for a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/httpsedgetlsterminationmodule/replace.mdx
+++ b/api-reference/httpsedgetlsterminationmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/https/{id}/tls_termination
 description: Replace or configure the TLS termination module for a specific HTTPS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/staticbackends/create.mdx
+++ b/api-reference/staticbackends/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /backends/static
 description: Create a new static backend for forwarding traffic to a fixed upstream server address.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/staticbackends/delete.mdx
+++ b/api-reference/staticbackends/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /backends/static/{id}
 description: Delete a specific static backend configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/staticbackends/get.mdx
+++ b/api-reference/staticbackends/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/static/{id}
 description: Retrieve details about a specific static backend including its upstream address configuration.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/staticbackends/list.mdx
+++ b/api-reference/staticbackends/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/static
 description: List all static backend configurations in your ngrok account with optional filtering.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/staticbackends/update.mdx
+++ b/api-reference/staticbackends/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /backends/static/{id}
 description: Update an existing static backend with a new upstream address or configuration.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgebackendmodule/delete.mdx
+++ b/api-reference/tcpedgebackendmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tcp/{id}/backend
 description: Remove the backend module configuration from a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgebackendmodule/get.mdx
+++ b/api-reference/tcpedgebackendmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tcp/{id}/backend
 description: Retrieve the backend module configuration for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgebackendmodule/replace.mdx
+++ b/api-reference/tcpedgebackendmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tcp/{id}/backend
 description: Replace or configure the backend module for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgeiprestrictionmodule/delete.mdx
+++ b/api-reference/tcpedgeiprestrictionmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tcp/{id}/ip_restriction
 description: Remove the IP restriction module configuration from a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgeiprestrictionmodule/get.mdx
+++ b/api-reference/tcpedgeiprestrictionmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tcp/{id}/ip_restriction
 description: Retrieve the IP restriction module configuration for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgeiprestrictionmodule/replace.mdx
+++ b/api-reference/tcpedgeiprestrictionmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tcp/{id}/ip_restriction
 description: Replace or configure the IP restriction module for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgetrafficpolicymodule/delete.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/delete.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: delete /edges/tcp/{id}/traffic_policy
-description: Remove the traffic policy module configuration from a specific TCP edge.
+description: Remove the Traffic Policy module configuration from a specific TCP edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tcpedgetrafficpolicymodule/delete.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tcp/{id}/traffic_policy
 description: Remove the traffic policy module configuration from a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgetrafficpolicymodule/get.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/get.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: get /edges/tcp/{id}/traffic_policy
-description: Retrieve the traffic policy module configuration for a specific TCP edge.
+description: Retrieve the Traffic Policy module configuration for a specific TCP edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tcpedgetrafficpolicymodule/get.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tcp/{id}/traffic_policy
 description: Retrieve the traffic policy module configuration for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tcpedgetrafficpolicymodule/replace.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/replace.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: put /edges/tcp/{id}/traffic_policy
-description: Replace or configure the traffic policy module for a specific TCP edge.
+description: Replace or configure the Traffic Policy module for a specific TCP edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tcpedgetrafficpolicymodule/replace.mdx
+++ b/api-reference/tcpedgetrafficpolicymodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tcp/{id}/traffic_policy
 description: Replace or configure the traffic policy module for a specific TCP edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgebackendmodule/delete.mdx
+++ b/api-reference/tlsedgebackendmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}/backend
 description: Remove the backend module configuration from a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgebackendmodule/get.mdx
+++ b/api-reference/tlsedgebackendmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}/backend
 description: Retrieve the backend module configuration for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgebackendmodule/replace.mdx
+++ b/api-reference/tlsedgebackendmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tls/{id}/backend
 description: Replace or configure the backend module for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgeiprestrictionmodule/delete.mdx
+++ b/api-reference/tlsedgeiprestrictionmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}/ip_restriction
 description: Remove the IP restriction module configuration from a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgeiprestrictionmodule/get.mdx
+++ b/api-reference/tlsedgeiprestrictionmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}/ip_restriction
 description: Retrieve the IP restriction module configuration for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgeiprestrictionmodule/replace.mdx
+++ b/api-reference/tlsedgeiprestrictionmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tls/{id}/ip_restriction
 description: Replace or configure the IP restriction module for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgemutualtlsmodule/delete.mdx
+++ b/api-reference/tlsedgemutualtlsmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}/mutual_tls
 description: Remove the mutual TLS module configuration from a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgemutualtlsmodule/get.mdx
+++ b/api-reference/tlsedgemutualtlsmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}/mutual_tls
 description: Retrieve the mutual TLS module configuration for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgemutualtlsmodule/replace.mdx
+++ b/api-reference/tlsedgemutualtlsmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tls/{id}/mutual_tls
 description: Replace or configure the mutual TLS module for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetlsterminationmodule/delete.mdx
+++ b/api-reference/tlsedgetlsterminationmodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}/tls_termination
 description: Remove the TLS termination module configuration from a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetlsterminationmodule/get.mdx
+++ b/api-reference/tlsedgetlsterminationmodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}/tls_termination
 description: Retrieve the TLS termination module configuration for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetlsterminationmodule/replace.mdx
+++ b/api-reference/tlsedgetlsterminationmodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tls/{id}/tls_termination
 description: Replace or configure the TLS termination module for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetrafficpolicymodule/delete.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/delete.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: delete /edges/tls/{id}/traffic_policy
-description: Remove the traffic policy module configuration from a specific TLS edge.
+description: Remove the Traffic Policy module configuration from a specific TLS edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tlsedgetrafficpolicymodule/delete.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /edges/tls/{id}/traffic_policy
 description: Remove the traffic policy module configuration from a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetrafficpolicymodule/get.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/get.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: get /edges/tls/{id}/traffic_policy
-description: Retrieve the traffic policy module configuration for a specific TLS edge.
+description: Retrieve the Traffic Policy module configuration for a specific TLS edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tlsedgetrafficpolicymodule/get.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /edges/tls/{id}/traffic_policy
 description: Retrieve the traffic policy module configuration for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tlsedgetrafficpolicymodule/replace.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/replace.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: put /edges/tls/{id}/traffic_policy
-description: Replace or configure the traffic policy module for a specific TLS edge.
+description: Replace or configure the Traffic Policy module for a specific TLS edge.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tlsedgetrafficpolicymodule/replace.mdx
+++ b/api-reference/tlsedgetrafficpolicymodule/replace.mdx
@@ -2,3 +2,7 @@
 openapi: put /edges/tls/{id}/traffic_policy
 description: Replace or configure the traffic policy module for a specific TLS edge.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnelgroupbackends/create.mdx
+++ b/api-reference/tunnelgroupbackends/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /backends/tunnel_group
 description: Create a new tunnel group backend for load balancing across multiple agent endpoints.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnelgroupbackends/create.mdx
+++ b/api-reference/tunnelgroupbackends/create.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: post /backends/tunnel_group
-description: Create a new tunnel group backend for load balancing across multiple agent endpoints.
+description: Create a new tunnel group backend for load balancing across multiple Agent Endpoints.
 ---
 
 import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';

--- a/api-reference/tunnelgroupbackends/delete.mdx
+++ b/api-reference/tunnelgroupbackends/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /backends/tunnel_group/{id}
 description: Delete a specific tunnel group backend configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnelgroupbackends/get.mdx
+++ b/api-reference/tunnelgroupbackends/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/tunnel_group/{id}
 description: Retrieve details about a specific tunnel group backend including its member endpoints.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnelgroupbackends/list.mdx
+++ b/api-reference/tunnelgroupbackends/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/tunnel_group
 description: List all tunnel group backend configurations in your ngrok account with optional filtering.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnelgroupbackends/update.mdx
+++ b/api-reference/tunnelgroupbackends/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /backends/tunnel_group/{id}
 description: Update an existing tunnel group backend with new member endpoints or load balancing settings.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnels/get.mdx
+++ b/api-reference/tunnels/get.mdx
@@ -3,6 +3,6 @@ openapi: get /tunnels/{id}
 description: "Retrieve details about a specific tunnel. Note: The Tunnels endpoint is deprecated in favor of Endpoints."
 ---
 
-<Tip>
-Use the [Endpoints](/api-reference/endpoints/get) endpoints instead. The Tunnels endpoint is deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/tunnels/list.mdx
+++ b/api-reference/tunnels/list.mdx
@@ -3,6 +3,6 @@ openapi: get /tunnels
 description: "List all tunnels in your ngrok account. Note: The Tunnels endpoint is deprecated in favor of Endpoints."
 ---
 
-<Tip>
-Use the [Endpoints](/api-reference/endpoints/list) endpoints instead. The Tunnels endpoint is deprecated.
-</Tip>
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/weightedbackends/create.mdx
+++ b/api-reference/weightedbackends/create.mdx
@@ -2,3 +2,7 @@
 openapi: post /backends/weighted
 description: Create a new weighted backend for distributing traffic across multiple backends based on weights.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/weightedbackends/delete.mdx
+++ b/api-reference/weightedbackends/delete.mdx
@@ -2,3 +2,7 @@
 openapi: delete /backends/weighted/{id}
 description: Delete a specific weighted backend configuration by its unique identifier.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/weightedbackends/get.mdx
+++ b/api-reference/weightedbackends/get.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/weighted/{id}
 description: Retrieve details about a specific weighted backend including its member backends and weights.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/weightedbackends/list.mdx
+++ b/api-reference/weightedbackends/list.mdx
@@ -2,3 +2,7 @@
 openapi: get /backends/weighted
 description: List all weighted backend configurations in your ngrok account with optional filtering.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/api-reference/weightedbackends/update.mdx
+++ b/api-reference/weightedbackends/update.mdx
@@ -2,3 +2,7 @@
 openapi: patch /backends/weighted/{id}
 description: Update an existing weighted backend with new member backends or weight distributions.
 ---
+
+import DeprecatedWarning from '/snippets/api/deprecated-warning.mdx';
+
+<DeprecatedWarning />

--- a/snippets/api/deprecated-warning.mdx
+++ b/snippets/api/deprecated-warning.mdx
@@ -1,0 +1,3 @@
+<Warning>
+**Deprecated:** This API resource is deprecated and may be removed in a future version. Avoid using it for new integrations.
+</Warning>


### PR DESCRIPTION
## Summary
- Create a reusable `DeprecatedWarning` snippet (`snippets/api/deprecated-warning.mdx`) using the `<Warning>` callout component
- Include it on all 120 API reference pages nested under the "Deprecated" navigation group
- Replaces ad-hoc `<Tip>` callouts on botusers and tunnels pages with the standardized component

## Why
Deprecation status is only visible in the sidebar nav grouping — not in the page content itself. AI agents and LLMs reading these pages have no way to know the endpoint is deprecated, causing them to repeatedly suggest deprecated APIs (Edges, Tunnels, Bot Users) in new integrations and specs.

Prior art: `universal-gateway/edges.mdx`, `agent/config/v3.mdx`, and `snippets/shared/warnings/traffic-policy-preview.mdx` all use this same `<Warning>` pattern.

Closes DOC-569