### PR TITLE
Add pay-as-you-go plan note to custom domains page

### DIFF
--- a/universal-gateway/custom-domains.mdx
+++ b/universal-gateway/custom-domains.mdx
@@ -10,6 +10,10 @@ This guide shows you how to use any domain name you already own, such as `app.yo
 ngrok is not a domain registrar; you must already own a domain name to use it with ngrok.
 </Note>
 
+<Note>
+Custom domains are only available on the [Pay-as-you-go](https://ngrok.com/pricing) plan.
+</Note>
+
 ## 1. Add your domain in ngrok
 
 On your dashboard's [Domain page](https://dashboard.ngrok.com/domains), click the **New Domain** button to add your domain to your ngrok account.


### PR DESCRIPTION
## Summary
- Adds a `<Note>` callout to the custom domains page indicating that custom domains are only available on the Pay-as-you-go plan
- Matches the existing callout pattern used for other paid features (e.g., wildcard endpoints in `domains.mdx`)

## Test plan
- [ ] Verify the note renders correctly on the custom domains page

🤖 Generated with [Claude Code](https://claude.com/claude-code)