### PR TITLE
Small nav restructure

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -821,53 +821,9 @@
           }
         ]
       },
-      {
-        "tab": "Guides",
-        "menu": [
+
           {
-            "item": "Overview",
-            "pages": [
-              "guides/index"
-            ]
-          },
-          {
-            "item": "API Gateway",
-            "pages": [
-              "guides/api-gateway/get-started",
-              "guides/api-gateway/multicloud",
-              "guides/api-gateway/monitor-ngrok"
-            ]
-          },
-          {
-            "item": "Device Gateway",
-            "pages": [
-              "guides/device-gateway/agent",
-              "guides/device-gateway/sdk",
-              {
-                "group": "Installation Guides",
-                "pages": [
-                  "guides/device-gateway/linux",
-                  "guides/device-gateway/arm64",
-                  "guides/device-gateway/raspberry-pi",
-                  "guides/device-gateway/raspbian",
-                  "guides/device-gateway/windows"
-                ]
-              }
-            ]
-          },
-          {
-            "item": "Security Best Practices",
-            "pages": [
-              "guides/security-dev-productivity/index",
-              "guides/security-dev-productivity/securing-your-tunnels",
-              "guides/security-dev-productivity/hipaa-compliance",
-              "guides/identity-aware-proxy/securing-with-oauth",
-              "guides/ssh-rdp/index",
-              "guides/running-behind-firewalls"
-            ]
-          },
-          {
-            "item": "Share Localhost",
+            "tab": "Share Localhost",
             "pages": [
               "guides/share-localhost/overview",
               "guides/share-localhost/quickstart",
@@ -890,53 +846,18 @@
               }
             ]
           },
-          {
-            "item": "Site-to-Site Connectivity",
-            "pages": [
-              "guides/site-to-site-connectivity/overview",
-              "guides/site-to-site-connectivity/quickstart",
-              "guides/site-to-site-connectivity/index",
-              "guides/site-to-site-connectivity/faq",
-              "guides/site-to-site-connectivity/end-customers",
-              {
-                "group": "Security",
-                "pages": [
-                  "guides/site-to-site-connectivity/agent-tls-termination",
-                  "guides/site-to-site-connectivity/region-ip-resolution",
-                  "guides/site-to-site-connectivity/authtoken-acls"
-                ]
-              },
-              {
-                "group": "Reliability",
-                "pages": [
-                  "guides/site-to-site-connectivity/background-service",
-                  "guides/site-to-site-connectivity/redundant-agents",
-                  "guides/site-to-site-connectivity/traffic-events",
-                  "guides/site-to-site-connectivity/multi-region-failover"
-                ]
-              },
-              {
-                "group": "Private addressability",
-                "pages": [
-                  "guides/site-to-site-connectivity/customer-networks"
-                ]
-              },
-              {
-                "group": "Production ready",
-                "pages": [
-                  "guides/site-to-site-connectivity/custom-connect-url",
-                  "guides/site-to-site-connectivity/agent-cli",
-                  "guides/site-to-site-connectivity/agent-sdks",
-                  "guides/site-to-site-connectivity/apis-terraform",
-                  "guides/site-to-site-connectivity/agent-packaging"
-                ]
-              }
-            ]
-          }
-        ]
-      },
       {
-        "tab": "Integrations",
+        "tab": "Guides",
+        "menu": [
+          {
+            "item": "Overview",
+            "pages": [
+              "guides/index"
+            ]
+          },
+
+      {
+        "item": "Integrations",
         "pages": [
           "integrations/index",
           {
@@ -1149,6 +1070,87 @@
               "using-ngrok-with/outboundProxy",
               "using-ngrok-with/virtualHosts",
               "using-ngrok-with/gRPC"
+            ]
+          }
+        ]
+      },
+          {
+            "item": "Site-to-Site Connectivity",
+            "pages": [
+              "guides/site-to-site-connectivity/overview",
+              "guides/site-to-site-connectivity/quickstart",
+              "guides/site-to-site-connectivity/index",
+              "guides/site-to-site-connectivity/faq",
+              "guides/site-to-site-connectivity/end-customers",
+              {
+                "group": "Security",
+                "pages": [
+                  "guides/site-to-site-connectivity/agent-tls-termination",
+                  "guides/site-to-site-connectivity/region-ip-resolution",
+                  "guides/site-to-site-connectivity/authtoken-acls"
+                ]
+              },
+              {
+                "group": "Reliability",
+                "pages": [
+                  "guides/site-to-site-connectivity/background-service",
+                  "guides/site-to-site-connectivity/redundant-agents",
+                  "guides/site-to-site-connectivity/traffic-events",
+                  "guides/site-to-site-connectivity/multi-region-failover"
+                ]
+              },
+              {
+                "group": "Private addressability",
+                "pages": [
+                  "guides/site-to-site-connectivity/customer-networks"
+                ]
+              },
+              {
+                "group": "Production ready",
+                "pages": [
+                  "guides/site-to-site-connectivity/custom-connect-url",
+                  "guides/site-to-site-connectivity/agent-cli",
+                  "guides/site-to-site-connectivity/agent-sdks",
+                  "guides/site-to-site-connectivity/apis-terraform",
+                  "guides/site-to-site-connectivity/agent-packaging"
+                ]
+              }
+            ]
+          },
+          {
+            "item": "API Gateway",
+            "pages": [
+              "guides/api-gateway/get-started",
+              "guides/api-gateway/multicloud",
+              "guides/api-gateway/monitor-ngrok"
+            ]
+          },
+          {
+            "item": "Device Gateway",
+            "pages": [
+              "guides/device-gateway/agent",
+              "guides/device-gateway/sdk",
+              {
+                "group": "Installation Guides",
+                "pages": [
+                  "guides/device-gateway/linux",
+                  "guides/device-gateway/arm64",
+                  "guides/device-gateway/raspberry-pi",
+                  "guides/device-gateway/raspbian",
+                  "guides/device-gateway/windows"
+                ]
+              }
+            ]
+          },
+          {
+            "item": "Security Best Practices",
+            "pages": [
+              "guides/security-dev-productivity/index",
+              "guides/security-dev-productivity/securing-your-tunnels",
+              "guides/security-dev-productivity/hipaa-compliance",
+              "guides/identity-aware-proxy/securing-with-oauth",
+              "guides/ssh-rdp/index",
+              "guides/running-behind-firewalls"
             ]
           }
         ]


### PR DESCRIPTION
In the spirit of our plan to productize ngrok [outlined here](https://docs.google.com/document/d/1IFLm4_YAjvBu9lNA4-vz6LG38spMuk81RVijZ1yf3OE/edit?tab=t.0), these are the main products:

- Universal Gateway
- AI Gateway
- Share Localhost
- Other unannounced product

This pr just restructures the top nav to break Share Localhost out of guides, and put Integrations back under Guides to make room for the currently unnanounced future product that will take that spot