### PR TITLE
chore(ngrok-operator): Add docs callouts that namespaces must exist for bound endpoints

### DIFF
--- a/k8s/crds/boundendpoint.mdx
+++ b/k8s/crds/boundendpoint.mdx
@@ -31,6 +31,18 @@ the cluster that this Operator is running in. Unless this is configured, by defa
 For more information about Kubernetes bound endpoints, you can reference the [Kubernetes endpoints](/universal-gateway/kubernetes-endpoints) page.
 For a guide on using Kubernetes bound endpoints with the ngrok Operator, please see the [bound endpoints guide](/k8s/guides/bindings).
 
+<Warning title="The target namespace must exist before the BoundEndpoint can project">
+	The ngrok Operator does not create the target namespace
+	(`spec.target.namespace`) for you. If the namespace does not already exist
+	in the cluster, projection fails and the `BoundEndpoint`'s
+	`ServicesCreated` condition reports
+	[`ERR_NGROK_20003`](/errors/err_ngrok_20003) with a
+	`namespaces "<name>" not found` message — see the
+	[example status](#bound-endpoint-with-service-creation-error) below.
+
+	Create the namespace ahead of time with `kubectl create ns <namespace>`.
+</Warning>
+
 ## BoundEndpoint structure and types
 
 The following outlines the high level structure and typings of a `BoundEndpoint`

--- a/k8s/guides/bindings.mdx
+++ b/k8s/guides/bindings.mdx
@@ -82,6 +82,17 @@ This is not limited to the Kubernetes cluster that you installed the Operator in
 
 ## Kubernetes binding
 
+<Warning title="The target namespace must exist before the bound endpoint is created">
+	The ngrok Operator does not create the target namespace for you. Before
+	creating a Kubernetes-bound endpoint, ensure the namespace referenced in the
+	URL (the `<namespace>` in `<scheme>://<service-name>.<namespace>`) already
+	exists in the cluster — otherwise the `BoundEndpoint` will fail to project
+	with [`ERR_NGROK_20003`](/errors/err_ngrok_20003) and a
+	`namespaces "<name>" not found` message in its status.
+
+	You can create the namespace with `kubectl create ns <namespace>`.
+</Warning>
+
 Endpoints with a kubernetes binding are private endpoints that are only available inside of Kubernetes clusters where you installed the ngrok Kubernetes Operator.
 
 Example URLs:


### PR DESCRIPTION
Just adding callouts that the namespaces need to exist to our guide