### PR TITLE
Fix unintended markdown parsing

### DIFF
--- a/pricing-limits/index.mdx
+++ b/pricing-limits/index.mdx
@@ -103,7 +103,7 @@ It is ideal for production workloads that require scalability and flexibility.
 
 ### How does the Pay-as-you-go plan work?
 
-You pay a $20/month base fee that includes $20/month of usage covering data transfer, endpoints, connections, and other resources.
+You pay a $20 per month base fee that includes $20 in usage covering data transfer, endpoints, connections, and other resources.
 Usage beyond the included amount is billed monthly based on actual consumption. You can scale your usage up or down as needed.
 
 {/* Unsure of the status of this, I believe that now we have one invoice for paygo per cycle


### PR DESCRIPTION
Turns out `/ /` makes fancy italics with our markdown parser `¯\_(ツ)_/¯`