### PR TITLE
Document filterable fields on API resource list pages

### DIFF
--- a/api-reference/agentingresses/list.mdx
+++ b/api-reference/agentingresses/list.mdx
@@ -2,3 +2,19 @@
 openapi: get /agent_ingresses
 description: List all agent ingress configurations in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `domain`
+
+### Example
+
+```http
+GET /agent_ingresses?filter=obj.domain in ["foo.com","bar.com"]
+```

--- a/api-reference/apikeys/list.mdx
+++ b/api-reference/apikeys/list.mdx
@@ -2,3 +2,19 @@
 openapi: get /api_keys
 description: List all API keys in your ngrok account with optional filtering and pagination support.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `owner_id`
+
+### Example
+
+```http
+GET /api_keys?filter=obj.owner_id == "usr_2tEpN0yrxDI4j8jVnhVRoTNN2Tx"
+```

--- a/api-reference/certificateauthorities/list.mdx
+++ b/api-reference/certificateauthorities/list.mdx
@@ -2,3 +2,21 @@
 openapi: get /certificate_authorities
 description: List all certificate authority configurations in your ngrok account with optional filtering.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `subject_common_name`
+- `not_before`
+- `not_after`
+
+### Example
+
+```http
+GET /certificate_authorities?filter=obj.subject_common_name == "example.com"
+```

--- a/api-reference/credentials/list.mdx
+++ b/api-reference/credentials/list.mdx
@@ -2,3 +2,20 @@
 openapi: get /credentials
 description: List all credentials in your ngrok account with optional filtering and pagination support.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `owner_id`
+- `acl`
+
+### Example
+
+```http
+GET /credentials?filter=obj.owner_id == "usr_2tEpN0yrxDI4j8jVnhVRoTNN2Tx" && (obj.acl == null || obj.acl == "")
+```

--- a/api-reference/endpoints/list.mdx
+++ b/api-reference/endpoints/list.mdx
@@ -2,3 +2,26 @@
 openapi: get /endpoints
 description: List all agent endpoint configurations in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `principal.id`
+- `type`
+- `binding`
+- `url`
+- `pooling_enabled`
+- `scheme`
+- `region`
+- `name`
+
+### Example
+
+```http
+GET /endpoints?filter=obj.type == "cloud" && obj.created_at >= timestamp(time.now).subtract("6d")
+```

--- a/api-reference/endpoints/list.mdx
+++ b/api-reference/endpoints/list.mdx
@@ -1,6 +1,6 @@
 ---
 openapi: get /endpoints
-description: List all agent endpoint configurations in your ngrok account with optional filtering and pagination.
+description: List all endpoint configurations in your ngrok account with optional filtering and pagination.
 ---
 
 ## Filterable fields

--- a/api-reference/eventdestinations/list.mdx
+++ b/api-reference/eventdestinations/list.mdx
@@ -2,3 +2,18 @@
 openapi: get /event_destinations
 description: List all event destination configurations in your ngrok account with optional filtering.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+
+### Example
+
+```http
+GET /event_destinations?filter=obj.description.contains("audit")
+```

--- a/api-reference/eventsubscriptions/list.mdx
+++ b/api-reference/eventsubscriptions/list.mdx
@@ -2,3 +2,18 @@
 openapi: get /event_subscriptions
 description: List all event subscriptions in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+
+### Example
+
+```http
+GET /event_subscriptions?filter=obj.metadata.contains("team=platform")
+```

--- a/api-reference/ippolicies/list.mdx
+++ b/api-reference/ippolicies/list.mdx
@@ -2,3 +2,18 @@
 openapi: get /ip_policies
 description: List all IP policies in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+
+### Example
+
+```http
+GET /ip_policies?filter=obj.description.contains("prod")
+```

--- a/api-reference/ippolicyrules/list.mdx
+++ b/api-reference/ippolicyrules/list.mdx
@@ -2,3 +2,21 @@
 openapi: get /ip_policy_rules
 description: List all IP policy rules in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `ip_policy`
+- `cidr`
+- `action`
+
+### Example
+
+```http
+GET /ip_policy_rules?filter=obj.cidr.contains("1.1.0.0/16") && obj.action == "deny"
+```

--- a/api-reference/iprestrictions/list.mdx
+++ b/api-reference/iprestrictions/list.mdx
@@ -2,3 +2,18 @@
 openapi: get /ip_restrictions
 description: List all IP restriction configurations in your ngrok account with optional filtering.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+
+### Example
+
+```http
+GET /ip_restrictions?filter=obj.description.contains("blocklist")
+```

--- a/api-reference/reservedaddrs/list.mdx
+++ b/api-reference/reservedaddrs/list.mdx
@@ -2,3 +2,20 @@
 openapi: get /reserved_addrs
 description: List all reserved static IP addresses in your ngrok account with optional filtering.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `addr`
+- `region`
+
+### Example
+
+```http
+GET /reserved_addrs?filter=obj.region == "us"
+```

--- a/api-reference/reserveddomains/list.mdx
+++ b/api-reference/reserveddomains/list.mdx
@@ -2,3 +2,23 @@
 openapi: get /reserved_domains
 description: List all reserved custom domains in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `domain`
+- `region`
+- `cname_target`
+- `certificate.id`
+- `acme_challenge_cname_target`
+
+### Example
+
+```http
+GET /reserved_domains?filter=obj.domain.startsWith("myapi.ngrok")
+```

--- a/api-reference/secrets/list.mdx
+++ b/api-reference/secrets/list.mdx
@@ -2,3 +2,19 @@
 openapi: get /vault_secrets
 description: List all vault secrets in your ngrok account with optional filtering and pagination support.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `name`
+
+### Example
+
+```http
+GET /vault_secrets?filter=obj.name.startsWith("db_")
+```

--- a/api-reference/service-users.mdx
+++ b/api-reference/service-users.mdx
@@ -104,6 +104,19 @@ List all Service Users in this account.
 
 <ServiceUsersListRequest />
 
+### Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+
+#### Example
+
+```http
+GET /service_users?filter=obj.created_at >= timestamp(time.now).subtract("30d")
+```
+
 ### Response
 
 Returns a 200 response on success.

--- a/api-reference/sshcertificateauthorities/list.mdx
+++ b/api-reference/sshcertificateauthorities/list.mdx
@@ -2,3 +2,18 @@
 openapi: get /ssh_certificate_authorities
 description: List all SSH certificate authorities in your ngrok account with optional filtering.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+
+### Example
+
+```http
+GET /ssh_certificate_authorities?filter=obj.description.contains("ops")
+```

--- a/api-reference/sshcredentials/list.mdx
+++ b/api-reference/sshcredentials/list.mdx
@@ -2,3 +2,20 @@
 openapi: get /ssh_credentials
 description: List all SSH credentials in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `owner_id`
+- `acl`
+
+### Example
+
+```http
+GET /ssh_credentials?filter=obj.owner_id == "usr_2tEpN0yrxDI4j8jVnhVRoTNN2Tx"
+```

--- a/api-reference/tlscertificates/list.mdx
+++ b/api-reference/tlscertificates/list.mdx
@@ -2,3 +2,22 @@
 openapi: get /tls_certificates
 description: List all TLS certificates in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `subject_common_name`
+- `not_after`
+- `not_before`
+- `serial_number`
+
+### Example
+
+```http
+GET /tls_certificates?filter=obj.not_after <= timestamp(time.now).add("24h")
+```

--- a/api-reference/tunnelsessions/list.mdx
+++ b/api-reference/tunnelsessions/list.mdx
@@ -2,3 +2,22 @@
 openapi: get /tunnel_sessions
 description: List all tunnel sessions in your ngrok account with optional filtering and pagination.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `metadata`
+- `agent_version`
+- `ip`
+- `os`
+- `region`
+- `started_at`
+- `credential`
+
+### Example
+
+```http
+GET /tunnel_sessions?filter=obj.region == "us" && obj.started_at >= timestamp(time.now).subtract("24h")
+```

--- a/api-reference/vaults/list.mdx
+++ b/api-reference/vaults/list.mdx
@@ -2,3 +2,19 @@
 openapi: get /vaults
 description: List all vaults in your ngrok account with optional filtering and pagination support.
 ---
+
+## Filterable fields
+
+You can narrow results with the `filter` query parameter using a [CEL expression](/api/api-filtering). The following fields on this resource are filterable:
+
+- `id`
+- `created_at`
+- `description`
+- `metadata`
+- `name`
+
+### Example
+
+```http
+GET /vaults?filter=obj.name == "production"
+```


### PR DESCRIPTION
Adds a "Filterable fields" section with the supported field list and one example expression to each list operation page

AGENT-531