### PR TITLE
aigpk docs

### DIFF
--- a/ai-gateway/concepts/api-keys.mdx
+++ b/ai-gateway/concepts/api-keys.mdx
@@ -124,6 +124,17 @@ Set `model: "ngrok/auto"` and the gateway picks the best available model from Op
 }
 ```
 
+## Attaching your own provider keys
+
+You can attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy configuration needed. This is useful when you have your own provider accounts but want simpler setup than BYOK.
+
+When you authenticate with an AI Gateway API Key, the gateway checks for keys in this order for each provider:
+1. Provider keys in your Traffic Policy (`providers[].api_keys`): always takes precedence
+2. Keys you've attached to the AI Gateway API Key: used when no Traffic Policy key is configured
+3. ngrok-managed keys: fallback for OpenAI and Anthropic (requires credits)
+
+See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for setup instructions.
+
 ## Mixing AI Gateway API Keys with your own provider keys
 
 You can use both AI Gateway API Keys and [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys) in the same gateway. This is useful when you want ngrok to handle OpenAI and Anthropic, but you also need access to other providers like Google.

--- a/ai-gateway/concepts/api-keys.mdx
+++ b/ai-gateway/concepts/api-keys.mdx
@@ -128,9 +128,9 @@ Set `model: "ngrok/auto"` and the gateway picks the best available model from Op
 
 You can attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy configuration needed. This is useful when you have your own provider accounts but want simpler setup than BYOK.
 
-When you authenticate with an AI Gateway API Key, the gateway checks for keys in this order for each provider:
-1. Provider keys in your Traffic Policy (`providers[].api_keys`): always takes precedence
-2. Keys you've attached to the AI Gateway API Key: used when no Traffic Policy key is configured
+When you authenticate with an AI Gateway API Key, the gateway selects a provider key for each provider as follows:
+1. Keys you've attached to the AI Gateway API Key: used exclusively when present for that provider
+2. Provider keys in your Traffic Policy (`providers[].api_keys`): used only if no attached key exists for that provider
 3. ngrok-managed keys: fallback for OpenAI and Anthropic (requires credits)
 
 See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for setup instructions.

--- a/ai-gateway/concepts/api-keys.mdx
+++ b/ai-gateway/concepts/api-keys.mdx
@@ -126,7 +126,7 @@ Set `model: "ngrok/auto"` and the gateway picks the best available model from Op
 
 ## Attaching your own provider keys
 
-Attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy or Vaults & Secrets configuration.
+Attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts them at rest and uses them automatically when routing requests.
 
 When you authenticate with an AI Gateway API Key, the gateway selects a provider key for each provider as follows:
 1. Keys you've attached to the AI Gateway API Key: used exclusively when present for that provider

--- a/ai-gateway/concepts/api-keys.mdx
+++ b/ai-gateway/concepts/api-keys.mdx
@@ -126,11 +126,11 @@ Set `model: "ngrok/auto"` and the gateway picks the best available model from Op
 
 ## Attaching your own provider keys
 
-You can attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy configuration needed. This is useful when you have your own provider accounts but want simpler setup than BYOK.
+Attach your own provider API keys directly to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy or Vaults & Secrets configuration.
 
 When you authenticate with an AI Gateway API Key, the gateway selects a provider key for each provider as follows:
 1. Keys you've attached to the AI Gateway API Key: used exclusively when present for that provider
-2. Provider keys in your Traffic Policy (`providers[].api_keys`): used only if no attached key exists for that provider
+2. Provider keys in your Traffic Policy (`providers[].api_keys`): deprecated for standard providers, still required for [custom or self-hosted providers](/ai-gateway/concepts/bring-your-own-keys); used only when no attached key exists for that provider
 3. ngrok-managed keys: fallback for OpenAI and Anthropic (requires credits)
 
 See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for setup instructions.

--- a/ai-gateway/concepts/bring-your-own-keys.mdx
+++ b/ai-gateway/concepts/bring-your-own-keys.mdx
@@ -33,7 +33,7 @@ If you currently use `providers[].api_keys`, see [Migrate to Attached Provider K
 | Setup complexity | Low (create key, use it) | Low (attach key to API key) | Medium (configure secrets, Traffic Policy) |
 | Key storage | ngrok manages | Encrypted by ngrok | ngrok Vaults & Secrets |
 | Key rotation | Managed by ngrok | Update attached key | Update secret or Traffic Policy |
-| Multi-key failover | Automatic | Per-key ordering | Configurable |
+| Multi-key failover | Automatic | Automatic (most recently attached key tried first) | Configurable (keys tried in list order) |
 | Custom/self-hosted providers | Not supported | Not supported | Supported |
 | Auth | Built-in (AI Gateway API Key) | Built-in (AI Gateway API Key) | DIY (secrets, JWT, etc.) |
 | Supported providers | OpenAI, Anthropic | Any supported provider | Any provider |

--- a/ai-gateway/concepts/bring-your-own-keys.mdx
+++ b/ai-gateway/concepts/bring-your-own-keys.mdx
@@ -3,40 +3,26 @@ title: Bring Your Own Keys
 description: Use your own provider API keys with the AI Gateway.
 ---
 
-Instead of using [AI Gateway API Keys](/ai-gateway/concepts/api-keys) with ngrok-managed provider keys, you can configure your own provider API keys directly in the gateway's Traffic Policy. This is called **Bring Your Own Keys (BYOK)**.
-
 <Warning>
-When you configure provider keys in the gateway, your endpoint becomes publicly accessible—anyone with the URL can make requests using your keys. You must add your own authorization layer. See [Securing Endpoints (BYOK)](/ai-gateway/guides/protecting-byok-endpoints).
+Configuring provider API keys in Traffic Policy (`providers[].api_keys`) is deprecated for standard providers. Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Traffic Policy keys are still supported for [CEL-based key selection](/ai-gateway/guides/key-selection-failover) and [custom or self-hosted providers](#when-traffic-policy-keys-are-still-needed).
 </Warning>
 
-## When to use BYOK
+The recommended way to use your own provider API keys is to attach them directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). ngrok encrypts and stores them—no Traffic Policy configuration or Vaults & Secrets needed.
 
-- You already have provider accounts and billing relationships
-- You need specific provider plans or tiers (enterprise agreements, committed-use discounts)
-- You want to use providers beyond OpenAI and Anthropic (Google, DeepSeek, OpenRouter, etc.)
-- You want to use custom or self-hosted providers (Ollama, vLLM)—see [Custom Providers](/ai-gateway/concepts/custom-providers)
-- You need fine-grained control over which provider keys are used ([CEL-based key selection](/ai-gateway/guides/key-selection-failover))
-- You want to manage your own cost allocation per key
+See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) to get started.
 
-## How BYOK works
+## When Traffic Policy keys are still needed
 
-1. Store your provider API keys in [ngrok Vaults & Secrets](/traffic-policy/secrets)
-2. Reference them in your AI Gateway Traffic Policy
-3. The gateway uses your keys instead of ngrok's managed keys
+Traffic Policy `providers[].api_keys` configuration is still required for:
 
-```yaml
-on_http_request:
-  - type: ai-gateway
-    config:
-      providers:
-        - id: openai
-          api_keys:
-            - value: ${secrets.get('openai', 'primary-key')}
-            - value: ${secrets.get('openai', 'backup-key')}
-        - id: google
-          api_keys:
-            - value: ${secrets.get('google', 'key')}
-```
+- **CEL-based key selection**: quota-aware or error-rate-based strategies using `api_key_selection.strategy`. See [Key Selection & Failover](/ai-gateway/guides/key-selection-failover).
+- **Custom or self-hosted providers**: any provider with a `base_url` (Ollama, vLLM, custom endpoints). See [Custom Providers](/ai-gateway/concepts/custom-providers).
+
+For everything else, use attached provider keys.
+
+## Migrating from Traffic Policy keys
+
+If you currently use `providers[].api_keys`, see [Migrate to Attached Provider Keys](/ai-gateway/guides/migrate-to-attached-provider-keys) for step-by-step instructions.
 
 ## Comparing your options
 
@@ -61,16 +47,16 @@ You can combine all three approaches in the same gateway. When you authenticate 
 ## Guides
 
 <CardGroup cols={2}>
-  <Card title="Configuring Providers" icon="building" href="/ai-gateway/guides/configuring-providers">
-    Set up providers, models, and API keys in your Traffic Policy
+  <Card title="Attaching Provider Keys" icon="key" href="/ai-gateway/guides/attaching-provider-keys">
+    Attach your own provider keys to an AI Gateway API Key
   </Card>
-  <Card title="Managing Provider Keys" icon="key" href="/ai-gateway/guides/managing-provider-keys">
-    Store, rotate, and manage your provider API keys
+  <Card title="Migrate to Attached Provider Keys" icon="arrow-right" href="/ai-gateway/guides/migrate-to-attached-provider-keys">
+    Move existing Traffic Policy keys to attached keys
   </Card>
   <Card title="Key Selection & Failover" icon="rotate" href="/ai-gateway/guides/key-selection-failover">
-    Advanced CEL-based key selection strategies
+    CEL-based key selection for advanced use cases
   </Card>
-  <Card title="Securing Endpoints" icon="shield" href="/ai-gateway/guides/protecting-byok-endpoints">
-    Add authorization when using your own provider keys
+  <Card title="Configuring Providers" icon="building" href="/ai-gateway/guides/configuring-providers">
+    Set up custom and self-hosted providers in Traffic Policy
   </Card>
 </CardGroup>

--- a/ai-gateway/concepts/bring-your-own-keys.mdx
+++ b/ai-gateway/concepts/bring-your-own-keys.mdx
@@ -4,7 +4,7 @@ description: Use your own provider API keys with the AI Gateway.
 ---
 
 <Warning>
-Configuring provider API keys in Traffic Policy (`providers[].api_keys`) is deprecated for standard providers. Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Traffic Policy keys are still supported for [CEL-based key selection](/ai-gateway/guides/key-selection-failover) and [custom or self-hosted providers](#when-traffic-policy-keys-are-still-needed).
+Configuring provider API keys in Traffic Policy (`providers[].api_keys`) is deprecated for standard providers. Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Traffic Policy keys are still supported for [custom or self-hosted providers](#when-traffic-policy-keys-are-still-needed).
 </Warning>
 
 The recommended way to use your own provider API keys is to attach them directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). ngrok encrypts and stores them—no Traffic Policy configuration or Vaults & Secrets needed.
@@ -15,7 +15,6 @@ See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) to get
 
 Traffic Policy `providers[].api_keys` configuration is still required for:
 
-- **CEL-based key selection**: quota-aware or error-rate-based strategies using `api_key_selection.strategy`. See [Key Selection & Failover](/ai-gateway/guides/key-selection-failover).
 - **Custom or self-hosted providers**: any provider with a `base_url` (Ollama, vLLM, custom endpoints). See [Custom Providers](/ai-gateway/concepts/custom-providers).
 
 For everything else, use attached provider keys.
@@ -35,7 +34,6 @@ If you currently use `providers[].api_keys`, see [Migrate to Attached Provider K
 | Key storage | ngrok manages | Encrypted by ngrok | ngrok Vaults & Secrets |
 | Key rotation | Managed by ngrok | Update attached key | Update secret or Traffic Policy |
 | Multi-key failover | Automatic | Per-key ordering | Configurable |
-| CEL key selection | Not applicable | Not applicable | Full control |
 | Custom/self-hosted providers | Not supported | Not supported | Supported |
 | Auth | Built-in (AI Gateway API Key) | Built-in (AI Gateway API Key) | DIY (secrets, JWT, etc.) |
 | Supported providers | OpenAI, Anthropic | Any supported provider | Any provider |
@@ -52,9 +50,6 @@ You can combine all three approaches in the same gateway. When you authenticate 
   </Card>
   <Card title="Migrate to Attached Provider Keys" icon="arrow-right" href="/ai-gateway/guides/migrate-to-attached-provider-keys">
     Move existing Traffic Policy keys to attached keys
-  </Card>
-  <Card title="Key Selection & Failover" icon="rotate" href="/ai-gateway/guides/key-selection-failover">
-    CEL-based key selection for advanced use cases
   </Card>
   <Card title="Configuring Providers" icon="building" href="/ai-gateway/guides/configuring-providers">
     Set up custom and self-hosted providers in Traffic Policy

--- a/ai-gateway/concepts/bring-your-own-keys.mdx
+++ b/ai-gateway/concepts/bring-your-own-keys.mdx
@@ -38,24 +38,25 @@ on_http_request:
             - value: ${secrets.get('google', 'key')}
 ```
 
-## AI Gateway API Keys compared to BYOK
+## Comparing your options
 
-| | AI Gateway API Keys | BYOK |
-|---|---|---|
-| Provider accounts needed | No (OpenAI & Anthropic only) | Yes |
-| Credits required | Yes (processing fee + upstream provider fee) | No |
-| Provider billing | Included in credits (ngrok pays provider) | Direct with providers |
-| Setup complexity | Low (create key, use it) | Medium (configure secrets, Traffic Policy) |
-| Key rotation | Managed by ngrok (provider keys) | You manage |
-| Multi-key failover | Automatic | Configurable |
-| CEL key selection | Not applicable | Full control |
-| Custom/self-hosted providers | Not supported | Supported |
-| Auth | Built-in (AI Gateway API Key) | DIY (secrets, JWT, etc.) |
-| Supported providers | OpenAI, Anthropic | Any provider |
+| | AI Gateway API Keys | Attached provider keys | BYOK |
+|---|---|---|---|
+| Provider accounts needed | No (OpenAI & Anthropic only) | Yes | Yes |
+| Credits required | Yes | No | No |
+| Provider billing | Included in credits (ngrok pays provider) | Direct with providers | Direct with providers |
+| Setup complexity | Low (create key, use it) | Low (attach key to API key) | Medium (configure secrets, Traffic Policy) |
+| Key storage | ngrok manages | Encrypted by ngrok | ngrok Vaults & Secrets |
+| Key rotation | Managed by ngrok | Update attached key | Update secret or Traffic Policy |
+| Multi-key failover | Automatic | Per-key ordering | Configurable |
+| CEL key selection | Not applicable | Not applicable | Full control |
+| Custom/self-hosted providers | Not supported | Not supported | Supported |
+| Auth | Built-in (AI Gateway API Key) | Built-in (AI Gateway API Key) | DIY (secrets, JWT, etc.) |
+| Supported providers | OpenAI, Anthropic | Any supported provider | Any provider |
 
 ### Mixed mode
 
-You can combine both approaches in the same gateway. Use AI Gateway API Keys for OpenAI and Anthropic while bringing your own keys for other providers. When you authenticate with an AI Gateway API Key, BYOK keys take precedence for providers where they're configured. See [AI Gateway API Keys—Mixed mode](/ai-gateway/concepts/api-keys#mixing-ai-gateway-api-keys-with-your-own-provider-keys) for details.
+You can combine all three approaches in the same gateway. When you authenticate with an AI Gateway API Key, the provider key lookup order is: Traffic Policy BYOK → attached provider keys → ngrok-managed keys. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) and [AI Gateway API Keys](/ai-gateway/concepts/api-keys#attaching-your-own-provider-keys) for details.
 
 ## Guides
 

--- a/ai-gateway/concepts/bring-your-own-keys.mdx
+++ b/ai-gateway/concepts/bring-your-own-keys.mdx
@@ -40,7 +40,7 @@ If you currently use `providers[].api_keys`, see [Migrate to Attached Provider K
 
 ### Mixed mode
 
-You can combine all three approaches in the same gateway. When you authenticate with an AI Gateway API Key, the provider key lookup order is: Traffic Policy BYOK → attached provider keys → ngrok-managed keys. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) and [AI Gateway API Keys](/ai-gateway/concepts/api-keys#attaching-your-own-provider-keys) for details.
+You can combine all three approaches in the same gateway. When you authenticate with an AI Gateway API Key, the per-provider lookup order is: attached provider keys → Traffic Policy BYOK → ngrok-managed keys. Attached keys fully replace BYOK for a provider; BYOK is only consulted when no key is attached for that provider. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) and [AI Gateway API Keys](/ai-gateway/concepts/api-keys#attaching-your-own-provider-keys) for details.
 
 ## Guides
 

--- a/ai-gateway/examples/multi-key-failover.mdx
+++ b/ai-gateway/examples/multi-key-failover.mdx
@@ -134,6 +134,6 @@ on_http_request:
 ## See also
 
 - [Multi-Provider Failover](/ai-gateway/examples/multi-provider-failover) - Failover across providers
-- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) - Attach and manage provider keys on your AI Gateway API Key
-- [Managing Provider API Keys](/ai-gateway/guides/managing-provider-keys) - Key rotation and secrets for custom providers
-- [Configuring Providers](/ai-gateway/guides/configuring-providers) - Full provider setup
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): Attach and manage provider keys on your AI Gateway API Key
+- [Managing Provider API Keys](/ai-gateway/guides/managing-provider-keys): Key rotation and secrets for custom providers
+- [Configuring Providers](/ai-gateway/guides/configuring-providers): Full provider setup

--- a/ai-gateway/examples/multi-key-failover.mdx
+++ b/ai-gateway/examples/multi-key-failover.mdx
@@ -6,7 +6,7 @@ description: Configure multiple provider keys for automatic failover across rate
 Configure multiple provider keys per provider to automatically failover when keys hit rate limits or encounter errors. This works with both [attached provider keys](/ai-gateway/guides/attaching-provider-keys) (recommended) and Traffic Policy keys (custom providers only).
 
 <Tip>
-For standard providers (OpenAI, Anthropic, Google, etc.), use [attached provider keys](/ai-gateway/guides/attaching-provider-keys)—attach multiple keys to your AI Gateway API Key and the most recently attached key is tried first, falling back to older keys on failure. Traffic Policy `api_keys` is deprecated for standard providers.
+For standard providers (such as OpenAI, Anthropic, and Google), use [attached provider keys](/ai-gateway/guides/attaching-provider-keys): attach multiple keys to your AI Gateway API Key and the most recently attached key is tried first, falling back to older keys on failure. Traffic Policy `api_keys` is deprecated for standard providers.
 </Tip>
 
 ## Basic example

--- a/ai-gateway/examples/multi-key-failover.mdx
+++ b/ai-gateway/examples/multi-key-failover.mdx
@@ -1,12 +1,12 @@
 ---
 title: Multi-Key Failover
-description: Configure multiple provider API keys for automatic failover.
+description: Configure multiple provider keys for automatic failover across rate limits and errors.
 ---
 
-Configure multiple provider API keys per provider to automatically failover when keys hit rate limits or encounter errors.
+Configure multiple provider keys per provider to automatically failover when keys hit rate limits or encounter errors. This works with both [attached provider keys](/ai-gateway/guides/attaching-provider-keys) (recommended) and Traffic Policy keys (custom providers only).
 
 <Tip>
-This example uses [Bring Your Own Keys (BYOK)](/ai-gateway/concepts/bring-your-own-keys) with your own provider keys. If you're using [AI Gateway API Keys](/ai-gateway/concepts/api-keys), ngrok manages provider key failover automatically.
+For standard providers (OpenAI, Anthropic, Google, etc.), use [attached provider keys](/ai-gateway/guides/attaching-provider-keys)—attach multiple keys to your AI Gateway API Key and they are tried in order. Traffic Policy `api_keys` is deprecated for standard providers.
 </Tip>
 
 ## Basic example
@@ -123,89 +123,6 @@ on_http_request:
             - value: ${secrets.get('openai', 'emergency-key')}
 ```
 
-## Advanced key selection
-
-For smarter key selection based on runtime metrics, use `api_key_selection`:
-
-```yaml
-on_http_request:
-  - type: ai-gateway
-    config:
-      providers:
-        - id: openai
-          api_keys:
-            - value: ${secrets.get('openai', 'key-one')}
-            - value: ${secrets.get('openai', 'key-two')}
-            - value: ${secrets.get('openai', 'key-three')}
-      
-      api_key_selection:
-        strategy:
-          # Prefer keys with remaining quota
-          - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
-          # Fall back to all keys
-          - "ai.keys"
-```
-
-### Quota-aware selection
-
-Route to keys with the most remaining capacity:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Keys with plenty of quota
-    - "ai.keys.filter(k, k.quota.remaining_requests > 500)"
-    # Keys with some quota
-    - "ai.keys.filter(k, k.quota.remaining_requests > 50)"
-    # Fall back to all keys
-    - "ai.keys"
-```
-
-### Error rate-aware selection
-
-Avoid keys that are hitting rate limits:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Keys with low rate limit errors
-    - "ai.keys.filter(k, k.error_rate.rate_limit < 0.05)"
-    # Keys with acceptable overall error rates
-    - "ai.keys.filter(k, k.error_rate.total < 0.2)"
-    # Fall back to all keys
-    - "ai.keys"
-```
-
-### Combined strategy
-
-Use both quota and error rate for optimal selection:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Best keys: high quota AND low errors
-    - "ai.keys.filter(k, k.quota.remaining_requests > 500 && k.error_rate.rate_limit < 0.05)"
-    # Good keys: decent quota
-    - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
-    # Acceptable keys: low errors
-    - "ai.keys.filter(k, k.error_rate.total < 0.3)"
-    # Fall back to all keys
-    - "ai.keys"
-```
-
-### Load distribution
-
-Randomize selection to spread load across keys:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Randomly select from healthy keys
-    - "ai.keys.filter(k, k.quota.remaining_requests > 100).randomize()"
-    # Fall back to any key
-    - "ai.keys.randomize()"
-```
-
 ## Best practices
 
 1. **Use at least 2-3 keys** per provider for reliability
@@ -217,6 +134,6 @@ api_key_selection:
 ## See also
 
 - [Multi-Provider Failover](/ai-gateway/examples/multi-provider-failover) - Failover across providers
-- [Managing Provider API Keys](/ai-gateway/guides/managing-provider-keys) - Key rotation and secrets
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) - Attach and manage provider keys on your AI Gateway API Key
+- [Managing Provider API Keys](/ai-gateway/guides/managing-provider-keys) - Key rotation and secrets for custom providers
 - [Configuring Providers](/ai-gateway/guides/configuring-providers) - Full provider setup
-- [CEL Functions Reference](/ai-gateway/reference/cel-functions#api-key-selection) - Complete API key selection reference

--- a/ai-gateway/examples/multi-key-failover.mdx
+++ b/ai-gateway/examples/multi-key-failover.mdx
@@ -6,7 +6,7 @@ description: Configure multiple provider keys for automatic failover across rate
 Configure multiple provider keys per provider to automatically failover when keys hit rate limits or encounter errors. This works with both [attached provider keys](/ai-gateway/guides/attaching-provider-keys) (recommended) and Traffic Policy keys (custom providers only).
 
 <Tip>
-For standard providers (OpenAI, Anthropic, Google, etc.), use [attached provider keys](/ai-gateway/guides/attaching-provider-keys)—attach multiple keys to your AI Gateway API Key and they are tried in order. Traffic Policy `api_keys` is deprecated for standard providers.
+For standard providers (OpenAI, Anthropic, Google, etc.), use [attached provider keys](/ai-gateway/guides/attaching-provider-keys)—attach multiple keys to your AI Gateway API Key and the most recently attached key is tried first, falling back to older keys on failure. Traffic Policy `api_keys` is deprecated for standard providers.
 </Tip>
 
 ## Basic example

--- a/ai-gateway/faq.mdx
+++ b/ai-gateway/faq.mdx
@@ -38,7 +38,7 @@ Yes. Each key is scoped to a specific AI Gateway endpoint via the required `endp
 
 ### Which providers work with AI Gateway API Keys?
 
-Currently **OpenAI** and **Anthropic** are supported with ngrok-managed keys. For other providers (Google, DeepSeek, etc.), use [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys).
+Currently **OpenAI** and **Anthropic** are supported with ngrok-managed keys. For other providers (Google, DeepSeek, etc.), [attach your own provider keys](/ai-gateway/guides/attaching-provider-keys).
 
 ---
 
@@ -78,7 +78,7 @@ AI Gateway API Key requests stop working. Clients receive HTTP 403 with error [`
 
 ### Does ngrok provide AI provider API keys?
 
-Yes. When you use [AI Gateway API Keys](/ai-gateway/concepts/api-keys), ngrok manages the provider keys for you—no provider accounts needed. Currently supported for OpenAI and Anthropic. For other providers, you [bring your own keys](/ai-gateway/concepts/bring-your-own-keys).
+Yes. When you use [AI Gateway API Keys](/ai-gateway/concepts/api-keys), ngrok manages the provider keys for you—no provider accounts needed. Currently supported for OpenAI and Anthropic. For other providers, [attach your own provider keys](/ai-gateway/guides/attaching-provider-keys).
 
 ---
 
@@ -237,13 +237,15 @@ Use [AI Gateway API Keys](/ai-gateway/concepts/api-keys). Create a key, use it i
 
 ### Do I need to configure provider API keys in the gateway?
 
-Not if you're using AI Gateway API Keys—ngrok handles provider keys for you. If you want to use your own provider keys, see [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys).
+Not if you're using AI Gateway API Keys—ngrok handles provider keys for you. If you want to use your own provider keys, [attach them to your AI Gateway API Key](/ai-gateway/guides/attaching-provider-keys)—no Traffic Policy configuration needed.
 
 ---
 
-### How do I secure my gateway when using my own provider keys (BYOK)?
+### How do I secure my gateway when using my own provider keys?
 
-When you configure your own provider keys in the gateway, your endpoint becomes publicly accessible. You need to add your own authorization layer. See [Securing Endpoints (BYOK)](/ai-gateway/guides/protecting-byok-endpoints) for complete examples.
+With [attached provider keys](/ai-gateway/guides/attaching-provider-keys), your endpoint is already secured—clients must present a valid AI Gateway API Key. No additional authorization layer needed.
+
+If you configure provider keys directly in Traffic Policy (required only for custom or self-hosted providers), the endpoint becomes publicly accessible and you must add your own authorization layer. See [Securing Endpoints](/ai-gateway/guides/protecting-byok-endpoints) for complete examples.
 
 ---
 
@@ -251,7 +253,7 @@ When you configure your own provider keys in the gateway, your endpoint becomes 
 
 Yes. Create separate [AI Gateway API Keys](/ai-gateway/concepts/api-keys) for each team or client. Each key has its own description, metadata, and `last_used` tracking.
 
-For BYOK, configure multiple provider keys and use separate endpoints or providers for team-based tracking.
+Each AI Gateway API Key can have its own set of attached provider keys, so teams can use isolated provider accounts without sharing credentials.
 
 ---
 
@@ -259,7 +261,7 @@ For BYOK, configure multiple provider keys and use separate endpoints or provide
 
 **AI Gateway API Keys**: Delete the old key and create a new one. Update your clients with the new key.
 
-**BYOK provider keys**: Add the new key, deploy, then remove the old key. See [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys#key-rotation) for details.
+**Attached provider keys**: Attach the new key, confirm it's working, then delete the old one—no redeployment needed. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys#rotating-attached-keys) for details.
 
 ---
 

--- a/ai-gateway/faq.mdx
+++ b/ai-gateway/faq.mdx
@@ -38,7 +38,7 @@ Yes. Each key is scoped to a specific AI Gateway endpoint via the required `endp
 
 ### Which providers work with AI Gateway API Keys?
 
-Currently **OpenAI** and **Anthropic** are supported with ngrok-managed keys. For other providers (Google, DeepSeek, etc.), [attach your own provider keys](/ai-gateway/guides/attaching-provider-keys).
+Currently, OpenAI and Anthropic are supported with ngrok-managed keys. For other providers (such Google or DeepSeek), [attach your own provider keys](/ai-gateway/guides/attaching-provider-keys).
 
 ---
 

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -116,7 +116,7 @@ To rotate a provider key without downtime:
 
 <Steps>
   <Step title="Attach the new key">
-    Attach the replacement key alongside the existing one. The gateway tries keys in the order they were attached.
+    Attach the replacement key alongside the existing one. The gateway tries the most recently attached key first, so the new key takes over immediately while the old key remains available as fallback.
 
     ```bash
     ngrok api ai-gateway-provider-keys create \

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -43,12 +43,12 @@ If you just need OpenAI and Anthropic and don't have your own provider accounts,
 
 ### Dashboard
 
-1. Navigate to [**AI Gateways**](https://dashboard.ngrok.com/ai-gateways) in the dashboard
-2. Select your gateway
-3. Go to the **API Keys** tab and select the key you want to configure
-4. Click **Add Provider Key**
-5. Select the provider and paste your provider API key
-6. Click **Save**
+1. Navigate to [**AI Gateways**](https://dashboard.ngrok.com/ai-gateways) in the dashboard.
+2. Select your gateway.
+3. Go to the **API Keys** tab and select the key you want to configure.
+4. Click **Add Provider Key**.
+5. Select the provider and paste your provider API key.
+6. Click **Save**.
 
 ### CLI
 

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -16,6 +16,16 @@ When a request arrives authenticated with your AI Gateway API Key, the gateway s
 
 Selection happens per provider. You can attach keys for some providers, leave others on BYOK, and fall back to ngrok-managed keys for the rest—all with the same AI Gateway API Key.
 
+## How keys are stored and shown
+
+Provider keys are envelope-encrypted with AES-256 before being persisted. Plaintext exists only in memory for the duration of a single upstream request and is never written to disk or logged.
+
+**Shown exactly once at creation.** The full key value is returned in the API response and dashboard exactly once, when you create it. Save it somewhere safe—if you lose it, delete the key and create a new one.
+
+**Display form is redacted everywhere else.** After creation, the key appears in the API and dashboard as `first10***last4` for standard-length keys (or `***lastN` for short keys, matching the Stripe/Cloudflare "last 4" convention). The redacted form identifies the key without exposing it.
+
+**No update-in-place.** There is no `PATCH` operation for a key value. To rotate, attach a replacement and delete the old key—see [Rotating attached keys](#rotating-attached-keys) below.
+
 ## When to use attached provider keys
 
 Attach provider keys to your AI Gateway API Key when you:
@@ -109,6 +119,10 @@ ngrok api ai-gateway-provider-keys create \
 ```
 
 Requests are then routed to the right provider key based on which model is requested. Providers without an attached key fall back to ngrok-managed keys (if available) or return an error.
+
+<Note>
+You can attach up to **15 keys per provider** to a single AI Gateway API Key. Requests beyond that return [`ERR_NGROK_27506`](/ai-gateway/reference/error-codes) (provider key limit exceeded). Most teams need 2–3 for failover and staged rotation.
+</Note>
 
 ## Rotating attached keys
 

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -22,7 +22,7 @@ Provider keys are envelope-encrypted with AES-256 before being persisted. Plaint
 
 **Shown exactly once at creation.** The full key value is returned in the API response and dashboard exactly once, when you create it. Save it somewhere safe—if you lose it, delete the key and create a new one.
 
-**Display form is redacted everywhere else.** After creation, the key appears in the API and dashboard as `first10***last4` for standard-length keys (or `***lastN` for short keys, matching the Stripe/Cloudflare "last 4" convention). The redacted form identifies the key without exposing it.
+**Display form is redacted everywhere else.** After creation, the key appears in the API and dashboard as `first10***last4` for standard-length keys (or `***lastN` for short keys, matching the Stripe "last 4" convention). The redacted form identifies the key without exposing it.
 
 **No update-in-place.** There is no `PATCH` operation for a key value. To rotate, attach a replacement and delete the old key—see [Rotating attached keys](#rotating-attached-keys) below.
 

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -43,10 +43,11 @@ If you just need OpenAI and Anthropic and don't have your own provider accounts,
 ### CLI
 
 ```bash
-ngrok api ai-gateway-api-keys add-provider-key \
-  --id ngk_xxxxx \
-  --provider openai \
-  --secret-key sk-proj-...
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id openai \
+  --name "My OpenAI Key" \
+  --value sk-proj-...
 ```
 
 ### API
@@ -85,22 +86,25 @@ Attach keys for as many providers as you need. Each provider is configured indep
 
 ```bash
 # Attach an OpenAI key
-ngrok api ai-gateway-api-keys add-provider-key \
-  --id ngk_xxxxx \
-  --provider openai \
-  --secret-key sk-proj-...
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id openai \
+  --name "My OpenAI Key" \
+  --value sk-proj-...
 
 # Attach an Anthropic key
-ngrok api ai-gateway-api-keys add-provider-key \
-  --id ngk_xxxxx \
-  --provider anthropic \
-  --secret-key sk-ant-...
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id anthropic \
+  --name "My Anthropic Key" \
+  --value sk-ant-...
 
 # Attach a Google key
-ngrok api ai-gateway-api-keys add-provider-key \
-  --id ngk_xxxxx \
-  --provider google \
-  --secret-key AIza...
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id google \
+  --name "My Google Key" \
+  --value AIza...
 ```
 
 Requests are then routed to the right provider key based on which model is requested. Providers without an attached key fall back to ngrok-managed keys (if available) or return an error.
@@ -114,10 +118,11 @@ To rotate a provider key without downtime:
     Attach the replacement key alongside the existing one. The gateway tries keys in the order they were attached.
 
     ```bash
-    ngrok api ai-gateway-api-keys add-provider-key \
-      --id ngk_xxxxx \
-      --provider openai \
-      --secret-key sk-proj-new...
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id openai \
+      --name "My OpenAI Key (new)" \
+      --value sk-proj-new...
     ```
   </Step>
 
@@ -125,9 +130,7 @@ To rotate a provider key without downtime:
     Once you confirm the new key is working, remove the old one:
 
     ```bash
-    ngrok api ai-gateway-api-keys remove-provider-key \
-      --id ngk_xxxxx \
-      --provider-key-id pkid_xxxxx
+    ngrok api ai-gateway-provider-keys delete pkid_xxxxx
     ```
   </Step>
 
@@ -155,7 +158,7 @@ This means you can use attached keys as a default for most providers while overr
 ### List
 
 ```bash
-ngrok api ai-gateway-api-keys list-provider-keys --id ngk_xxxxx
+ngrok api ai-gateway-provider-keys list --ai-gateway-api-key-id aigk_xxxxx
 ```
 
 ```bash
@@ -167,9 +170,7 @@ curl https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
 ### Remove
 
 ```bash
-ngrok api ai-gateway-api-keys remove-provider-key \
-  --id ngk_xxxxx \
-  --provider-key-id pkid_xxxxx
+ngrok api ai-gateway-provider-keys delete pkid_xxxxx
 ```
 
 ```bash
@@ -188,4 +189,3 @@ Removing a provider key takes effect immediately. Any in-flight requests using t
 - [AI Gateway API Keys](/ai-gateway/concepts/api-keys): Overview of AI Gateway API Keys and how they work
 - [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys): Configure provider keys directly in Traffic Policy
 - [Managing Provider Keys (BYOK)](/ai-gateway/guides/managing-provider-keys): Key rotation and management for Traffic Policy keys
-- [Key Selection & Failover](/ai-gateway/guides/key-selection-failover): CEL-based key selection strategies

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -30,7 +30,7 @@ Provider keys are envelope-encrypted with AES-256 before being persisted. Plaint
 
 Attach provider keys to your AI Gateway API Key when you:
 
-- **Have your own provider accounts** but want simpler setup than BYOK—no Traffic Policy changes, no secrets to configure
+- **Have your own provider accounts** but want simpler setup than BYOK: no Traffic Policy changes, no secrets to configure
 - **Need providers beyond OpenAI and Anthropic**: attached keys work with any supported provider
 - **Want to separate key management from gateway config**: ops teams can manage keys independently from Traffic Policy deployments
 - **Need per-key provider routing**: different API keys can have different provider keys attached, so teams can use isolated provider accounts

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -1,0 +1,191 @@
+---
+title: Attaching Provider Keys to Your AI Gateway API Key
+sidebarTitle: Attaching Provider Keys
+description: Attach your own provider keys to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy configuration needed.
+---
+
+Instead of configuring provider API keys in your Traffic Policy (BYOK), you can attach them directly to an [AI Gateway API Key](/ai-gateway/concepts/api-keys). ngrok encrypts your keys at rest and automatically uses them when routing requests—no secrets or Traffic Policy changes needed.
+
+## How it works
+
+When a request arrives authenticated with your AI Gateway API Key, the gateway checks for attached provider keys before falling back to other sources. The lookup order for each provider is:
+
+1. **Traffic Policy BYOK**: provider keys in `providers[].api_keys` always take precedence
+2. **Attached provider keys**: your keys stored securely against the AI Gateway API Key _(this feature)_
+3. **ngrok-managed keys**: ngrok's shared keys for OpenAI and Anthropic (requires [credits](/ai-gateway/concepts/credits))
+
+This means you can attach keys for the providers you care about, use ngrok-managed keys for the rest, and keep BYOK in Traffic Policy as an override when needed—all with the same AI Gateway API Key.
+
+## When to use attached provider keys
+
+Attach provider keys to your AI Gateway API Key when you:
+
+- **Have your own provider accounts** but want simpler setup than BYOK—no Traffic Policy changes, no secrets to configure
+- **Need providers beyond OpenAI and Anthropic**: attached keys work with any supported provider
+- **Want to separate key management from gateway config**: ops teams can manage keys independently from Traffic Policy deployments
+- **Need per-key provider routing**: different API keys can have different provider keys attached, so teams can use isolated provider accounts
+
+<Note>
+If you just need OpenAI and Anthropic and don't have your own provider accounts, use [AI Gateway API Keys](/ai-gateway/concepts/api-keys) with ngrok-managed keys—no setup required.
+</Note>
+
+## Attaching a provider key
+
+### Dashboard
+
+1. Navigate to [**AI Gateways**](https://dashboard.ngrok.com/ai-gateways) in the dashboard
+2. Select your gateway
+3. Go to the **API Keys** tab and select the key you want to configure
+4. Click **Add Provider Key**
+5. Select the provider and paste your provider API key
+6. Click **Save**
+
+### CLI
+
+```bash
+ngrok api ai-gateway-api-keys add-provider-key \
+  --id ngk_xxxxx \
+  --provider openai \
+  --secret-key sk-proj-...
+```
+
+### API
+
+```bash
+curl -X POST https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
+  -H "Authorization: Bearer $NGROK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Ngrok-Version: 2" \
+  -d '{
+    "provider_id": "openai",
+    "key": "sk-proj-..."
+  }'
+```
+
+Once attached, requests authenticated with that AI Gateway API Key automatically use your provider key—no other changes needed.
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://your-ai-gateway.ngrok.app/v1",
+    api_key="ng-xxxxx-g1-xxxxx"  # Your AI Gateway API Key
+)
+
+# Routes to openai using your attached provider key
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+## Attaching keys for multiple providers
+
+Attach keys for as many providers as you need. Each provider is configured independently:
+
+```bash
+# Attach an OpenAI key
+ngrok api ai-gateway-api-keys add-provider-key \
+  --id ngk_xxxxx \
+  --provider openai \
+  --secret-key sk-proj-...
+
+# Attach an Anthropic key
+ngrok api ai-gateway-api-keys add-provider-key \
+  --id ngk_xxxxx \
+  --provider anthropic \
+  --secret-key sk-ant-...
+
+# Attach a Google key
+ngrok api ai-gateway-api-keys add-provider-key \
+  --id ngk_xxxxx \
+  --provider google \
+  --secret-key AIza...
+```
+
+Requests are then routed to the right provider key based on which model is requested. Providers without an attached key fall back to ngrok-managed keys (if available) or return an error.
+
+## Rotating attached keys
+
+To rotate a provider key without downtime:
+
+<Steps>
+  <Step title="Attach the new key">
+    Attach the replacement key alongside the existing one. The gateway tries keys in the order they were attached.
+
+    ```bash
+    ngrok api ai-gateway-api-keys add-provider-key \
+      --id ngk_xxxxx \
+      --provider openai \
+      --secret-key sk-proj-new...
+    ```
+  </Step>
+
+  <Step title="Remove the old key">
+    Once you confirm the new key is working, remove the old one:
+
+    ```bash
+    ngrok api ai-gateway-api-keys remove-provider-key \
+      --id ngk_xxxxx \
+      --provider-key-id pkid_xxxxx
+    ```
+  </Step>
+
+  <Step title="Revoke the old key with your provider">
+    Complete the rotation by revoking the old key in your provider's dashboard (OpenAI, Anthropic, etc.).
+  </Step>
+</Steps>
+
+## Relationship with Traffic Policy BYOK
+
+Attached provider keys and BYOK ([Traffic Policy `providers[].api_keys`](/ai-gateway/concepts/bring-your-own-keys)) can coexist. BYOK always takes precedence for a given provider:
+
+| Provider config | What gets used |
+|---|---|
+| Attached key only | Your attached key |
+| BYOK only | Your BYOK key |
+| Both attached and BYOK | BYOK key (Traffic Policy wins) |
+| Neither | ngrok-managed key (if available) |
+| None of the above | Error |
+
+This means you can use attached keys as a default for most providers while overriding specific providers in Traffic Policy—for example, to use a high-capacity key for production traffic on a particular endpoint.
+
+## Listing and removing attached keys
+
+### List
+
+```bash
+ngrok api ai-gateway-api-keys list-provider-keys --id ngk_xxxxx
+```
+
+```bash
+curl https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
+  -H "Authorization: Bearer $NGROK_API_KEY" \
+  -H "Ngrok-Version: 2"
+```
+
+### Remove
+
+```bash
+ngrok api ai-gateway-api-keys remove-provider-key \
+  --id ngk_xxxxx \
+  --provider-key-id pkid_xxxxx
+```
+
+```bash
+curl -X DELETE https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys/{provider_key_id} \
+  -H "Authorization: Bearer $NGROK_API_KEY" \
+  -H "Ngrok-Version: 2"
+```
+
+<Warning>
+Removing a provider key takes effect immediately. Any in-flight requests using that key will fail. If you have no other keys configured for that provider, requests will fall back to ngrok-managed keys or fail.
+</Warning>
+
+## Next steps
+
+- [Migrate from Traffic Policy Keys](/ai-gateway/guides/migrate-to-attached-provider-keys): Step-by-step guide for moving existing BYOK config to attached keys
+- [AI Gateway API Keys](/ai-gateway/concepts/api-keys): Overview of AI Gateway API Keys and how they work
+- [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys): Configure provider keys directly in Traffic Policy
+- [Managing Provider Keys (BYOK)](/ai-gateway/guides/managing-provider-keys): Key rotation and management for Traffic Policy keys
+- [Key Selection & Failover](/ai-gateway/guides/key-selection-failover): CEL-based key selection strategies

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -20,7 +20,7 @@ Selection happens per provider. You can attach keys for some providers, leave ot
 
 Provider keys are envelope-encrypted with AES-256 before being persisted. Plaintext exists only in memory for the duration of a single upstream request and is never written to disk or logged.
 
-**Shown exactly once at creation.** The full key value is returned in the API response and dashboard exactly once, when you create it. Save it somewhere safe—if you lose it, delete the key and create a new one.
+**Keys are shown exactly once at creation.** The full key value is returned in the API response and dashboard exactly once, when you create it. Save it somewhere safe—if you lose it, delete the key and create a new one.
 
 **Display form is redacted everywhere else.** After creation, the key appears in the API and dashboard as `first10***last4` for standard-length keys (or `***lastN` for short keys, matching the Stripe "last 4" convention). The redacted form identifies the key without exposing it.
 

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -46,7 +46,7 @@ If you just need OpenAI and Anthropic and don't have your own provider accounts,
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id openai \
-  --name "My OpenAI Key" \
+  --description "My OpenAI Key" \
   --value sk-proj-...
 ```
 
@@ -89,21 +89,21 @@ Attach keys for as many providers as you need. Each provider is configured indep
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id openai \
-  --name "My OpenAI Key" \
+  --description "My OpenAI Key" \
   --value sk-proj-...
 
 # Attach an Anthropic key
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id anthropic \
-  --name "My Anthropic Key" \
+  --description "My Anthropic Key" \
   --value sk-ant-...
 
 # Attach a Google key
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id google \
-  --name "My Google Key" \
+  --description "My Google Key" \
   --value AIza...
 ```
 
@@ -121,7 +121,7 @@ To rotate a provider key without downtime:
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id openai \
-      --name "My OpenAI Key (new)" \
+      --description "My OpenAI Key (new)" \
       --value sk-proj-new...
     ```
   </Step>

--- a/ai-gateway/guides/attaching-provider-keys.mdx
+++ b/ai-gateway/guides/attaching-provider-keys.mdx
@@ -4,17 +4,17 @@ sidebarTitle: Attaching Provider Keys
 description: Attach your own provider keys to an AI Gateway API Key. ngrok encrypts and stores them—no Traffic Policy configuration needed.
 ---
 
-Instead of configuring provider API keys in your Traffic Policy (BYOK), you can attach them directly to an [AI Gateway API Key](/ai-gateway/concepts/api-keys). ngrok encrypts your keys at rest and automatically uses them when routing requests—no secrets or Traffic Policy changes needed.
+Instead of configuring provider API keys in your Traffic Policy, you can attach them directly to an [AI Gateway API Key](/ai-gateway/concepts/api-keys). ngrok encrypts your keys at rest and automatically uses them when routing requests—no secrets or Traffic Policy changes needed.
 
 ## How it works
 
-When a request arrives authenticated with your AI Gateway API Key, the gateway checks for attached provider keys before falling back to other sources. The lookup order for each provider is:
+When a request arrives authenticated with your AI Gateway API Key, the gateway selects a provider key for the target provider as follows:
 
-1. **Traffic Policy BYOK**: provider keys in `providers[].api_keys` always take precedence
-2. **Attached provider keys**: your keys stored securely against the AI Gateway API Key _(this feature)_
-3. **ngrok-managed keys**: ngrok's shared keys for OpenAI and Anthropic (requires [credits](/ai-gateway/concepts/credits))
+1. **Attached provider keys**: if any are attached for the provider, they are used exclusively _(this feature)_
+2. **Traffic Policy BYOK**: provider keys in `providers[].api_keys`—used only when no attached key exists for that provider
+3. **ngrok-managed keys**: ngrok's shared keys for OpenAI and Anthropic (requires [credits](/ai-gateway/concepts/credits))—used only when no attached or BYOK key exists for that provider
 
-This means you can attach keys for the providers you care about, use ngrok-managed keys for the rest, and keep BYOK in Traffic Policy as an override when needed—all with the same AI Gateway API Key.
+Selection happens per provider. You can attach keys for some providers, leave others on BYOK, and fall back to ngrok-managed keys for the rest—all with the same AI Gateway API Key.
 
 ## When to use attached provider keys
 
@@ -53,13 +53,14 @@ ngrok api ai-gateway-provider-keys create \
 ### API
 
 ```bash
-curl -X POST https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
+curl -X POST https://api.ngrok.com/ai_gateway_provider_keys \
   -H "Authorization: Bearer $NGROK_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Ngrok-Version: 2" \
   -d '{
+    "ai_gateway_api_key_id": "aigk_xxxxx",
     "provider_id": "openai",
-    "key": "sk-proj-..."
+    "value": "sk-proj-..."
   }'
 ```
 
@@ -130,7 +131,7 @@ To rotate a provider key without downtime:
     Once you confirm the new key is working, remove the old one:
 
     ```bash
-    ngrok api ai-gateway-provider-keys delete pkid_xxxxx
+    ngrok api ai-gateway-provider-keys delete aigpk_xxxxx
     ```
   </Step>
 
@@ -141,17 +142,17 @@ To rotate a provider key without downtime:
 
 ## Relationship with Traffic Policy BYOK
 
-Attached provider keys and BYOK ([Traffic Policy `providers[].api_keys`](/ai-gateway/concepts/bring-your-own-keys)) can coexist. BYOK always takes precedence for a given provider:
+Attached provider keys and BYOK ([Traffic Policy `providers[].api_keys`](/ai-gateway/concepts/bring-your-own-keys)) can coexist, but attached keys always win for a given provider:
 
 | Provider config | What gets used |
 |---|---|
 | Attached key only | Your attached key |
 | BYOK only | Your BYOK key |
-| Both attached and BYOK | BYOK key (Traffic Policy wins) |
+| Both attached and BYOK | Attached key (BYOK is ignored for that provider) |
 | Neither | ngrok-managed key (if available) |
 | None of the above | Error |
 
-This means you can use attached keys as a default for most providers while overriding specific providers in Traffic Policy—for example, to use a high-capacity key for production traffic on a particular endpoint.
+Attaching a key for a provider fully replaces BYOK for that provider—BYOK is not used as a fallback. If you need both configured simultaneously (for example during a migration), expect traffic to route through the attached key as soon as it's attached.
 
 ## Listing and removing attached keys
 
@@ -162,7 +163,7 @@ ngrok api ai-gateway-provider-keys list --ai-gateway-api-key-id aigk_xxxxx
 ```
 
 ```bash
-curl https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
+curl "https://api.ngrok.com/ai_gateway_provider_keys?ai_gateway_api_key_id=aigk_xxxxx" \
   -H "Authorization: Bearer $NGROK_API_KEY" \
   -H "Ngrok-Version: 2"
 ```
@@ -170,11 +171,11 @@ curl https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys \
 ### Remove
 
 ```bash
-ngrok api ai-gateway-provider-keys delete pkid_xxxxx
+ngrok api ai-gateway-provider-keys delete aigpk_xxxxx
 ```
 
 ```bash
-curl -X DELETE https://api.ngrok.com/ai_gateway_api_keys/{id}/provider_keys/{provider_key_id} \
+curl -X DELETE https://api.ngrok.com/ai_gateway_provider_keys/aigpk_xxxxx \
   -H "Authorization: Bearer $NGROK_API_KEY" \
   -H "Ngrok-Version: 2"
 ```

--- a/ai-gateway/guides/configuring-providers.mdx
+++ b/ai-gateway/guides/configuring-providers.mdx
@@ -3,7 +3,7 @@ title: Configuring Providers
 description: How to configure AI providers, custom endpoints, and advanced key selection in Traffic Policy.
 ---
 
-This guide covers Traffic Policy provider configuration. This is required for custom or self-hosted providers. For standard providers (OpenAI, Anthropic, Google, etc.), attach your keys directly to your AI Gateway API Key instead—see [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
+This guide covers Traffic Policy provider configuration. This is required for custom or self-hosted providers. For standard providers (such as OpenAI, Anthropic, and Google), [attach your keys directly](/ai-gateway/guides/attaching-provider-keys) to your AI Gateway API Key instead.
 
 ## Basic configuration
 

--- a/ai-gateway/guides/configuring-providers.mdx
+++ b/ai-gateway/guides/configuring-providers.mdx
@@ -1,9 +1,9 @@
 ---
 title: Configuring Providers
-description: How to configure AI providers when using your own provider API keys (BYOK).
+description: How to configure AI providers, custom endpoints, and advanced key selection in Traffic Policy.
 ---
 
-This guide covers configuring providers when using your own provider API keys (BYOK). If you're using AI Gateway API Keys, providers are pre-configured—see [AI Gateway API Keys](/ai-gateway/concepts/api-keys).
+This guide covers Traffic Policy provider configuration. This is required for custom or self-hosted providers and CEL-based key selection. For standard providers (OpenAI, Anthropic, Google, etc.), attach your keys directly to your AI Gateway API Key instead—see [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
 
 ## Basic configuration
 
@@ -78,7 +78,7 @@ on_http_request:
 
 - **Type**: `array`
 - **Optional**: Yes
-- **Description**: List of API keys for this provider. See [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys).
+- **Description**: List of API keys for this provider. **Deprecated for standard providers.** Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Still supported for custom providers with `base_url` and for CEL-based key selection strategies.
 
 ```yaml
 api_keys:

--- a/ai-gateway/guides/configuring-providers.mdx
+++ b/ai-gateway/guides/configuring-providers.mdx
@@ -3,7 +3,7 @@ title: Configuring Providers
 description: How to configure AI providers, custom endpoints, and advanced key selection in Traffic Policy.
 ---
 
-This guide covers Traffic Policy provider configuration. This is required for custom or self-hosted providers and CEL-based key selection. For standard providers (OpenAI, Anthropic, Google, etc.), attach your keys directly to your AI Gateway API Key instead—see [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
+This guide covers Traffic Policy provider configuration. This is required for custom or self-hosted providers. For standard providers (OpenAI, Anthropic, Google, etc.), attach your keys directly to your AI Gateway API Key instead—see [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
 
 ## Basic configuration
 
@@ -78,7 +78,7 @@ on_http_request:
 
 - **Type**: `array`
 - **Optional**: Yes
-- **Description**: List of API keys for this provider. **Deprecated for standard providers.** Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Still supported for custom providers with `base_url` and for CEL-based key selection strategies.
+- **Description**: List of API keys for this provider. **Deprecated for standard providers.** Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead. Still supported for custom providers with `base_url`.
 
 ```yaml
 api_keys:

--- a/ai-gateway/guides/debugging.mdx
+++ b/ai-gateway/guides/debugging.mdx
@@ -275,7 +275,7 @@ Look for `status_code: 429` in request responses:
 }
 ```
 
-**Solution:** Add more provider keys. With attached provider keys, attach additional keys for the same provider—they are tried in order. See [Multi-Key Failover](/ai-gateway/guides/key-selection-failover).
+**Solution:** Add more provider keys. With attached provider keys, attach additional keys for the same provider—the most recently attached key is tried first, falling back to older keys on failure. See [Multi-Key Failover](/ai-gateway/guides/key-selection-failover).
 
 ### Identifying model filtering issues
 

--- a/ai-gateway/guides/debugging.mdx
+++ b/ai-gateway/guides/debugging.mdx
@@ -275,7 +275,7 @@ Look for `status_code: 429` in request responses:
 }
 ```
 
-**Solution:** Add more API keys or configure key rotation with `api_key_selection`.
+**Solution:** Add more provider keys. With attached provider keys, attach additional keys for the same provider—they are tried in order. See [Multi-Key Failover](/ai-gateway/guides/key-selection-failover).
 
 ### Identifying model filtering issues
 

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -1,20 +1,48 @@
 ---
-title: Key Selection & Failover
-description: Advanced CEL-based API key selection and multi-key failover strategies for BYOK usage.
+title: Multi-Key Failover
+description: Automatic failover across multiple provider keys for resilience and capacity.
 ---
 
-When using your own provider API keys (BYOK), you can configure advanced key selection strategies using CEL expressions. This enables key rotation based on quota usage, error rates, and load distribution.
+<Warning>
+CEL-based `api_key_selection` strategies are deprecated. Attached provider keys use simple ordered failover—keys are tried in the order they were attached. For advanced routing logic, use [model selection strategies](/ai-gateway/guides/model-selection-strategies) instead.
+</Warning>
 
-## Multi-key failover
+When multiple keys are configured for a provider, the gateway automatically fails over between them:
 
-When you configure multiple API keys for a provider, the gateway automatically handles failover:
-
-1. Keys are tried **in the order they are listed**
-2. If a key fails, the next key is used automatically
+1. Keys are tried **in the order they are attached**
+2. If a key fails, the next key is tried automatically
 3. Failover triggers include:
    - **Rate limit errors** (HTTP 429)
    - **Quota exceeded** responses from the provider
    - **Timeout or server errors** (HTTP 5xx)
+
+## With attached provider keys
+
+Attach multiple keys for the same provider to your AI Gateway API Key. They are tried in the order they were attached:
+
+```bash
+# Attach primary key (tried first)
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id openai \
+  --name "OpenAI Primary" \
+  --value sk-proj-primary...
+
+# Attach backup key (tried if primary fails)
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id openai \
+  --name "OpenAI Backup" \
+  --value sk-proj-backup...
+```
+
+<Tip>
+Attach keys in priority order—highest-capacity or most reliable keys first.
+</Tip>
+
+## With Traffic Policy keys (custom providers only)
+
+For custom or self-hosted providers, configure multiple keys in Traffic Policy:
 
 ```yaml
 on_http_request:
@@ -28,102 +56,12 @@ on_http_request:
             - value: ${secrets.get('openai', 'key-three')}  # last resort
 ```
 
-<Tip>
-Order your keys so that your highest-capacity or primary keys are listed first.
-</Tip>
-
-## Advanced key selection
-
-For fine-grained control over which API key is used, configure `api_key_selection` with CEL expressions that select keys based on runtime metrics like quota usage and error rates.
-
-### Basic configuration
-
-```yaml
-on_http_request:
-  - type: ai-gateway
-    config:
-      providers:
-        - id: openai
-          api_keys:
-            - value: ${secrets.get('openai', 'key-one')}
-            - value: ${secrets.get('openai', 'key-two')}
-            - value: ${secrets.get('openai', 'key-three')}
-      
-      api_key_selection:
-        strategy:
-          - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
-          - "ai.keys"
-```
-
-### How strategies work
-
-Strategies execute **in order** until one returns at least one key:
-
-1. First strategy filters keys with >100 remaining requests
-2. If no keys match, falls back to all keys
-3. Selected keys are then tried in order for failover
-
 <Note>
-Each strategy is a CEL expression that returns a list of keys. The first strategy that returns a non-empty list is used.
+`providers[].api_keys` is deprecated for standard providers. Use attached provider keys instead. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
 </Note>
-
-### Quota-based selection
-
-Prioritize keys with remaining capacity:
-
-```yaml
-api_key_selection:
-  strategy:
-    # High capacity keys first
-    - "ai.keys.filter(k, k.quota.remaining_requests > 500)"
-    # Medium capacity keys
-    - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
-    # Any key with quota
-    - "ai.keys.filter(k, k.quota.remaining_requests > 0)"
-    # Fall back to all keys
-    - "ai.keys"
-```
-
-### Error-rate-based selection
-
-Avoid keys experiencing issues:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Keys with very low rate limit errors
-    - "ai.keys.filter(k, k.error_rate.rate_limit < 0.05)"
-    # Keys with acceptable error rates
-    - "ai.keys.filter(k, k.error_rate.total < 0.2)"
-    # Fall back to all keys
-    - "ai.keys"
-```
-
-### Load distribution
-
-Randomize key selection to distribute load:
-
-```yaml
-api_key_selection:
-  strategy:
-    # Randomly select from keys with good quota
-    - "ai.keys.filter(k, k.quota.remaining_requests > 100).randomize()"
-    # Fall back to any key
-    - "ai.keys.randomize()"
-```
-
-## Available key variables
-
-| Variable | Description |
-|----------|-------------|
-| `k.quota.remaining_requests` | Requests remaining before rate limit |
-| `k.quota.remaining_tokens` | Tokens remaining before rate limit |
-| `k.error_rate.total` | Fraction of all errors (0.0 to 1.0) |
-| `k.error_rate.rate_limit` | Fraction of rate limit (429) errors |
-| `k.error_rate.timeout` | Fraction of timeout errors |
 
 ## Next steps
 
-- [CEL Functions Reference](/ai-gateway/reference/cel-functions#api-key-selection): complete list of CEL functions for key selection
-- [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys): storing, rotating, and securing your provider API keys
-- [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys): overview of using your own provider keys
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): attach and manage provider keys on your AI Gateway API Key
+- [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys): storing and rotating Traffic Policy keys for custom providers
+- [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys): overview of provider key options

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -4,12 +4,12 @@ description: Automatic failover across multiple provider keys for resilience and
 ---
 
 <Warning>
-CEL-based `api_key_selection` strategies are deprecated. Attached provider keys use simple ordered failover—keys are tried in the order they were attached. For advanced routing logic, use [model selection strategies](/ai-gateway/guides/model-selection-strategies) instead.
+CEL-based `api_key_selection` strategies are deprecated. Attached provider keys use simple ordered failover—the most recently attached key is tried first. For advanced routing logic, use [model selection strategies](/ai-gateway/guides/model-selection-strategies) instead.
 </Warning>
 
 When multiple keys are configured for a provider, the gateway automatically fails over between them:
 
-1. Keys are tried **in the order they are attached**
+1. Keys are tried in **reverse order of attachment**—the most recently attached key first
 2. If a key fails, the next key is tried automatically
 3. Failover triggers include:
    - **Rate limit errors** (HTTP 429)
@@ -18,26 +18,26 @@ When multiple keys are configured for a provider, the gateway automatically fail
 
 ## With attached provider keys
 
-Attach multiple keys for the same provider to your AI Gateway API Key. They are tried in the order they were attached:
+Attach multiple keys for the same provider to your AI Gateway API Key. The most recently attached key is tried first, then the gateway falls back to older keys in reverse order of attachment:
 
 ```bash
-# Attach primary key (tried first)
-ngrok api ai-gateway-provider-keys create \
-  --ai-gateway-api-key-id aigk_xxxxx \
-  --provider-id openai \
-  --description "OpenAI Primary" \
-  --value sk-proj-primary...
-
-# Attach backup key (tried if primary fails)
+# Attach backup key first (tried last)
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id openai \
   --description "OpenAI Backup" \
   --value sk-proj-backup...
+
+# Attach primary key last (tried first)
+ngrok api ai-gateway-provider-keys create \
+  --ai-gateway-api-key-id aigk_xxxxx \
+  --provider-id openai \
+  --description "OpenAI Primary" \
+  --value sk-proj-primary...
 ```
 
 <Tip>
-Attach keys in priority order—highest-capacity or most reliable keys first.
+Attach your highest-capacity or most reliable key **last**—the most recently attached key is tried first.
 </Tip>
 
 ## With Traffic Policy keys (custom providers only)

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -25,14 +25,14 @@ Attach multiple keys for the same provider to your AI Gateway API Key. They are 
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id openai \
-  --name "OpenAI Primary" \
+  --description "OpenAI Primary" \
   --value sk-proj-primary...
 
 # Attach backup key (tried if primary fails)
 ngrok api ai-gateway-provider-keys create \
   --ai-gateway-api-key-id aigk_xxxxx \
   --provider-id openai \
-  --name "OpenAI Backup" \
+  --description "OpenAI Backup" \
   --value sk-proj-backup...
 ```
 

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -4,7 +4,7 @@ description: Automatic failover across multiple provider keys for resilience and
 ---
 
 <Warning>
-CEL-based `api_key_selection` strategies are deprecated. Attached provider keys use simple ordered failover—the most recently attached key is tried first. For advanced routing logic, use [model selection strategies](/ai-gateway/guides/model-selection-strategies) instead.
+CEL-based `api_key_selection` strategies are deprecated. Attached provider keys use simple ordered failover: the most recently attached key is tried first. For advanced routing logic, use [model selection strategies](/ai-gateway/guides/model-selection-strategies) instead.
 </Warning>
 
 When multiple keys are configured for a provider, the gateway automatically fails over between them:

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -57,7 +57,7 @@ on_http_request:
 ```
 
 <Note>
-`providers[].api_keys` is deprecated for standard providers. Use attached provider keys instead. See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
+`providers[].api_keys` is deprecated for standard providers. Use [attached provider keys](/ai-gateway/guides/attaching-provider-keys) instead. 
 </Note>
 
 ## Next steps

--- a/ai-gateway/guides/key-selection-failover.mdx
+++ b/ai-gateway/guides/key-selection-failover.mdx
@@ -9,8 +9,8 @@ CEL-based `api_key_selection` strategies are deprecated. Attached provider keys 
 
 When multiple keys are configured for a provider, the gateway automatically fails over between them:
 
-1. Keys are tried in **reverse order of attachment**—the most recently attached key first
-2. If a key fails, the next key is tried automatically
+1. Keys are tried in **reverse order of attachment**—the most recently attached key first.
+2. If a key fails, the next key is tried automatically.
 3. Failover triggers include:
    - **Rate limit errors** (HTTP 429)
    - **Quota exceeded** responses from the provider

--- a/ai-gateway/guides/managing-provider-keys.mdx
+++ b/ai-gateway/guides/managing-provider-keys.mdx
@@ -1,13 +1,13 @@
 ---
 title: Managing Provider Keys (Traffic Policy)
-description: Store and rotate provider API keys configured in Traffic Policy, for CEL-based selection and custom providers.
+description: Store and rotate provider API keys configured in Traffic Policy for custom and self-hosted providers.
 ---
 
 <Warning>
 Configuring provider API keys in Traffic Policy (`providers[].api_keys`) is deprecated for standard providers. Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead: no Vaults & Secrets required, and keys can be rotated without redeploying your Traffic Policy. See [Migrate to Attached Provider Keys](/ai-gateway/guides/migrate-to-attached-provider-keys).
 </Warning>
 
-This guide covers Traffic Policy key management for the cases that still require it: [CEL-based key selection](/ai-gateway/guides/key-selection-failover) and custom or self-hosted providers with a `base_url`.
+This guide covers Traffic Policy key management for the cases that still require it: custom or self-hosted providers with a `base_url`.
 
 <Warning>
 When you configure provider keys in Traffic Policy, anyone with your endpoint URL can make requests using your provider keys. See [Securing Your Gateway](/ai-gateway/guides/protecting-byok-endpoints) to add authorization.
@@ -162,6 +162,4 @@ This is useful for:
 
 - [Securing Your Gateway](/ai-gateway/guides/protecting-byok-endpoints) - Add authorization when using server-side keys
 - [BYOK Overview](/ai-gateway/concepts/bring-your-own-keys) - Understanding Bring Your Own Keys
-- [Key Selection & Failover](/ai-gateway/guides/key-selection-failover) - Intelligent key selection with CEL expressions
 - [Configuring Providers](/ai-gateway/guides/configuring-providers) - Full provider setup
-- [CEL Functions Reference](/ai-gateway/reference/cel-functions#api-key-selection) - Complete API key selection reference

--- a/ai-gateway/guides/managing-provider-keys.mdx
+++ b/ai-gateway/guides/managing-provider-keys.mdx
@@ -1,12 +1,16 @@
 ---
-title: Managing Provider Keys
-description: Store, rotate, and manage your own provider API keys for BYOK usage.
+title: Managing Provider Keys (Traffic Policy)
+description: Store and rotate provider API keys configured in Traffic Policy, for CEL-based selection and custom providers.
 ---
 
-This guide covers managing provider API keys when using your own keys (BYOK). If you're using AI Gateway API Keys, key management is handled automatically—see [AI Gateway API Keys](/ai-gateway/concepts/api-keys).
+<Warning>
+Configuring provider API keys in Traffic Policy (`providers[].api_keys`) is deprecated for standard providers. Use [Attached Provider Keys](/ai-gateway/guides/attaching-provider-keys) instead: no Vaults & Secrets required, and keys can be rotated without redeploying your Traffic Policy. See [Migrate to Attached Provider Keys](/ai-gateway/guides/migrate-to-attached-provider-keys).
+</Warning>
+
+This guide covers Traffic Policy key management for the cases that still require it: [CEL-based key selection](/ai-gateway/guides/key-selection-failover) and custom or self-hosted providers with a `base_url`.
 
 <Warning>
-When you configure provider keys in the gateway, anyone with your endpoint URL can make requests using your provider keys. See [Securing Your Gateway](/ai-gateway/guides/protecting-byok-endpoints) to add authorization.
+When you configure provider keys in Traffic Policy, anyone with your endpoint URL can make requests using your provider keys. See [Securing Your Gateway](/ai-gateway/guides/protecting-byok-endpoints) to add authorization.
 </Warning>
 
 ## Key storage options

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -1,0 +1,212 @@
+---
+title: Migrate from Traffic Policy Keys to Attached Provider Keys
+sidebarTitle: Migrate to Attached Provider Keys
+description: Move your provider API keys out of Traffic Policy config and attach them directly to your AI Gateway API Key.
+---
+
+If you're using `providers[].api_keys` in your Traffic Policy to configure BYOK, you can move those keys to be attached directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). This removes key management from your Traffic Policy entirely—no more secrets references, no redeployment needed when rotating keys.
+
+## Before you start
+
+This migration applies to you if your Traffic Policy has `api_keys` under one or more providers:
+
+```yaml
+providers:
+  - id: openai
+    api_keys:                                           # ← migrating this
+      - value: ${secrets.get('openai', 'primary-key')}
+      - value: ${secrets.get('openai', 'backup-key')}
+```
+
+**Check that this migration makes sense for you.** Attached provider keys don't support:
+
+- **CEL-based key selection**: if you use `api_key_selection.strategy` with quota or error-rate expressions, keep those keys in Traffic Policy. Attached keys use simple ordered failover only.
+- **Custom or self-hosted providers**: providers with a `base_url` must stay in Traffic Policy.
+
+If either of those applies, see [partial migration](#partial-migration) below.
+
+## Migration steps
+
+<Steps>
+  <Step title="Attach your keys to your AI Gateway API Key">
+    For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
+
+    If you stored keys in ngrok Vaults & Secrets, retrieve them first—you'll need the raw key values:
+
+    ```bash
+    ngrok api secrets get --vault openai --name primary-key
+    ```
+
+    Then attach each key:
+
+    ```bash
+    # Attach OpenAI primary key
+    ngrok api ai-gateway-api-keys add-provider-key \
+      --id ngk_xxxxx \
+      --provider openai \
+      --secret-key sk-proj-primary...
+
+    # Attach OpenAI backup key
+    ngrok api ai-gateway-api-keys add-provider-key \
+      --id ngk_xxxxx \
+      --provider openai \
+      --secret-key sk-proj-backup...
+
+    # Attach Anthropic key
+    ngrok api ai-gateway-api-keys add-provider-key \
+      --id ngk_xxxxx \
+      --provider anthropic \
+      --secret-key sk-ant-...
+    ```
+
+    Keys are tried in the order they are attached, matching the failover behavior from Traffic Policy.
+
+    <Tip>
+    Attach keys in the same order they appear in your Traffic Policy so failover behavior stays the same.
+    </Tip>
+  </Step>
+
+  <Step title="Verify the attached keys work">
+    Before removing keys from Traffic Policy, confirm your attached keys are routing correctly. Make a test request using your AI Gateway API Key and check the response:
+
+    ```python
+    from openai import OpenAI
+
+    client = OpenAI(
+        base_url="https://your-ai-gateway.ngrok.app/v1",
+        api_key="ng-xxxxx-g1-xxxxx"
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "ping"}]
+    )
+    print(response.choices[0].message.content)
+    ```
+
+    Check [Traffic Inspector](/ai-gateway/observability/traffic-inspector) to confirm the request used your attached key, not the Traffic Policy key. At this point both are configured—Traffic Policy BYOK takes precedence—so you're still on the old path until the next step.
+  </Step>
+
+  <Step title="Remove api_keys from your Traffic Policy">
+    Remove the `api_keys` fields from your provider configurations. If a provider has no other configuration (models, `base_url`, metadata), you can remove it entirely.
+
+    **Before:**
+
+    ```yaml
+    on_http_request:
+      - type: ai-gateway
+        config:
+          providers:
+            - id: openai
+              api_keys:
+                - value: ${secrets.get('openai', 'primary-key')}
+                - value: ${secrets.get('openai', 'backup-key')}
+            - id: anthropic
+              api_keys:
+                - value: ${secrets.get('anthropic', 'key')}
+    ```
+
+    **After:**
+
+    ```yaml
+    on_http_request:
+      - type: ai-gateway
+        config: {}
+    ```
+
+    Or if you have other provider configuration to keep:
+
+    ```yaml
+    on_http_request:
+      - type: ai-gateway
+        config:
+          providers:
+            - id: openai
+              models:
+                - id: gpt-4o
+                - id: gpt-4o-mini
+            - id: anthropic
+              # api_keys removed; key is now attached to the AI Gateway API Key
+    ```
+
+    Deploy the updated Traffic Policy.
+  </Step>
+
+  <Step title="Confirm requests still work">
+    Make another test request and verify it succeeds. The gateway now routes using your attached provider keys.
+
+    If requests fail, check [error codes](/ai-gateway/reference/error-codes) and verify your keys were attached correctly:
+
+    ```bash
+    ngrok api ai-gateway-api-keys list-provider-keys --id ngk_xxxxx
+    ```
+  </Step>
+
+  <Step title="Clean up secrets (optional)">
+    If the only consumers of your Vaults & Secrets entries were these Traffic Policy references, you can delete them:
+
+    ```bash
+    ngrok api secrets delete --vault openai --name primary-key
+    ngrok api secrets delete --vault openai --name backup-key
+    ngrok api secrets delete --vault anthropic --name key
+    ```
+
+    <Warning>
+    Only delete secrets after confirming your Traffic Policy no longer references them and all deployments have picked up the updated config.
+    </Warning>
+  </Step>
+</Steps>
+
+## Partial migration
+
+If you have a mix of simple keys and CEL-based selection, you can migrate the simple providers and leave the advanced ones in Traffic Policy.
+
+For example, if you have OpenAI with CEL selection and Anthropic with simple keys:
+
+```yaml
+# Keep this in Traffic Policy; CEL selection stays
+providers:
+  - id: openai
+    api_keys:
+      - value: ${secrets.get('openai', 'key-one')}
+      - value: ${secrets.get('openai', 'key-two')}
+      - value: ${secrets.get('openai', 'key-three')}
+api_key_selection:
+  strategy:
+    - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
+    - "ai.keys"
+```
+
+Attach only the Anthropic key:
+
+```bash
+ngrok api ai-gateway-api-keys add-provider-key \
+  --id ngk_xxxxx \
+  --provider anthropic \
+  --secret-key sk-ant-...
+```
+
+Then remove only the Anthropic `api_keys` from Traffic Policy. The routing priority still holds—Traffic Policy BYOK on OpenAI wins over any attached key, and Anthropic uses the attached key.
+
+## What doesn't change
+
+- **Your application code**: same AI Gateway API Key, same gateway URL, no client changes needed
+- **Failover behavior**: attached keys are tried in the order they were attached, same as Traffic Policy list ordering
+- **Gateway auth**: the gateway still validates requests with your AI Gateway API Key before routing
+- **Observability**: logs and metrics work the same way; you can inspect which key was used in [Traffic Inspector](/ai-gateway/observability/traffic-inspector)
+
+## What changes
+
+| | Traffic Policy BYOK | Attached provider keys |
+|---|---|---|
+| Key rotation | Update secret or Traffic Policy, redeploy | Add new key, remove old key via API—no redeploy |
+| CEL selection | Supported | Not supported (simple failover only) |
+| Custom providers (`base_url`) | Supported | Not supported—keep in Traffic Policy |
+| Secrets vault needed | Yes | No |
+| Key visible in config | As secret reference | Never visible |
+
+## Next steps
+
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): full reference for managing attached keys
+- [Key Selection & Failover](/ai-gateway/guides/key-selection-failover): keeping CEL selection for advanced use cases
+- [Managing Provider Keys (BYOK)](/ai-gateway/guides/managing-provider-keys): if you're staying with Traffic Policy keys

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -18,12 +18,9 @@ providers:
       - value: ${secrets.get('openai', 'backup-key')}
 ```
 
-**Two cases still require Traffic Policy keys** and cannot be migrated yet:
+**One case still requires Traffic Policy keys** and cannot be migrated:
 
-- **CEL-based key selection**: if you use `api_key_selection.strategy` with quota or error-rate expressions, keep those keys in Traffic Policy. Attached keys use simple ordered failover only.
 - **Custom or self-hosted providers**: providers with a `base_url` must stay in Traffic Policy.
-
-If either of those applies, see [partial migration](#partial-migration) below.
 
 ## Migration steps
 
@@ -41,22 +38,25 @@ If either of those applies, see [partial migration](#partial-migration) below.
 
     ```bash
     # Attach OpenAI primary key
-    ngrok api ai-gateway-api-keys add-provider-key \
-      --id ngk_xxxxx \
-      --provider openai \
-      --secret-key sk-proj-primary...
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id openai \
+      --name "OpenAI Primary" \
+      --value sk-proj-primary...
 
     # Attach OpenAI backup key
-    ngrok api ai-gateway-api-keys add-provider-key \
-      --id ngk_xxxxx \
-      --provider openai \
-      --secret-key sk-proj-backup...
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id openai \
+      --name "OpenAI Backup" \
+      --value sk-proj-backup...
 
     # Attach Anthropic key
-    ngrok api ai-gateway-api-keys add-provider-key \
-      --id ngk_xxxxx \
-      --provider anthropic \
-      --secret-key sk-ant-...
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id anthropic \
+      --name "Anthropic Key" \
+      --value sk-ant-...
     ```
 
     Keys are tried in the order they are attached, matching the failover behavior from Traffic Policy.
@@ -138,7 +138,7 @@ If either of those applies, see [partial migration](#partial-migration) below.
     If requests fail, check [error codes](/ai-gateway/reference/error-codes) and verify your keys were attached correctly:
 
     ```bash
-    ngrok api ai-gateway-api-keys list-provider-keys --id ngk_xxxxx
+    ngrok api ai-gateway-provider-keys list --ai-gateway-api-key-id aigk_xxxxx
     ```
   </Step>
 
@@ -157,36 +157,6 @@ If either of those applies, see [partial migration](#partial-migration) below.
   </Step>
 </Steps>
 
-## Partial migration
-
-If you have a mix of simple keys and CEL-based selection, you can migrate the simple providers and leave the advanced ones in Traffic Policy.
-
-For example, if you have OpenAI with CEL selection and Anthropic with simple keys:
-
-```yaml
-# Keep this in Traffic Policy; CEL selection stays
-providers:
-  - id: openai
-    api_keys:
-      - value: ${secrets.get('openai', 'key-one')}
-      - value: ${secrets.get('openai', 'key-two')}
-      - value: ${secrets.get('openai', 'key-three')}
-api_key_selection:
-  strategy:
-    - "ai.keys.filter(k, k.quota.remaining_requests > 100)"
-    - "ai.keys"
-```
-
-Attach only the Anthropic key:
-
-```bash
-ngrok api ai-gateway-api-keys add-provider-key \
-  --id ngk_xxxxx \
-  --provider anthropic \
-  --secret-key sk-ant-...
-```
-
-Then remove only the Anthropic `api_keys` from Traffic Policy. The routing priority still holds—Traffic Policy BYOK on OpenAI wins over any attached key, and Anthropic uses the attached key.
 
 ## What doesn't change
 
@@ -208,5 +178,4 @@ Then remove only the Anthropic `api_keys` from Traffic Policy. The routing prior
 ## Next steps
 
 - [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): full reference for managing attached keys
-- [Key Selection & Failover](/ai-gateway/guides/key-selection-failover): keeping CEL selection for advanced use cases
-- [Managing Provider Keys (BYOK)](/ai-gateway/guides/managing-provider-keys): if you're staying with Traffic Policy keys
+- [Managing Provider Keys (BYOK)](/ai-gateway/guides/managing-provider-keys): if you're staying with Traffic Policy keys for custom providers

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -28,11 +28,7 @@ providers:
   <Step title="Attach your keys to your AI Gateway API Key">
     For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
 
-    If you stored keys in ngrok Vaults & Secrets, retrieve them first—you'll need the raw key values:
-
-    ```bash
-    ngrok api secrets get --vault openai --name primary-key
-    ```
+    If you stored keys in ngrok Vaults & Secrets, retrieve the raw key values:
 
     Then attach each key:
 
@@ -41,21 +37,21 @@ providers:
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id openai \
-      --name "OpenAI Primary" \
+      --description "OpenAI Primary" \
       --value sk-proj-primary...
 
     # Attach OpenAI backup key
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id openai \
-      --name "OpenAI Backup" \
+      --description "OpenAI Backup" \
       --value sk-proj-backup...
 
     # Attach Anthropic key
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id anthropic \
-      --name "Anthropic Key" \
+      --description "Anthropic Key" \
       --value sk-ant-...
     ```
 
@@ -146,9 +142,9 @@ providers:
     If the only consumers of your Vaults & Secrets entries were these Traffic Policy references, you can delete them:
 
     ```bash
-    ngrok api secrets delete --vault openai --name primary-key
-    ngrok api secrets delete --vault openai --name backup-key
-    ngrok api secrets delete --vault anthropic --name key
+    ngrok api secrets delete --vault openai --description primary-key
+    ngrok api secrets delete --vault openai --description backup-key
+    ngrok api secrets delete --vault anthropic --description key
     ```
 
     <Warning>

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -11,11 +11,16 @@ API keys in Traffic Policy config is deprecated for standard providers. The supp
 This migration applies to you if your Traffic Policy has `api_keys` under one or more providers:
 
 ```yaml
-providers:
-  - id: openai
-    api_keys:                                           # ← migrating this
-      - value: ${secrets.get('openai', 'primary-key')}
-      - value: ${secrets.get('openai', 'backup-key')}
+on_http_request:
+  - name: DefaultAIGateway
+    actions:
+      - type: ai-gateway
+        config:
+          providers:
+            - id: openai
+              api_keys: # ← migrating this
+                - value: ${secrets.get('openai', 'primary-key')}
+                - value: ${secrets.get('openai', 'backup-key')}
 ```
 
 **One case still requires Traffic Policy keys** and cannot be migrated:
@@ -25,12 +30,18 @@ providers:
 ## Migration steps
 
 <Steps>
+  <Step title="Create an AI Gateway Managed Key">
+  First we'll need to create a AI Gateway Managed Key that will be added to your SDK or cURL requests.
+  ```bash
+  nd api ai-gateway-api-keys create \
+  --endpoint-id ep_xxxx \
+
+  ```
+
+  Make sure to save the ng-xxxxx-g1-xxxxx token since this will be the only time you'll see the unredacted key
+  </Step>
   <Step title="Attach your keys to your AI Gateway API Key">
     For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
-
-    If you stored keys in ngrok Vaults & Secrets, retrieve the raw key values
-
-    Then attach each key:
 
     ```bash
     # Attach OpenAI primary key
@@ -46,14 +57,6 @@ providers:
       --provider-id openai \
       --description "OpenAI Backup" \
       --value sk-proj-backup...
-
-    # Attach Anthropic key
-    ngrok api ai-gateway-provider-keys create \
-      --ai-gateway-api-key-id aigk_xxxxx \
-      --provider-id anthropic \
-      --description "Anthropic Key" \
-      --value sk-ant-...
-    ```
 
     Keys are tried in the order they are attached.
 
@@ -77,7 +80,7 @@ providers:
     print(response.choices[0].message.content)
     ```
 
-    Check [Traffic Inspector](/ai-gateway/observability/traffic-inspector) to confirm the request used your attached key. Attached keys take precedence over Traffic Policy BYOK for each provider, so as soon as a key is attached the gateway starts routing through it—even while BYOK is still configured. If the attached key works, you're safe to remove the BYOK config in the next step.
+    Check your AI gateway's usage page to confirm the request used your attached key. If the attached key works, you're safe to remove the BYOK config in the next step.
   </Step>
 
   <Step title="Remove api_keys from your Traffic Policy">
@@ -87,41 +90,26 @@ providers:
 
     ```yaml
     on_http_request:
-      - type: ai-gateway
-        config:
-          providers:
-            - id: openai
-              api_keys:
-                - value: ${secrets.get('openai', 'primary-key')}
-                - value: ${secrets.get('openai', 'backup-key')}
-            - id: anthropic
-              api_keys:
-                - value: ${secrets.get('anthropic', 'key')}
+      actions:
+        - type: ai-gateway
+          config:
+            providers:
+              - id: openai
+                api_keys:
+                  - value: ${secrets.get('openai', 'primary-key')}
+                  - value: ${secrets.get('openai', 'backup-key')}
+              - id: google
+                api_keys:
+                  - value: ${secrets.get('google', 'key')}
     ```
 
     **After:**
 
     ```yaml
     on_http_request:
-      - type: ai-gateway
-        config: {}
+      actions:
+        - type: ai-gateway
     ```
-
-    Or if you have other provider configuration to keep:
-
-    ```yaml
-    on_http_request:
-      - type: ai-gateway
-        config:
-          providers:
-            - id: openai
-              models:
-                - id: gpt-4o
-                - id: gpt-4o-mini
-            - id: anthropic
-              # api_keys removed; key is now attached to the AI Gateway API Key
-    ```
-
     Deploy the updated Traffic Policy.
   </Step>
 

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -23,15 +23,15 @@ on_http_request:
                 - value: ${secrets.get('openai', 'backup-key')}
 ```
 
-**One case still requires Traffic Policy keys** and cannot be migrated:
-
-- **Custom or self-hosted providers**: providers with a `base_url` must stay in Traffic Policy.
+<Warning>
+One case still requires Traffic Policy keys and cannot be migrated: Custom or self-hosted providers (that is, providers with a `base_url`) must stay in Traffic Policy.
+</Warning>
 
 ## Migration steps
 
 <Steps>
   <Step title="Create an AI Gateway Managed Key">
-    First we'll need to create an AI Gateway Managed Key that will be added to your SDK or cURL requests.
+    First, create an AI Gateway Managed Key that will be added to your SDK or cURL requests.
 
     ```bash
     ngrok api ai-gateway-api-keys create \

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Migrate to Attached Provider Keys
 description: Move your provider API keys out of Traffic Policy config and attach them directly to your AI Gateway API Key.
 ---
 
-`providers[].api_keys` in Traffic Policy is deprecated for standard providers. The supported path going forward is to attach keys directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). This removes key management from your Traffic Policy entirely—no more secrets references, no redeployment needed when rotating keys.
+API keys in Traffic Policy config is deprecated for standard providers. The supported path going forward is to attach keys directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). This removes key management from your Traffic Policy entirely—no more secrets references, no redeployment needed when rotating keys.
 
 ## Before you start
 
@@ -28,7 +28,7 @@ providers:
   <Step title="Attach your keys to your AI Gateway API Key">
     For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
 
-    If you stored keys in ngrok Vaults & Secrets, retrieve the raw key values:
+    If you stored keys in ngrok Vaults & Secrets, retrieve the raw key values
 
     Then attach each key:
 
@@ -55,11 +55,8 @@ providers:
       --value sk-ant-...
     ```
 
-    Keys are tried in the order they are attached, matching the failover behavior from Traffic Policy.
+    Keys are tried in the order they are attached.
 
-    <Tip>
-    Attach keys in the same order they appear in your Traffic Policy so failover behavior stays the same.
-    </Tip>
   </Step>
 
   <Step title="Verify the attached keys work">
@@ -137,29 +134,15 @@ providers:
     ngrok api ai-gateway-provider-keys list --ai-gateway-api-key-id aigk_xxxxx
     ```
   </Step>
-
-  <Step title="Clean up secrets (optional)">
-    If the only consumers of your Vaults & Secrets entries were these Traffic Policy references, you can delete them:
-
-    ```bash
-    ngrok api secrets delete --vault openai --description primary-key
-    ngrok api secrets delete --vault openai --description backup-key
-    ngrok api secrets delete --vault anthropic --description key
-    ```
-
-    <Warning>
-    Only delete secrets after confirming your Traffic Policy no longer references them and all deployments have picked up the updated config.
-    </Warning>
-  </Step>
 </Steps>
 
 
 ## What doesn't change
 
 - **Your application code**: same AI Gateway API Key, same gateway URL, no client changes needed
-- **Failover behavior**: attached keys are tried in the order they were attached, same as Traffic Policy list ordering
+- **Failover behavior**: attached keys are tried in the order they were attached
 - **Gateway auth**: the gateway still validates requests with your AI Gateway API Key before routing
-- **Observability**: logs and metrics work the same way; you can inspect which key was used in [Traffic Inspector](/ai-gateway/observability/traffic-inspector)
+- **Observability**: you can inspect which key was used on your AI Gateway's usage page
 
 ## What changes
 

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Migrate to Attached Provider Keys
 description: Move your provider API keys out of Traffic Policy config and attach them directly to your AI Gateway API Key.
 ---
 
-If you're using `providers[].api_keys` in your Traffic Policy to configure BYOK, you can move those keys to be attached directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). This removes key management from your Traffic Policy entirely—no more secrets references, no redeployment needed when rotating keys.
+`providers[].api_keys` in Traffic Policy is deprecated for standard providers. The supported path going forward is to attach keys directly to your [AI Gateway API Key](/ai-gateway/concepts/api-keys). This removes key management from your Traffic Policy entirely—no more secrets references, no redeployment needed when rotating keys.
 
 ## Before you start
 
@@ -18,7 +18,7 @@ providers:
       - value: ${secrets.get('openai', 'backup-key')}
 ```
 
-**Check that this migration makes sense for you.** Attached provider keys don't support:
+**Two cases still require Traffic Policy keys** and cannot be migrated yet:
 
 - **CEL-based key selection**: if you use `api_key_selection.strategy` with quota or error-rate expressions, keep those keys in Traffic Policy. Attached keys use simple ordered failover only.
 - **Custom or self-hosted providers**: providers with a `base_url` must stay in Traffic Policy.

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -44,21 +44,21 @@ on_http_request:
     For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
 
     ```bash
-    # Attach OpenAI primary key
-    ngrok api ai-gateway-provider-keys create \
-      --ai-gateway-api-key-id aigk_xxxxx \
-      --provider-id openai \
-      --description "OpenAI Primary" \
-      --value sk-proj-primary...
-
-    # Attach OpenAI backup key
+    # Attach OpenAI backup key first (tried last)
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id openai \
       --description "OpenAI Backup" \
       --value sk-proj-backup...
 
-    Keys are tried in the order they are attached.
+    # Attach OpenAI primary key last (tried first)
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id openai \
+      --description "OpenAI Primary" \
+      --value sk-proj-primary...
+
+    The most recently attached key is tried first. Attach the key you want tried first **last**.
 
   </Step>
 
@@ -128,7 +128,7 @@ on_http_request:
 ## What doesn't change
 
 - **Your application code**: same AI Gateway API Key, same gateway URL, no client changes needed
-- **Failover behavior**: attached keys are tried in the order they were attached
+- **Failover behavior**: attached keys are tried in reverse order of attachment (most recently attached first)
 - **Gateway auth**: the gateway still validates requests with your AI Gateway API Key before routing
 - **Observability**: you can inspect which key was used on your AI Gateway's usage page
 

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -31,14 +31,14 @@ on_http_request:
 
 <Steps>
   <Step title="Create an AI Gateway Managed Key">
-  First we'll need to create a AI Gateway Managed Key that will be added to your SDK or cURL requests.
-  ```bash
-  nd api ai-gateway-api-keys create \
-  --endpoint-id ep_xxxx \
+    First we'll need to create an AI Gateway Managed Key that will be added to your SDK or cURL requests.
 
-  ```
+    ```bash
+    ngrok api ai-gateway-api-keys create \
+      --endpoint-id ep_xxxx
+    ```
 
-  Make sure to save the ng-xxxxx-g1-xxxxx token since this will be the only time you'll see the unredacted key
+    Make sure to save the `ng-xxxxx-g1-xxxxx` token since this will be the only time you'll see the unredacted key.
   </Step>
   <Step title="Attach your keys to your AI Gateway API Key">
     For each provider and key in your Traffic Policy, attach the key to your AI Gateway API Key.
@@ -57,9 +57,9 @@ on_http_request:
       --provider-id openai \
       --description "OpenAI Primary" \
       --value sk-proj-primary...
+    ```
 
     The most recently attached key is tried first. Attach the key you want tried first **last**.
-
   </Step>
 
   <Step title="Verify the attached keys work">

--- a/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
+++ b/ai-gateway/guides/migrate-to-attached-provider-keys.mdx
@@ -77,7 +77,7 @@ providers:
     print(response.choices[0].message.content)
     ```
 
-    Check [Traffic Inspector](/ai-gateway/observability/traffic-inspector) to confirm the request used your attached key, not the Traffic Policy key. At this point both are configured—Traffic Policy BYOK takes precedence—so you're still on the old path until the next step.
+    Check [Traffic Inspector](/ai-gateway/observability/traffic-inspector) to confirm the request used your attached key. Attached keys take precedence over Traffic Policy BYOK for each provider, so as soon as a key is attached the gateway starts routing through it—even while BYOK is still configured. If the attached key works, you're safe to remove the BYOK config in the next step.
   </Step>
 
   <Step title="Remove api_keys from your Traffic Policy">

--- a/ai-gateway/guides/model-selection-strategies.mdx
+++ b/ai-gateway/guides/model-selection-strategies.mdx
@@ -237,7 +237,7 @@ m.metrics.endpoint.latency.upstream_ms_avg
 
 
 <Note>
-When accessing API key metrics, always check if the key exists first using `'key_id' in m.metrics.api_keys`. See [Metrics Reference](/ai-gateway/observability/metrics#quota-metrics-api-key-scope-only) for details.
+`m.metrics.api_keys` is sparse — it only contains entries for keys that have made requests recently, so accessing a missing entry throws. Always gate with `'key_id' in m.metrics.api_keys` first. See [Metrics Reference](/ai-gateway/observability/metrics#quota-metrics-api-key-scope-only) for details.
 </Note>
 ## CEL operators
 

--- a/ai-gateway/guides/model-selection-strategies.mdx
+++ b/ai-gateway/guides/model-selection-strategies.mdx
@@ -237,7 +237,7 @@ m.metrics.endpoint.latency.upstream_ms_avg
 
 
 <Note>
-`m.metrics.api_keys` is sparse — it only contains entries for keys that have made requests recently, so accessing a missing entry throws. Always gate with `'key_id' in m.metrics.api_keys` first. See [Metrics Reference](/ai-gateway/observability/metrics#quota-metrics-api-key-scope-only) for details.
+`m.metrics.api_keys` is sparse: it only contains entries for keys that have made requests recently, so accessing a missing entry throws. Always gate with `'key_id' in m.metrics.api_keys` first. See [Metrics Reference](/ai-gateway/observability/metrics#quota-metrics-api-key-scope-only) for details.
 </Note>
 ## CEL operators
 

--- a/ai-gateway/observability/metrics.mdx
+++ b/ai-gateway/observability/metrics.mdx
@@ -13,7 +13,6 @@ The AI Gateway collects real-time performance metrics that you can use in [model
 
 - General `expression` fields in Traffic Policies
 - Other action configurations
-- `api_key_selection.strategy` expressions (not yet implemented)
 
 This is because metrics are populated at runtime during AI Gateway request processing, specifically when evaluating model selection strategies.
 </Warning>

--- a/ai-gateway/observability/metrics.mdx
+++ b/ai-gateway/observability/metrics.mdx
@@ -113,9 +113,9 @@ Token metrics are only available at Account, Endpoint, and API Key scopes. Globa
 ### Quota metrics (API key scope only)
 
 <Warning>
-**Safe API key access**: `m.metrics.api_keys` is only populated for keys that have made requests recently, so a given model may have no entry for a given key. Accessing a missing map entry in CEL throws — always check existence first.
+**Safe API key access**: `m.metrics.api_keys` is only populated for keys that have made requests recently, so a given model may have no entry for a given key. Accessing a missing map entry in CEL throws—always check existence first.
 
-❌ This errors if the key hasn't issued a request for this model yet:
+❌ This throws an error if the key hasn't issued a request for this model yet:
 
 ```yaml
 - "ai.models.filter(m, m.metrics.api_keys['my-key-id'].latency.upstream_ms_avg < 1000)"

--- a/ai-gateway/observability/metrics.mdx
+++ b/ai-gateway/observability/metrics.mdx
@@ -113,19 +113,21 @@ Token metrics are only available at Account, Endpoint, and API Key scopes. Globa
 ### Quota metrics (API key scope only)
 
 <Warning>
-**Safe API key access**: Not all models have metrics for every API key. Always check if the key exists before accessing it.
+**Safe API key access**: `m.metrics.api_keys` is only populated for keys that have made requests recently, so a given model may have no entry for a given key. Accessing a missing map entry in CEL throws — always check existence first.
 
-❌ This will error if metrics don't exist for this API key:
+❌ This errors if the key hasn't issued a request for this model yet:
 
 ```yaml
-- "ai.models.filter(m, m.metrics.api_keys['sk-abc123'].latency.upstream_ms_avg < 1000)"
+- "ai.models.filter(m, m.metrics.api_keys['my-key-id'].latency.upstream_ms_avg < 1000)"
 ```
 
 ✅ Check the key exists first:
 
 ```yaml
-- "ai.models.filter(m, 'sk-abc123' in m.metrics.api_keys && m.metrics.api_keys['sk-abc123'].latency.upstream_ms_avg < 1000)"
+- "ai.models.filter(m, 'my-key-id' in m.metrics.api_keys && m.metrics.api_keys['my-key-id'].latency.upstream_ms_avg < 1000)"
 ```
+
+Keys in this map are AI Gateway API Key IDs, not raw key values.
 </Warning>
 
 Access via `m.metrics.api_keys["key_id"].quota`:

--- a/ai-gateway/observability/traffic-inspector.mdx
+++ b/ai-gateway/observability/traffic-inspector.mdx
@@ -45,12 +45,12 @@ This is useful for:
 Traffic Inspector shows **standard HTTP request/response data**. The AI Gateway does not currently add AI-specific instrumentation to Traffic Inspector.
 
 **Not currently available:**
-- Which provider was selected from your configured list
+- Which provider was selected
+- Whether a request used an attached provider key, ngrok-managed key, or passthrough
 - Retry attempts and failover decisions
 - Token counts and cost estimates
 - Model selection strategy evaluation results
 - Per-provider latency breakdowns
-- API key selection details
 
 These features are on our roadmap. Email [niji@ngrok.ai](mailto:niji@ngrok.ai) to tell us what you'd like to see—your feedback directly influences our roadmap.
 </Warning>

--- a/ai-gateway/providers/anthropic.mdx
+++ b/ai-gateway/providers/anthropic.mdx
@@ -132,7 +132,7 @@ Attach your Anthropic key to your AI Gateway API Key. ngrok encrypts and stores 
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id anthropic \
-      --name "My Anthropic Key" \
+      --description "My Anthropic Key" \
       --value sk-ant-...
     ```
   </Step>

--- a/ai-gateway/providers/anthropic.mdx
+++ b/ai-gateway/providers/anthropic.mdx
@@ -120,7 +120,7 @@ curl https://your-ai-gateway.ngrok.app/v1/messages \
 
 ## Attach your own key
 
-Attach your Anthropic key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
+Attach your Anthropic key to your AI Gateway API Key. ngrok encrypts and stores it server-side, so clients only ever send your AI Gateway API Key.
 
 <Steps>
   <Step title="Get an Anthropic API key">

--- a/ai-gateway/providers/anthropic.mdx
+++ b/ai-gateway/providers/anthropic.mdx
@@ -118,154 +118,27 @@ curl https://your-ai-gateway.ngrok.app/v1/messages \
 ```
 </CodeGroup>
 
-## Bring your own key
+## Attach your own key
 
-Use your own Anthropic API key. Pass it directly—the gateway forwards it to Anthropic.
+Attach your Anthropic key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
 
 <Steps>
-  <Step title="Create an AI Gateway">
-    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint.
-  </Step>
-
   <Step title="Get an Anthropic API key">
     Create an account at [console.anthropic.com](https://console.anthropic.com) and generate an API key. Keys start with `sk-ant-`.
   </Step>
 
-  <Step title="Make a request">
-    Pass your key directly—the gateway forwards it to Anthropic.
-
-    <CodeGroup>
-    ```python Python (OpenAI SDK)
-    from openai import OpenAI
-
-    client = OpenAI(
-        base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="sk-ant-..."  # Your Anthropic key, forwarded by gateway
-    )
-
-    response = client.chat.completions.create(
-        model="claude-opus-4-6",
-        messages=[{"role": "user", "content": "Hello!"}]
-    )
-
-    print(response.choices[0].message.content)
-    ```
-
-    ```python Python (Anthropic SDK)
-    import anthropic
-
-    client = anthropic.Anthropic(
-        base_url="https://your-ai-gateway.ngrok.app",
-        api_key="sk-ant-..."  # Your Anthropic key, forwarded by gateway
-    )
-
-    message = client.messages.create(
-        model="claude-opus-4-6",
-        max_tokens=1024,
-        messages=[{"role": "user", "content": "Hello!"}]
-    )
-
-    print(message.content[0].text)
-    ```
-
-    ```typescript TypeScript (OpenAI SDK)
-    import OpenAI from "openai";
-
-    const client = new OpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
-    });
-
-    const response = await client.chat.completions.create({
-      model: "claude-opus-4-6",
-      messages: [{ role: "user", content: "Hello!" }],
-    });
-
-    console.log(response.choices[0].message.content);
-    ```
-
-    ```typescript TypeScript (Anthropic SDK)
-    import Anthropic from "@anthropic-ai/sdk";
-
-    const client = new Anthropic({
-      baseURL: "https://your-ai-gateway.ngrok.app",
-      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
-    });
-
-    const message = await client.messages.create({
-      model: "claude-opus-4-6",
-      max_tokens: 1024,
-      messages: [{ role: "user", content: "Hello!" }],
-    });
-
-    console.log(message.content[0].text);
-    ```
-
-    ```typescript Vercel AI SDK
-    import { generateText } from "ai";
-    import { createOpenAI } from "@ai-sdk/openai";
-
-    const gateway = createOpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "sk-ant-...",  // Your Anthropic key, forwarded by gateway
-    });
-
-    const { text } = await generateText({
-      model: gateway("claude-opus-4-6"),
-      prompt: "Hello!",
-    });
-
-    console.log(text);
-    ```
-
-    ```bash cURL
-    curl https://your-ai-gateway.ngrok.app/v1/messages \
-      -H "Content-Type: application/json" \
-      -H "x-api-key: sk-ant-..." \
-      -H "anthropic-version: 2023-06-01" \
-      -d '{
-        "model": "claude-opus-4-6",
-        "max_tokens": 1024,
-        "messages": [{"role": "user", "content": "Hello!"}]
-      }'
-    ```
-    </CodeGroup>
-  </Step>
-</Steps>
-
-## Store key in the gateway
-
-Instead of each client passing their own key, you can store it once in ngrok Secrets and have the gateway inject it automatically.
-
-<Warning>
-Storing your provider key in the gateway makes your endpoint publicly accessible. You must add authorization to prevent unauthorized use and unexpected charges. See [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints).
-</Warning>
-
-<Steps>
-  <Step title="Store your key in ngrok secrets">
+  <Step title="Attach the key">
     ```bash
-    ngrok api secrets create \
-      --name anthropic \
-      --secret-data '{"api-key": "sk-ant-..."}'
-    ```
-
-    Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
-  </Step>
-
-  <Step title="Configure your Traffic Policy">
-    ```yaml
-    on_http_request:
-      - type: ai-gateway
-        config:
-          providers:
-            - id: "anthropic"
-              api_keys:
-                - value: ${secrets.get('anthropic', 'api-key')}
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id anthropic \
+      --name "My Anthropic Key" \
+      --value sk-ant-...
     ```
   </Step>
 
   <Step title="Make a request">
-    Clients no longer need an Anthropic key—pass any value for `api_key`.
+    Use your AI Gateway API Key—the gateway resolves the Anthropic key server-side.
 
     <CodeGroup>
     ```python Python (OpenAI SDK)
@@ -273,7 +146,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     client = OpenAI(
         base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="unused"  # Gateway injects your Anthropic key
+        api_key="ng-xxxxx-g1-xxxxx"  # Your AI Gateway API Key
     )
 
     response = client.chat.completions.create(
@@ -289,7 +162,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     client = anthropic.Anthropic(
         base_url="https://your-ai-gateway.ngrok.app",
-        api_key="unused"  # Gateway injects your Anthropic key
+        api_key="ng-xxxxx-g1-xxxxx"  # Your AI Gateway API Key
     )
 
     message = client.messages.create(
@@ -306,7 +179,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     const client = new OpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your Anthropic key
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const response = await client.chat.completions.create({
@@ -322,7 +195,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     const client = new Anthropic({
       baseURL: "https://your-ai-gateway.ngrok.app",
-      apiKey: "unused",  // Gateway injects your Anthropic key
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const message = await client.messages.create({
@@ -340,7 +213,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     const gateway = createOpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your Anthropic key
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const { text } = await generateText({
@@ -354,7 +227,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
     ```bash cURL
     curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer unused" \
+      -H "Authorization: Bearer ng-xxxxx-g1-xxxxx" \
       -d '{
         "model": "claude-opus-4-6",
         "messages": [{"role": "user", "content": "Hello!"}]
@@ -363,6 +236,8 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
     </CodeGroup>
   </Step>
 </Steps>
+
+See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for key rotation, listing, and removing attached keys.
 
 ## Explicit provider routing
 
@@ -382,5 +257,6 @@ See the [model catalog](/ai-gateway/reference/model-catalog#anthropic) for the f
 ## Next steps
 
 - [AI Gateway API Keys](/ai-gateway/concepts/api-keys): use ngrok-managed keys for the simplest setup
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): attach, rotate, and manage your own Anthropic keys
 - [Anthropic SDK guide](/ai-gateway/sdks/anthropic): detailed SDK integration
 - [Multi-provider failover](/ai-gateway/examples/multi-provider-failover): automatic failover across providers

--- a/ai-gateway/providers/google.mdx
+++ b/ai-gateway/providers/google.mdx
@@ -5,19 +5,31 @@ description: Use Google Gemini models through the ngrok AI Gateway.
 
 [Google AI Studio](https://aistudio.google.com) provides Gemini models. Google requires you to bring your own key—ngrok-managed keys are not available for Google.
 
-## Setup
+## Attach your key
+
+Attach your Google key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
 
 <Steps>
   <Step title="Create an AI Gateway endpoint">
-    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint.
+    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint with an AI Gateway API Key.
   </Step>
 
   <Step title="Get a Google AI API key">
     Generate an API key at [aistudio.google.com](https://aistudio.google.com). Keys are available on the free tier.
   </Step>
 
+  <Step title="Attach the key">
+    ```bash
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id google \
+      --name "My Google Key" \
+      --value AIza...
+    ```
+  </Step>
+
   <Step title="Make a request">
-    Pass your key directly—the gateway forwards it to Google.
+    Use your AI Gateway API Key—the gateway resolves the Google key server-side.
 
     <CodeGroup>
     ```python Python
@@ -25,7 +37,7 @@ description: Use Google Gemini models through the ngrok AI Gateway.
 
     client = OpenAI(
         base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="AIza..."  # Your Google AI key, forwarded by gateway
+        api_key="ng-xxxxx-g1-xxxxx"  # Your AI Gateway API Key
     )
 
     response = client.chat.completions.create(
@@ -41,7 +53,7 @@ description: Use Google Gemini models through the ngrok AI Gateway.
 
     const client = new OpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "AIza...",  // Your Google AI key, forwarded by gateway
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const response = await client.chat.completions.create({
@@ -58,7 +70,7 @@ description: Use Google Gemini models through the ngrok AI Gateway.
 
     const gateway = createOpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "AIza...",  // Your Google AI key, forwarded by gateway
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const { text } = await generateText({
@@ -72,7 +84,7 @@ description: Use Google Gemini models through the ngrok AI Gateway.
     ```bash cURL
     curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer AIza..." \
+      -H "Authorization: Bearer ng-xxxxx-g1-xxxxx" \
       -d '{
         "model": "gemini-2.5-flash",
         "messages": [{"role": "user", "content": "Hello!"}]
@@ -81,110 +93,14 @@ description: Use Google Gemini models through the ngrok AI Gateway.
     </CodeGroup>
   </Step>
 </Steps>
+
+See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for key rotation, listing, and removing attached keys.
 
 ## Available models
 
 See the [model catalog](/ai-gateway/reference/model-catalog#google) for the full list of supported Gemini models.
 
-## Store key in the gateway
-
-Instead of each client passing their own key, you can store it once in ngrok Secrets and have the gateway inject it automatically.
-
-<Warning>
-Storing your provider key in the gateway makes your endpoint publicly accessible. You must add authorization to prevent unauthorized use and unexpected charges. See [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints).
-</Warning>
-
-<Steps>
-  <Step title="Store your key in ngrok secrets">
-    ```bash
-    ngrok api secrets create \
-      --name google \
-      --secret-data '{"api-key": "AIza..."}'
-    ```
-
-    Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
-  </Step>
-
-  <Step title="Configure your traffic policy">
-    ```yaml
-    on_http_request:
-      - type: ai-gateway
-        config:
-          providers:
-            - id: "google"
-              api_keys:
-                - value: ${secrets.get('google', 'api-key')}
-    ```
-  </Step>
-
-  <Step title="Make a request">
-    Clients no longer need a Google key—pass any value for `api_key`.
-
-    <CodeGroup>
-    ```python Python
-    from openai import OpenAI
-
-    client = OpenAI(
-        base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="unused"  # Gateway injects your Google key
-    )
-
-    response = client.chat.completions.create(
-        model="gemini-2.5-flash",
-        messages=[{"role": "user", "content": "Hello!"}]
-    )
-
-    print(response.choices[0].message.content)
-    ```
-
-    ```typescript TypeScript
-    import OpenAI from "openai";
-
-    const client = new OpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your Google key
-    });
-
-    const response = await client.chat.completions.create({
-      model: "gemini-2.5-flash",
-      messages: [{ role: "user", content: "Hello!" }],
-    });
-
-    console.log(response.choices[0].message.content);
-    ```
-
-    ```typescript Vercel AI SDK
-    import { generateText } from "ai";
-    import { createOpenAI } from "@ai-sdk/openai";
-
-    const gateway = createOpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your Google key
-    });
-
-    const { text } = await generateText({
-      model: gateway("gemini-2.5-flash"),
-      prompt: "Hello!",
-    });
-
-    console.log(text);
-    ```
-
-    ```bash cURL
-    curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer unused" \
-      -d '{
-        "model": "gemini-2.5-flash",
-        "messages": [{"role": "user", "content": "Hello!"}]
-      }'
-    ```
-    </CodeGroup>
-  </Step>
-</Steps>
-
 ## Next steps
 
-- [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints): add authorization to your endpoint
-- [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys): key rotation and multiple keys
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): attach, rotate, and manage your Google keys
 - [Multi-provider failover](/ai-gateway/examples/multi-provider-failover): failover patterns

--- a/ai-gateway/providers/google.mdx
+++ b/ai-gateway/providers/google.mdx
@@ -23,7 +23,7 @@ Attach your Google key to your AI Gateway API Key. ngrok encrypts and stores it 
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id google \
-      --name "My Google Key" \
+      --description "My Google Key" \
       --value AIza...
     ```
   </Step>

--- a/ai-gateway/providers/google.mdx
+++ b/ai-gateway/providers/google.mdx
@@ -7,7 +7,7 @@ description: Use Google Gemini models through the ngrok AI Gateway.
 
 ## Attach your key
 
-Attach your Google key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
+Attach your Google key to your AI Gateway API Key. ngrok encrypts and stores it server-side, so clients only ever send your AI Gateway API Key.
 
 <Steps>
   <Step title="Create an AI Gateway endpoint">

--- a/ai-gateway/providers/openai.mdx
+++ b/ai-gateway/providers/openai.mdx
@@ -72,7 +72,7 @@ curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
 
 ## Attach your own key
 
-Attach your OpenAI key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
+Attach your OpenAI key to your AI Gateway API Key. ngrok encrypts and stores it server-side, so clients only ever send your AI Gateway API Key.
 
 <Steps>
   <Step title="Get an OpenAI API key">

--- a/ai-gateway/providers/openai.mdx
+++ b/ai-gateway/providers/openai.mdx
@@ -84,7 +84,7 @@ Attach your OpenAI key to your AI Gateway API Key. ngrok encrypts and stores it 
     ngrok api ai-gateway-provider-keys create \
       --ai-gateway-api-key-id aigk_xxxxx \
       --provider-id openai \
-      --name "My OpenAI Key" \
+      --description "My OpenAI Key" \
       --value sk-proj-...
     ```
   </Step>

--- a/ai-gateway/providers/openai.mdx
+++ b/ai-gateway/providers/openai.mdx
@@ -70,118 +70,27 @@ curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
 ```
 </CodeGroup>
 
-## Bring your own key
+## Attach your own key
 
-Use your own OpenAI API key. Pass it directly—the gateway forwards it to OpenAI.
+Attach your OpenAI key to your AI Gateway API Key. ngrok encrypts and stores it server-side—clients only ever send your AI Gateway API Key.
 
 <Steps>
-  <Step title="Create an AI Gateway">
-    If you don't have one yet, follow the [quickstart](/ai-gateway/quickstart) to create your AI Gateway endpoint.
-  </Step>
-
   <Step title="Get an OpenAI API key">
     Create an account at [platform.openai.com](https://platform.openai.com) and generate an API key. Keys start with `sk-proj-`.
   </Step>
 
-  <Step title="Make a request">
-    Pass your key directly—the gateway forwards it to OpenAI.
-
-    <CodeGroup>
-    ```python Python
-    from openai import OpenAI
-
-    client = OpenAI(
-        base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="sk-proj-..."  # Your OpenAI key, forwarded by gateway
-    )
-
-    response = client.chat.completions.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": "Hello!"}]
-    )
-
-    print(response.choices[0].message.content)
-    ```
-
-    ```typescript TypeScript
-    import OpenAI from "openai";
-
-    const client = new OpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "sk-proj-...",  // Your OpenAI key, forwarded by gateway
-    });
-
-    const response = await client.chat.completions.create({
-      model: "gpt-4o",
-      messages: [{ role: "user", content: "Hello!" }],
-    });
-
-    console.log(response.choices[0].message.content);
-    ```
-
-    ```typescript Vercel AI SDK
-    import { generateText } from "ai";
-    import { createOpenAI } from "@ai-sdk/openai";
-
-    const gateway = createOpenAI({
-      baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "sk-proj-...",  // Your OpenAI key, forwarded by gateway
-    });
-
-    const { text } = await generateText({
-      model: gateway("gpt-4o"),
-      prompt: "Hello!",
-    });
-
-    console.log(text);
-    ```
-
-    ```bash cURL
-    curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer sk-proj-..." \
-      -d '{
-        "model": "gpt-4o",
-        "messages": [{"role": "user", "content": "Hello!"}]
-      }'
-    ```
-    </CodeGroup>
-  </Step>
-</Steps>
-
-## Store key in the gateway
-
-Instead of each client passing their own key, you can store it once in ngrok Secrets and have the gateway inject it automatically.
-
-<Warning>
-Storing your provider key in the gateway makes your endpoint publicly accessible. You must add authorization to prevent unauthorized use and unexpected charges. See [Protecting BYOK Endpoints](/ai-gateway/guides/protecting-byok-endpoints).
-</Warning>
-
-<Steps>
-  <Step title="Store your key in ngrok secrets">
+  <Step title="Attach the key">
     ```bash
-    ngrok api secrets create \
-      --name openai \
-      --secret-data '{"api-key": "sk-proj-..."}'
-    ```
-
-    Or use the [Vaults & Secrets dashboard](https://dashboard.ngrok.com/vaults).
-  </Step>
-
-  <Step title="Configure your Traffic Policy">
-    ```yaml
-    on_http_request:
-      - type: ai-gateway
-        config:
-          providers:
-            - id: "openai"
-              api_keys:
-                - value: ${secrets.get('openai', 'api-key')}
+    ngrok api ai-gateway-provider-keys create \
+      --ai-gateway-api-key-id aigk_xxxxx \
+      --provider-id openai \
+      --name "My OpenAI Key" \
+      --value sk-proj-...
     ```
   </Step>
 
   <Step title="Make a request">
-    Clients no longer need an OpenAI key—pass any value for `api_key`.
+    Use your AI Gateway API Key—the gateway resolves the OpenAI key server-side.
 
     <CodeGroup>
     ```python Python
@@ -189,7 +98,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     client = OpenAI(
         base_url="https://your-ai-gateway.ngrok.app/v1",
-        api_key="unused"  # Gateway injects your OpenAI key
+        api_key="ng-xxxxx-g1-xxxxx"  # Your AI Gateway API Key
     )
 
     response = client.chat.completions.create(
@@ -205,7 +114,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     const client = new OpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your OpenAI key
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const response = await client.chat.completions.create({
@@ -222,7 +131,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
 
     const gateway = createOpenAI({
       baseURL: "https://your-ai-gateway.ngrok.app/v1",
-      apiKey: "unused",  // Gateway injects your OpenAI key
+      apiKey: "ng-xxxxx-g1-xxxxx",  // Your AI Gateway API Key
     });
 
     const { text } = await generateText({
@@ -236,7 +145,7 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
     ```bash cURL
     curl https://your-ai-gateway.ngrok.app/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer unused" \
+      -H "Authorization: Bearer ng-xxxxx-g1-xxxxx" \
       -d '{
         "model": "gpt-4o",
         "messages": [{"role": "user", "content": "Hello!"}]
@@ -245,6 +154,8 @@ Storing your provider key in the gateway makes your endpoint publicly accessible
     </CodeGroup>
   </Step>
 </Steps>
+
+See [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys) for key rotation, listing, and removing attached keys.
 
 ## Explicit provider routing
 
@@ -266,5 +177,5 @@ See the [model catalog](/ai-gateway/reference/model-catalog#openai) for the full
 ## Next steps
 
 - [AI Gateway API Keys](/ai-gateway/concepts/api-keys): use ngrok-managed keys for the simplest setup
-- [Managing Provider Keys](/ai-gateway/guides/managing-provider-keys): key rotation and multiple keys
+- [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys): attach, rotate, and manage your own OpenAI keys
 - [Multi-provider failover](/ai-gateway/examples/multi-provider-failover): automatic failover to other providers

--- a/ai-gateway/quickstart.mdx
+++ b/ai-gateway/quickstart.mdx
@@ -5,7 +5,7 @@ description: Get your AI Gateway running in minutes.
 ---
 
 <Note>
-This quickstart uses AI Gateway API Keys with ngrok-managed credits. If you'd rather bring your own OpenAI, Anthropic, or other provider keys, see [Bring Your Own Keys](/ai-gateway/concepts/bring-your-own-keys).
+This quickstart uses AI Gateway API Keys with ngrok-managed credits. If you'd rather use your own provider keys, see [Attaching Provider Keys](/ai-gateway/guides/attaching-provider-keys).
 </Note>
 
 ## Before you start

--- a/ai-gateway/reference/model-catalog.mdx
+++ b/ai-gateway/reference/model-catalog.mdx
@@ -42,9 +42,12 @@ You can also explicitly specify providers using the `provider:model` format (for
 | `gpt-5.4-pro` | GPT-5.4 Pro | 1,050,000 | 128,000 | text, image |
 | `gpt-5.4` | GPT-5.4 | 1,050,000 | 128,000 | text, image |
 | `gpt-5.3-codex` | GPT-5.3-Codex | 400,000 | 128,000 | text, image |
+| `gpt-5.2-codex` | GPT-5.2-Codex | 400,000 | 128,000 | text, image |
 | `gpt-5.2-pro` | GPT-5.2 Pro | 400,000 | 100,000 | text, image |
 | `gpt-5.2` | GPT-5.2 | 400,000 | 128,000 | text, image |
+| `gpt-5.2-chat-latest` | GPT-5.2 Chat Latest | 400,000 | 128,000 | text, image |
 | `gpt-5.1` | GPT-5.1 | 400,000 | 128,000 | text, image |
+| `gpt-5.1-chat-latest` | GPT-5.1 Chat Latest | 256,000 | 32,768 | text, image |
 | `gpt-5` | GPT-5 | 400,000 | 128,000 | text, image |
 | `gpt-5-mini` | GPT-5 Mini | 400,000 | 128,000 | text, image |
 | `gpt-5-nano` | GPT-5 Nano | 400,000 | 128,000 | text, image |

--- a/docs.json
+++ b/docs.json
@@ -783,6 +783,8 @@
               "ai-gateway/guides/model-selection-strategies",
               "ai-gateway/guides/restricting-access",
               "ai-gateway/guides/configuring-providers",
+              "ai-gateway/guides/attaching-provider-keys",
+              "ai-gateway/guides/migrate-to-attached-provider-keys",
               "ai-gateway/guides/managing-provider-keys",
               "ai-gateway/guides/key-selection-failover",
               "ai-gateway/guides/protecting-byok-endpoints",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
   "pnpm": {
     "overrides": {
       "react": "19.2.4"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "puppeteer",
+      "sharp"
+    ]
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
@@ -25,8 +29,8 @@
     "@types/react": "^19.1.13",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
-    "mint": "^4.2.466",
     "mdx2vast": "^0.3.1",
+    "mint": "^4.2.466",
     "react": "^19.1.1",
     "react-markdown": "^10.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,7 @@
   "pnpm": {
     "overrides": {
       "react": "19.2.4"
-    },
-    "ignoredBuiltDependencies": [
-      "puppeteer",
-      "sharp"
-    ]
+    }
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
@@ -29,8 +25,8 @@
     "@types/react": "^19.1.13",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
-    "mdx2vast": "^0.3.1",
     "mint": "^4.2.466",
+    "mdx2vast": "^0.3.1",
     "react": "^19.1.1",
     "react-markdown": "^10.1.0"
   }


### PR DESCRIPTION
 Docs for AI Gateway provider key:
 - adds a usage and migration guide
 - deprecates Traffic Policy api_keys for standard providers, and updates existing BYOK/provider pages to point at the new path
