### PR TITLE
Resolve CLS issues with (responsive) dimensions for images and components

### DIFF
--- a/agent/agent-mutual-tls-termination.mdx
+++ b/agent/agent-mutual-tls-termination.mdx
@@ -7,7 +7,7 @@ Mutual TLS Authentication (mTLS) is a network security protocol that ensures bot
 
 By verifying the clients, the server owner is able to restrict access only to verified clients, strengthening security.
 
-![](./img/mtls-diag.png)
+<img src="./img/mtls-diag.png" alt="" width="1749" height="341" />
 
 This guide walks you through enabling mTLS on your ngrok hosted endpoints using [the `terminate-tls` Traffic Policy action](/traffic-policy/actions/terminate-tls/).
 

--- a/agent/connect-url.mdx
+++ b/agent/connect-url.mdx
@@ -108,7 +108,7 @@ When you create a custom Connect URL, choose one of two certificate issuers:
 - ngrok's internal CA
 - [Let's Encrypt](https://letsencrypt.org/)
 
-![](/img/docs/new-ingress.png)
+<img src="/img/docs/new-ingress.png" alt="" width="946" height="632" />
 
 ### ngrok internal CA
 
@@ -130,7 +130,7 @@ When you create a custom Connect URL, choose one of two certificate issuers:
 If you select Let's Encrypt, the Connect URL drawer shows a status card while
 the certificate is provisioning:
 
-![](/img/docs/certificate-provisioning-delayed.png)
+<img src="/img/docs/certificate-provisioning-delayed.png" alt="" width="590" height="162" />
 
 <Note>
 Certificates issued by Let's Encrypt through ngrok are securely managed.

--- a/agent/web-inspection-interface.mdx
+++ b/agent/web-inspection-interface.mdx
@@ -19,7 +19,7 @@ Inspection is only supported for HTTP endpoints. TCP and TLS endpoints do not su
 
 ###### Detailed introspection of HTTP requests and responses
 
-![](/img/docs/inspect2.png)
+<img src="/img/docs/inspect2.png" alt="" width="689" height="501" />
 
 ## Request body validation
 
@@ -27,7 +27,7 @@ ngrok has special support for the most common data interchange formats in use on
 
 ###### The location of a JSON syntax error is highlighted
 
-![](/img/docs/syntax.png)
+<img src="/img/docs/syntax.png" alt="" width="520" height="581" />
 
 ## Filtering requests
 
@@ -35,13 +35,13 @@ Your upstream service may receive many requests, but you are often only interest
 
 ###### Click the filter bar for filtering options
 
-![](/img/docs/inspect-filter-select.png)
+<img src="/img/docs/inspect-filter-select.png" alt="" width="331" height="187" />
 
 You may specify multiple filters. If you do, requests will only be shown if they much all filters.
 
 ###### Filter requests by path and status code
 
-![](/img/docs/inspect-filter.png)
+<img src="/img/docs/inspect-filter.png" alt="" width="605" height="175" />
 
 ## Replaying requests
 
@@ -51,7 +51,7 @@ Replay works via the local agent sending the request directly to your upstream s
 
 ###### Replay any request against your web server with one click
 
-![](/img/docs/replay2.png)
+<img src="/img/docs/replay2.png" alt="" width="586" height="282" />
 
 ## Replaying modified requests
 
@@ -59,13 +59,13 @@ Sometimes you want to modify a request before you replay it to test a new behavi
 
 ###### Click the dropdown arrow on the 'Replay' button to modify a request before it is replayed
 
-![](/img/docs/replay-modify-button.png)
+<img src="/img/docs/replay-modify-button.png" alt="" width="588" height="180" />
 
 The replay editor allows you to modify every aspect of the HTTP request before replaying it, including the method, path, headers, trailers, and request body.
 
 ###### The request replay modification editor
 
-![](/img/docs/replay-modify.png)
+<img src="/img/docs/replay-modify.png" alt="" width="625" height="784" />
 
 ## ngrok Agent status page
 
@@ -75,10 +75,10 @@ The status page displays the configuration of each running endpoint and any glob
 
 ###### Endpoint and global configuration
 
-![](/img/docs/status-configuration.png)
+<img src="/img/docs/status-configuration.png" alt="" width="489" height="729" />
 
 The status page also display metrics about the traffic through each endpoint. It display connection rates and connection duration percentiles for all endpoints. For HTTP endpoints, it also displays http request rates and http response duration percentiles.
 
 ###### Endpoint traffic metrics
 
-![](/img/docs/status-metrics.png)
+<img src="/img/docs/status-metrics.png" alt="" width="566" height="675" />

--- a/guides/api-gateway/monitor-ngrok.mdx
+++ b/guides/api-gateway/monitor-ngrok.mdx
@@ -43,7 +43,7 @@ In this section, you'll learn the basics of the Traffic Inspector and work throu
 
   The list of recent requests provides you with basic information such as the time, origin, destination, duration, and response code of calls to your API.
 
-  ![Traffic Inspector](./img/monitor-ngrok/trafficInspector.png)
+  <img src="./img/monitor-ngrok/trafficInspector.png" alt="Traffic Inspector" width="2568" height="1162" />
 
 - You can filter requests by these fields—for instance, to show only server error responses and not successes.
 
@@ -51,11 +51,11 @@ To see more details about a request or to replay it, you need to enable full cap
 
 - Click a request in the Traffic Inspector list, then click **Enable full capture** in the sidebar.
 
-  ![Enable full capture](./img/monitor-ngrok/enableFullCapture.png)
+  <img src="./img/monitor-ngrok/enableFullCapture.png" alt="Enable full capture" width="2580" height="1222" />
 
 - This button takes you to your account settings, where you can enable full capture under **Observability**.
 
-  ![Enable full capture settings](./img/monitor-ngrok/enableFullCaptureAccount.png)
+  <img src="./img/monitor-ngrok/enableFullCaptureAccount.png" alt="Enable full capture settings" width="2566" height="642" />
 
 - Then, return to your published API URL and refresh the browser page a few times to send fresh requests through ngrok.
 - In the ngrok Traffic Inspector, click the event at the top of the list.
@@ -65,11 +65,11 @@ To see more details about a request or to replay it, you need to enable full cap
 
 - Click the **Replay** button and notice that the request is replayed from the ngrok host.
 
-  ![Replay request](./img/monitor-ngrok/replay.png)
+  <img src="./img/monitor-ngrok/replay.png" alt="Replay request" width="2810" height="912" />
 
 - You can also replay a request with changes to alter any of the headers or POST data.
 
-  ![Replay with changes](./img/monitor-ngrok/replayChanges2.png)
+  <img src="./img/monitor-ngrok/replayChanges2.png" alt="Replay with changes" width="2580" height="1364" />
 
 Replaying requests is useful for debugging.
 For example, you could find the request that caused an error in your API, deploy a fix for the API, and replay the request to confirm you've fixed the issue.
@@ -92,14 +92,14 @@ Now you can observe what happens to rate-limited requests and also use Traffic I
 
 - In Traffic Inspector, note that ngrok returned the error code `429` (rate limit) and that the duration of the request was instant, meaning it created no load on your API.
 
-  ![Rate limit](./img/monitor-ngrok/rateLimit.png)
+  <img src="./img/monitor-ngrok/rateLimit.png" alt="Rate limit" width="2828" height="906" />
 
 - Edit the `policy.yml` file and change `capacity` to `100` or another threshold you deem appropriate and restart your agent based on your form factor.
 
 - In the Traffic Inspector, click one of the `429` events, then click **Replay**.
   Note that the request now responds without error because you increased the rate limit for the given IP address of that request.
 
-  ![Replay after rate limit adjustment](./img/monitor-ngrok/replayLimit.png)
+  <img src="./img/monitor-ngrok/replayLimit.png" alt="Replay after rate limit adjustment" width="2820" height="1160" />
 
 ## Monitor your API gateway traffic with Datadog
 
@@ -110,12 +110,12 @@ For this simple example, you'll monitor a traffic event.
 
 - In the ngrok dashboard, browse to [**Log Exporting**](https://dashboard.ngrok.com/log-exporting) and add a new Log Export.
 
-  ![Add event subscription](./img/monitor-ngrok/makeSubscription.png)
+  <img src="./img/monitor-ngrok/makeSubscription.png" alt="Add event subscription" width="2208" height="1586" />
 
 - In the **New Log Export** sidebar, enter `traffic` as the **Description** and then **Add** a new log source.
   Choose `http_request_complete`.
 
-  ![Add log source](./img/monitor-ngrok/addEventType.png)
+  <img src="./img/monitor-ngrok/addEventType.png" alt="Add log source" width="2860" height="1566" />
 
 - Add Datadog as a destination, add the Datadog site and API key you noted earlier, and send a test log.
 
@@ -123,7 +123,7 @@ For this simple example, you'll monitor a traffic event.
   Enable logs.
   You should see that the log from ngrok has appeared.
 
-  ![Datadog logs](./img/monitor-ngrok/datadogLog.png)
+  <img src="./img/monitor-ngrok/datadogLog.png" alt="Datadog logs" width="2860" height="1566" />
 
 - In ngrok, click **Done** and **Save**.
 
@@ -136,17 +136,17 @@ Now that events are being sent to Datadog, you can set up visualizations and not
 - In the Datadog site, browse to the **Dashboards > Dashboard List** page from the navigation panel.
   Click the **ngrok HTTP Events** item to view the default dashboard.
 
-  ![Datadog dashboard list](./img/monitor-ngrok/datadogDashboardList.png)
+  <img src="./img/monitor-ngrok/datadogDashboardList.png" alt="Datadog dashboard list" width="2630" height="1528" />
 
 You need to clone the default dashboard to add a new widget to the dashboard.
 
 - Click **Clone** at the top right of the page.
 
-  ![Datadog default dashboard](./img/monitor-ngrok/datadogDefaultDashboard.png)
+  <img src="./img/monitor-ngrok/datadogDefaultDashboard.png" alt="Datadog default dashboard" width="2632" height="1132" />
 
 - In the cloned dashboard, click **Add widgets**.
 
-  ![Datadog add widget](./img/monitor-ngrok/datadogAddWidget.png)
+  <img src="./img/monitor-ngrok/datadogAddWidget.png" alt="Datadog add widget" width="2634" height="1132" />
 
 Configure the widget as follows.
 
@@ -155,11 +155,11 @@ Configure the widget as follows.
 - 3. Set the time preference to **Past 1 Hour**.
 - 4. Name the widget `Errors in the last hour`.
 
-  ![Datadog edit widget](./img/monitor-ngrok/datadogWidgetDetails.png)
+  <img src="./img/monitor-ngrok/datadogWidgetDetails.png" alt="Datadog edit widget" width="3168" height="1938" />
 
 Your new widget will be available in the dashboard, allowing your support staff to see instantly whether any errors have occurred in your API.
 
-![Datadog custom dashboard](./img/monitor-ngrok/datadogCustomDashboard.png)
+<img src="./img/monitor-ngrok/datadogCustomDashboard.png" alt="Datadog custom dashboard" width="3226" height="1390" />
 
 Since the sample API never returns errors, an easy way to test the `Errors in the last hour` widget is to stop the sample API Docker container and then try to browse to the site on the public ngrok endpoint.
 
@@ -175,12 +175,12 @@ For production workloads, consider using email, Slack, mobile push notifications
 
 - In Datadog, browse to **Integrations > Add integration > Webhooks**.
 
-  ![Datadog add integration](./img/monitor-ngrok/datadogAddIntegration.png)
+  <img src="./img/monitor-ngrok/datadogAddIntegration.png" alt="Datadog add integration" width="2642" height="1448" />
 
 - Under **Webhooks**, at the bottom of the configuration page, click **New**.
   Set the **Name** to `ntfy`, the **URL** to `https://ntfy.sh/$YOUR_COMPANY`, and the **Payload** to **Blank**. Click **Save**.
 
-  ![Datadog add webhook](./img/monitor-ngrok/datadogAddWebhook.png)
+  <img src="./img/monitor-ngrok/datadogAddWebhook.png" alt="Datadog add webhook" width="2720" height="1936" />
 
 - In the Datadog navigation panel, browse to the **Monitors > New monitor**. Choose **Logs**.
 
@@ -190,7 +190,7 @@ For production workloads, consider using email, Slack, mobile push notifications
   @webhook-ntfy Your API has errors. Investigate at https://app.datadoghq.eu/dashboard.
   ```
 
-  ![Datadog add webhook](./img/monitor-ngrok/datadogConfigureMonitor.png)
+  <img src="./img/monitor-ngrok/datadogConfigureMonitor.png" alt="Datadog add webhook" width="2646" height="1822" />
 
   It's important that the `@webhook` name matches the webhook integration you created earlier.
   If the names don't match, the notification won't arrive.
@@ -202,7 +202,7 @@ For production workloads, consider using email, Slack, mobile push notifications
 - Notice that the alert appears on the ntfy page.
   You can install ntfy as a mobile app so that you are always aware of whether your API has errors.
 
-  ![Datadog notify](./img/monitor-ngrok/datadogNotify.png)
+  <img src="./img/monitor-ngrok/datadogNotify.png" alt="Datadog notify" width="2614" height="1230" />
 
 - Save the monitor.
   Now, after a delay and once you've refreshed the ngrok endpoint for your API, you will receive a notification if an error occurs.

--- a/guides/api-gateway/multicloud.mdx
+++ b/guides/api-gateway/multicloud.mdx
@@ -19,7 +19,7 @@ You need a way to expose these APIs to the public internet without the complexit
 
 ## Architectural reference
 
-![Multicloud API Gateway architecture diagram](./img/multicloud-apigw.png)
+<img src="./img/multicloud-apigw.png" alt="Multicloud API Gateway architecture diagram" width="4800" height="1913" />
 
 ### What you'll need
 
@@ -131,7 +131,7 @@ In this case, this single Cloud Endpoint will act as the gateway to receive inco
 
 Create a public Cloud Endpoint in the ngrok dashboard by navigating to endpoints and clicking **new** as shown in the screenshot below:
 
-![New Cloud Endpoint UI in the dashboard](./img/multicloud-dashboard.png)
+<img src="./img/multicloud-dashboard.png" alt="New Cloud Endpoint UI in the dashboard" width="1376" height="1044" />
 
 Now that you've created the Cloud Endpoint, you need to configure it to route to the correct internal endpoint based on the request header. Click on your Cloud Endpoint and replace the default Traffic Policy with: 
 

--- a/guides/device-gateway/cloud-to-device.mdx
+++ b/guides/device-gateway/cloud-to-device.mdx
@@ -17,7 +17,7 @@ However, your technicians need to do remote maintenance on these cameras via SSH
 
 ## Architectural reference
 
-![Architecture diagram: one ngrok agent per factory routing cloud traffic to internal devices](img/cloud-to-device/cloud-to-device-arch.png)
+<img src="img/cloud-to-device/cloud-to-device-arch.png" alt="Architecture diagram: one ngrok agent per factory routing cloud traffic to internal devices" width="5400" height="1380" />
 
 ### Why only one ngrok agent per factory?
 
@@ -43,11 +43,11 @@ Create a separate service user and associated authtoken for each of your factori
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click **New Service User**.
 
-![Service Users page with New Service User button](img/cloud-to-device/cloud-to-device-service-user.png)
+<img src="img/cloud-to-device/cloud-to-device-service-user.png" alt="Service Users page with New Service User button" width="918" height="272" />
 
 Next, create an authtoken assigned to this specific service user.
 
-![Authtokens page showing a new authtoken assigned to a service user](img/cloud-to-device/cloud-to-device-authtoken.png)
+<img src="img/cloud-to-device/cloud-to-device-authtoken.png" alt="Authtokens page showing a new authtoken assigned to a service user" width="1068" height="424" />
 
 ## 2. Install the ngrok agent within your remote network and configure internal Agent Endpoints in ngrok.yml
 
@@ -88,7 +88,7 @@ endpoints:
 You need to reserve a TCP address to create a TCP Cloud Endpoint, which you'll do in the next step.
 Reserving the address holds it exclusively for your ngrok account.
 
-![Reserved TCP addresses page with a newly reserved address](img/cloud-to-device/cloud-to-device-tcp-address.png)
+<img src="img/cloud-to-device/cloud-to-device-tcp-address.png" alt="Reserved TCP addresses page with a newly reserved address" width="1118" height="660" />
 
 ## 4. Create your Cloud Endpoints and attach a Traffic Policy
 
@@ -98,7 +98,7 @@ Cloud Endpoints don't forward their traffic to an agent by default—they only u
 
 Create a public Cloud Endpoint in the ngrok dashboard by navigating to **Endpoints** and clicking **New**.
 
-![Endpoints page with New button to create a Cloud Endpoint](img/cloud-to-device/cloud-to-device-cloud-endpoint.png)
+<img src="img/cloud-to-device/cloud-to-device-cloud-endpoint.png" alt="Endpoints page with New button to create a Cloud Endpoint" width="1384" height="1046" />
 
 Additionally, create Cloud Endpoints for the sensor and camera: `https://sensor.acme.com` and `tcp://1.tcp.ngrok.io:12345` (using your reserved TCP address).
 

--- a/guides/device-gateway/private-connectivity.mdx
+++ b/guides/device-gateway/private-connectivity.mdx
@@ -10,7 +10,7 @@ This guide walks you through how to configure `ngrokd`: an ngrok component that 
 
 ## Architectural reference
 
-![ngrokd device gateway architecture](img/private-connectivity/ngrokd_device_gw_architecture_(2).png)
+<img src="img/private-connectivity/ngrokd_device_gw_architecture_(2).png" alt="ngrokd device gateway architecture" width="4013" height="1163" />
 
 ## What you'll need
 
@@ -73,11 +73,11 @@ Create a separate service user and associated authtoken for each remote network 
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click **New Service User**.
 
-![Service Users page with New Service User button](img/cloud-to-device/cloud-to-device-service-user.png)
+<img src="img/cloud-to-device/cloud-to-device-service-user.png" alt="Service Users page with New Service User button" width="918" height="272" />
 
 Next, create an authtoken assigned to this specific service user.
 
-![Authtokens page showing a new authtoken assigned to a service user](img/cloud-to-device/cloud-to-device-authtoken.png)
+<img src="img/cloud-to-device/cloud-to-device-authtoken.png" alt="Authtokens page showing a new authtoken assigned to a service user" width="1068" height="424" />
 
 ## 3. Install the ngrok agent within your remote network and configure private Agent Endpoints in ngrok.yml
 
@@ -129,7 +129,7 @@ ngrokctl list
 
 You should see your private endpoints listed:
 
-![ngrokctl list output showing private endpoints](img/private-connectivity/Screenshot_2026-05-07_at_4.18.20_PM.png)
+<img src="img/private-connectivity/Screenshot_2026-05-07_at_4.18.20_PM.png" alt="ngrokctl list output showing private endpoints" width="908" height="314" />
 
 From here, you can curl your HTTP endpoint and verify you get the expected response.
 The same can be done for your TCP endpoint by connecting at the assigned hostname and port:

--- a/guides/device-gateway/remote-access.mdx
+++ b/guides/device-gateway/remote-access.mdx
@@ -12,7 +12,7 @@ This guide demonstrates the setup for a single remote network.
 
 ## Architectural reference
 
-![Architecture diagram: one ngrok agent per remote network routing cloud traffic to internal SSH and RDP devices](img/secure-remote-access/ngrok_SSH_RDP_Arch_(2).png)
+<img src="img/secure-remote-access/ngrok_SSH_RDP_Arch_(2).png" alt="Architecture diagram: one ngrok agent per remote network routing cloud traffic to internal SSH and RDP devices" width="5400" height="1380" />
 
 ### Why only one ngrok agent per remote network?
 
@@ -38,11 +38,11 @@ Create a separate service user and associated authtoken for each of your custome
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click **New Service User**.
 
-![Service Users page with New Service User button](img/secure-remote-access/Screenshot_2026-01-23_at_12.35.00_PM.png)
+<img src="img/secure-remote-access/Screenshot_2026-01-23_at_12.35.00_PM.png" alt="Service Users page with New Service User button" width="918" height="272" />
 
 Next, create an authtoken assigned to this specific service user.
 
-![Authtokens page showing a new authtoken assigned to a service user](img/secure-remote-access/Screenshot_2026-01-23_at_12.36.20_PM.png)
+<img src="img/secure-remote-access/Screenshot_2026-01-23_at_12.36.20_PM.png" alt="Authtokens page showing a new authtoken assigned to a service user" width="1068" height="424" />
 
 ## 2. Install the ngrok agent within your remote network and configure internal Agent Endpoints in ngrok.yml
 
@@ -84,7 +84,7 @@ You need to reserve a TCP address to create a TCP Cloud Endpoint, which you'll d
 Reserving the address holds it exclusively for your ngrok account.
 Do this for each device and for the RDP server.
 
-![Reserved TCP addresses page with a newly reserved address](img/secure-remote-access/Screenshot_2026-01-23_at_12.37.00_PM.png)
+<img src="img/secure-remote-access/Screenshot_2026-01-23_at_12.37.00_PM.png" alt="Reserved TCP addresses page with a newly reserved address" width="1118" height="660" />
 
 ## 4. Create your TCP Cloud Endpoints and attach a Traffic Policy
 
@@ -92,7 +92,7 @@ Cloud Endpoints are persistent, always-on endpoints whose creation, deletion, an
 They exist permanently until explicitly deleted.
 Cloud Endpoints don't forward their traffic to an agent by default—they only use their attached Traffic Policy to handle connections.
 
-![Endpoints page with New button to create a TCP Cloud Endpoint](img/secure-remote-access/Screenshot_2026-01-23_at_12.38.46_PM.png)
+<img src="img/secure-remote-access/Screenshot_2026-01-23_at_12.38.46_PM.png" alt="Endpoints page with New button to create a TCP Cloud Endpoint" width="1374" height="1042" />
 
 Click on your newly created Cloud Endpoint and replace the default Traffic Policy with:
 

--- a/guides/device-gateway/sdk.mdx
+++ b/guides/device-gateway/sdk.mdx
@@ -81,7 +81,7 @@ Next, add two `CNAME` records to your DNS provider's registry, providing values 
 
 Add a CNAME record for the domain you just reserved.
 
-![alt-text](./img/CNAME-device-gw.png)
+<img src="./img/CNAME-device-gw.png" alt="alt-text" width="2198" height="1310" />
 
 Then add another record for the
 [ACME (Automated Certificate Management Environment)](https://venafi.com/blog/what-acme-protocol-and-how-has-it-changed-pki/)
@@ -98,15 +98,15 @@ Use the ngrok dashboard to verify that you’ve configured DNS correctly.
 4. Click **2 targets** next to _DNS Targets_ in the panel displayed on the right-hand side of the screen,
    as denoted by the arrow in the screenshot below.
 
-![alt-text](./img/2tunnels.png)
+<img src="./img/2tunnels.png" alt="alt-text" width="3326" height="1918" />
 
 5. Click **Check Status**, as denoted by the arrow in the screenshot below.
 
-![alt-text](./img/check-status.png)
+<img src="./img/check-status.png" alt="alt-text" width="3850" height="1918" />
 
 6. You should see a successful response similar to the screenshot below.
 
-![alt-text](./img/dns-success.png)
+<img src="./img/dns-success.png" alt="alt-text" width="3326" height="1918" />
 
 ## Create a Service User
 
@@ -144,7 +144,7 @@ under _Tunnels_, then click **Add a Tunnel Authtoken**.
 For **Owner**, select the Service User you use created, and select `bind:*.sitea.{YOUR_DOMAIN}` for the ACL Rules.
 This ACL will allow an agent with the authtoken to create tunnels on any subdomain of `sitea.{YOUR_DOMAIN}`.
 
-![alt-text](./img/authtoken.png)
+<img src="./img/authtoken.png" alt="alt-text" width="3326" height="1918" />
 
 ## Configure the sample Agent
 

--- a/guides/security-dev-productivity/index.mdx
+++ b/guides/security-dev-productivity/index.mdx
@@ -14,7 +14,7 @@ Instead of exposing individual developer endpoints publicly, you can implement a
 
 ## Architectural reference
 
-![Secure Developer Productivity Architecture.](./img/architecture.png)
+<img src="./img/architecture.png" alt="Secure Developer Productivity Architecture." width="5775" height="1763" />
 
 Create one ngrok account, managed by security or DevOps. The following can be managed centrally at this account's dashboard:
 
@@ -26,7 +26,7 @@ Create one ngrok account, managed by security or DevOps. The following can be ma
 
 This will allow you to add each developer using ngrok to your central ngrok account. With RBAC (available on ngrok's pay-as-you-go plan), you also have the option to restrict their access to read-only.
 
-![The UI for inviting team members to your ngrok account.](./img/invite.png)
+<img src="./img/invite.png" alt="The UI for inviting team members to your ngrok account." width="978" height="1106" />
 
 Once the invite is sent, have the developer go to their email and sign up for their account which will be registered under the master account.
 
@@ -34,7 +34,7 @@ Once the invite is sent, have the developer go to their email and sign up for th
 
 Create a tunnel authtoken for each developer. This authtoken will be specific to each user and will be their key to setting up internal endpoints. Next, assign it an ACL rule. By assigning an ACL rule, you can ensure that this user with this authtoken may only create one internal endpoint bound to their alias. Navigate to the authtokens section on your dashboard and click "new authtoken" and set the description, set the owner to the developer email, and assign it an ACL rule as shown below:
 
-![The UI for creating an ACL rule.](./img/aclrules.png)
+<img src="./img/aclrules.png" alt="The UI for creating an ACL rule." width="1184" height="236" />
 
 ## Developer installs ngrok Agent and defines an internal endpoint in ngrok.yml
 
@@ -72,7 +72,7 @@ In this way, developers only handle private endpoints and don't have permissions
 
 Reserving a wildcard domain is the first step in creating a wildcard Cloud Endpoint to receive traffic on any subdomain of your domain. Navigate to the [domains](https://dashboard.ngrok.com/domains) section in your dashboard and click "new domain". Any naming convention you use for this domain will require proper DNS and CNAME records. These targets are returned after domain creation and can take 5-10 mins for ssl to be established. For billing information on wildcard endpoints, see [wildcard endpoints pricing](/pricing-limits/#wildcard-endpoints).
 
-![The UI for reserving a custom domain.](./img/newdomain.png)
+<img src="./img/newdomain.png" alt="The UI for reserving a custom domain." width="1234" height="586" />
 
 ## Create a public Cloud Endpoint and Traffic Policy
 

--- a/guides/site-to-site-connectivity/index.mdx
+++ b/guides/site-to-site-connectivity/index.mdx
@@ -19,7 +19,7 @@ Consider a situation where your company (Acme Corp.) needs direct access to reso
 
 ## Architectural reference
 
-![A diagram outlining the site-to-site connectivity architecture.](./img/s2s_arch.png)
+<img src="./img/s2s_arch.png" alt="A diagram outlining the site-to-site connectivity architecture." width="5400" height="1275" />
 
 ### Why only one ngrok Agent per network?
 
@@ -43,11 +43,11 @@ First, you'll create a service user and an associated authtoken for each of your
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click "new Service User".
 
-![Screenshot showing the Service Users section in the ngrok dashboard.](./img/Screenshot_2026-01-23_at_12.35.00_PM.png)
+<img src="./img/Screenshot_2026-01-23_at_12.35.00_PM.png" alt="Screenshot showing the Service Users section in the ngrok dashboard." width="918" height="272" />
 
 Next, create an authtoken assigned to this specific service user.
 
-![Screenshot showing authtoken creation.](./img/image.png)
+<img src="./img/image.png" alt="Screenshot showing authtoken creation." width="1068" height="424" />
 
 ### 2. Install ngrok and configure Internal Endpoints
 
@@ -86,7 +86,7 @@ Cloud Endpoints are persistent, always-on endpoints whose creation, deletion, an
 
 Create a public Cloud Endpoint in the ngrok dashboard by navigating to endpoints and clicking **new** as shown in the screenshot below:
 
-![Screenshot showing how to create a new endpoint in the dashboard.](./img/Screenshot_2026-02-12_at_3.27.34_PM.png)
+<img src="./img/Screenshot_2026-02-12_at_3.27.34_PM.png" alt="Screenshot showing how to create a new endpoint in the dashboard." width="1380" height="1040" />
 
 Additionally, create a Cloud Endpoint for the patient DB: `tls://db.acme.com`.
 

--- a/guides/site-to-site-connectivity/non-k8s-environment.mdx
+++ b/guides/site-to-site-connectivity/non-k8s-environment.mdx
@@ -10,7 +10,7 @@ This guide walks you through how to configure `ngrokd`: an ngrok component that 
 
 ## Architectural reference
 
-![ngrokd site-to-site architecture](./img/ngrokd_s2s_architecture_(1).png)
+<img src="./img/ngrokd_s2s_architecture_(1).png" alt="ngrokd site-to-site architecture" width="4013" height="1163" />
 
 ## What you'll need
 
@@ -73,11 +73,11 @@ Create a separate service user and associated authtoken for each customer so tha
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click **New Service User**.
 
-![Service Users page with New Service User button](./img/Screenshot_2026-01-23_at_12.35.00_PM.png)
+<img src="./img/Screenshot_2026-01-23_at_12.35.00_PM.png" alt="Service Users page with New Service User button" width="918" height="272" />
 
 Next, create an authtoken assigned to this specific service user.
 
-![Authtokens page showing a new authtoken assigned to a service user](./img/image.png)
+<img src="./img/image.png" alt="Authtokens page showing a new authtoken assigned to a service user" width="1068" height="424" />
 
 ## 3. Install the ngrok agent within your remote network and configure private Agent Endpoints in ngrok.yml
 
@@ -129,7 +129,7 @@ ngrokctl list
 
 You should see your private endpoints listed:
 
-![ngrokctl list output showing private endpoints](./img/Screenshot_2026-05-08_at_3.55.16_PM.png)
+<img src="./img/Screenshot_2026-05-08_at_3.55.16_PM.png" alt="ngrokctl list output showing private endpoints" width="900" height="278" />
 
 From here, you can curl your HTTP endpoint and verify you get the expected response.
 The same can be done for your TCP endpoint, for example connecting to a database:

--- a/guides/ssh-rdp/index.mdx
+++ b/guides/ssh-rdp/index.mdx
@@ -10,7 +10,7 @@ Examples where this is applicable include secure SSH into remote IoT devices or 
 
 ## Architectural reference
 
-![A diagram outlining the remote access architecture that will be configured in this guide.](./img/ssh_rdp_architecture.png)
+<img src="./img/ssh_rdp_architecture.png" alt="A diagram outlining the remote access architecture that will be configured in this guide." width="4236" height="1519" />
 
 ### Why only one ngrok Agent per remote network?
 

--- a/iam/users.mdx
+++ b/iam/users.mdx
@@ -40,11 +40,11 @@ You can sign up for an ngrok account using an email and password, or using an SS
 
 If you've forgotten your password, it can be reset at any time via the [login page](https://dashboard.ngrok.com/login).
 
-![Screenshot of the login screen with an arrow pointing to the Forgot password? item](img/password_forgot.png)
+<img src="img/password_forgot.png" alt="Screenshot of the login screen with an arrow pointing to the Forgot password? item" width="1124" height="1120" />
 
 From there, enter the email address you used to sign in to your ngrok account, and select **recover password**.
 
-![Screenshot of recover password form](img/password_reset.png)
+<img src="img/password_reset.png" alt="Screenshot of recover password form" width="1110" height="660" />
 
 <Note>
 If you use SSO to sign in, and haven't also added a password to your account, you won't be able to reset your password.
@@ -55,7 +55,7 @@ If you can't remember what email you used, you may want to try other possible ad
 
 If you receive an `ERR_NGROK_4301` error, you'll need to try signing in with SSO, as you didn't set a password for the account.
 
-![Screenshot of the 4301 error](img/password_4301.png)
+<img src="img/password_4301.png" alt="Screenshot of the 4301 error" width="652" height="316" />
 
 If you don't receive the email after completing these steps, contact support for further assistance.
 
@@ -65,7 +65,7 @@ If you already have access to your account already, but want to change the passw
 Select your username in the upper-left corner of the dashboard and selecting **User Settings**. 
 From there, you'll enter your old password, and the new one you would like to use.
 
-![Screenshot of the password change page](img/password_new.png)
+<img src="img/password_new.png" alt="Screenshot of the password change page" width="1082" height="610" />
 
 ### MFA
 
@@ -78,7 +78,7 @@ You may configure your ngrok account to enforce that all users have MFA enabled.
 
 When signing up for an ngrok account for the first time, you'll be prompted to set up Multi Factor Authentication with a QR code from ngrok to use with your preferred authenticator.
 
-![Screenshot of the MFA setup process](img/mfa_setup.png)
+<img src="img/mfa_setup.png" alt="Screenshot of the MFA setup process" width="1002" height="928" />
 
 From here, you'll want to open up your preferred authenticator (Google Authenticator, Microsoft Authenticator, Authy, Duo, Okta Authenticator, etc) and utilize the QR code provided.
 Once you set up your preferred authenticator, you'll be asked to enter a code from that authenticator each time you log into your ngrok account.
@@ -88,15 +88,15 @@ Once you set up your preferred authenticator, you'll be asked to enter a code fr
 You will also be provided a list of recovery codes, which you can copy and paste elsewhere or download directly.
 Store these recovery codes in a secure location, as they can be used to access your account if you lose access to your authenticator device.
 
-![Screenshot of MFA recovery codes](img/mfa_codes.png)
+<img src="img/mfa_codes.png" alt="Screenshot of MFA recovery codes" width="1106" height="458" />
 
 #### Manage MFA settings
 
 You can enable or disable MFA at any time once logged into your account by selecting on your username in the upper left corner of your dashboard, and then **User Settings**.
 Scroll down to **Multi Factor Authentication** and select **Enable** or **Disable**, as well as generate new recovery codes if needed.
 
-![Screenshot of enabling MFA on an existing account account](img/mfa_totp.png)
-![Screenshot of disabling MFA on an account](img/mfa_totp_disable.png)
+<img src="img/mfa_totp.png" alt="Screenshot of enabling MFA on an existing account account" width="1038" height="390" />
+<img src="img/mfa_totp_disable.png" alt="Screenshot of disabling MFA on an account" width="1126" height="796" />
 
 #### Lost access or recovery
 

--- a/k8s/how-it-works.mdx
+++ b/k8s/how-it-works.mdx
@@ -15,19 +15,19 @@ By default, Kubernetes offers similar types of approaches to exposing traffic as
 
 In this case below, the user cannot access the pod directly in the k8s private network without some sort of entry point.
 
-![k8s-basic](./assets/images/basic-k8s-diagram.png)
+<img src="./assets/images/basic-k8s-diagram.png" alt="k8s-basic" width="928" height="472" />
 
 In Kubernetes, operators (like the ngrok Kubernetes Operator) provide configuration options such as the existing Kubernetes Ingress and Gateway resources, and sometimes define their own configuration resources.
 These configuration resources provide a standard way of defining what traffic should be accepted, what operations should happen to the traffic (such as enforcing authentication or editing headers), and finally where the traffic should go.
 
 This follows the declarative nature of Kubernetes since the developer describes what they need and the Operator figures out how to provide it.
 
-![k8s-basic-ingress](./assets/images/basic-k8s-ingress-diagram.png)
+<img src="./assets/images/basic-k8s-ingress-diagram.png" alt="k8s-basic-ingress" width="877" height="600" />
 
 With ngrok, the Operator establishes a secure outbound connection to the ngrok service which creates a public endpoint for your Kubernetes service.
 When someone hits the public endpoint, that traffic is sent down to the ngrok Kubernetes Operator and is forwarded to the services in the cluster.
 
-![ngrok-k8s-basic](./assets/images/basic-ngrok-k8s-ingress-diagram.png)
+<img src="./assets/images/basic-ngrok-k8s-ingress-diagram.png" alt="ngrok-k8s-basic" width="1147" height="600" />
 
 Once installed, the wide variety of configuration options make it easy to separate concerns and responsibilities.
 For example, an operations/infrastructure team can manage the resources like `Gateway` from Gateway API that define what hostnames/protocols/ports to accept traffic on
@@ -35,4 +35,4 @@ while other developers or teams can create, update, and manage configuration res
 This allows your operations/infrastructure team to focus on the higher-level policy about what kinds of traffic to accept while allowing other teams to self-service deploying their
 services/applications and routing traffic to them without needing to put in a request for the operations/infrastructure team to do that for them.
 
-![basic-k8s-operator-user](./assets/images/basic-k8s-operator-user-diagram.png)
+<img src="./assets/images/basic-k8s-operator-user-diagram.png" alt="basic-k8s-operator-user" width="1052" height="557" />

--- a/k8s/installation/architecture.mdx
+++ b/k8s/installation/architecture.mdx
@@ -18,7 +18,7 @@ Before jumping directly into the ngrok Operator's specific architecture, first g
 The word _controller_ can sometimes be used in ways that can be confusing.
 While the whole thing is commonly referred to as the Operator or an ingress _controller_, in reality, many _controllers_ are actually a Controller Runtime Manager which runs multiple individual [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/) and provides common things to them like shared Kubernetes client caches and leader election.
 
-![Kubebuilder Architecture Diagram](../assets/images/kubebuilder_architecture_diagram.svg)
+<img src="../assets/images/kubebuilder_architecture_diagram.svg" alt="Kubebuilder Architecture Diagram" width="960" height="720" />
 
 > From: https://book.kubebuilder.io/architecture.html
 

--- a/snippets/ActionHub.jsx
+++ b/snippets/ActionHub.jsx
@@ -268,8 +268,10 @@ const Protocols = {
 	// Sort actions alphabetically by type
 	const sortedFilteredActions = filteredActions.sort((a, b) => a.type.localeCompare(b.type));
 
+	// Reserve vertical space to prevent CLS on page load.
+	// 3000px covers ~26 action cards in a 2-column grid.
 	return (
-		<>
+		<div style={{ minHeight: 3000 }}>
 			<div className="mb-4 flex flex-wrap justify-between place-items-end gap-4">
 				<div className="relative max-w-64">
 					<input
@@ -367,6 +369,6 @@ const Protocols = {
 					</div>
 				</div>
 			)}
-		</>
+		</div>
 	);
 };

--- a/snippets/ExampleHub.jsx
+++ b/snippets/ExampleHub.jsx
@@ -156,8 +156,11 @@ export const ExampleHub = ({ parentDir }) => {
 		groupedExamples.set(example.primaryCategoryId, group);
 	}
 
+	// Reserve vertical space to prevent CLS (Cumulative Layout Shift) on page load.
+	// 2400px is large enough to accommodate all example cards (~12 cards in 2-column grid)
+	// to prevent footer from shifting down as content renders.
 	return (
-		<>
+		<div style={{ minHeight: 2400 }}>
 			<div className="mb-4 flex flex-wrap justify-between place-items-end gap-4">
 				<div className="relative max-w-64">
 					<input
@@ -242,6 +245,6 @@ export const ExampleHub = ({ parentDir }) => {
 					</div>
 				</div>
 			)}
-		</>
+		</div>
 	);
 }

--- a/snippets/guides/customer-networks-content.mdx
+++ b/snippets/guides/customer-networks-content.mdx
@@ -14,7 +14,7 @@ In this guide, walk through setting up remote access to the systems in a single 
 
 ## Architectural reference
 
-![ngrok k8s Bindings Guide Arch](/img/guides/bindings-guide.png)
+<img src="/img/guides/bindings-guide.png" alt="ngrok k8s Bindings Guide Arch" width="3123" height="948" />
 
 ### What you'll need
 
@@ -38,11 +38,11 @@ Create a separate Service User + associated authtoken for each of your customers
 
 Navigate to the [Service Users](https://dashboard.ngrok.com/service-users) section of your dashboard and click "new Service User".
 
-![Service User interface screenshot](/img/guides/service-user-ss-1.png)
+<img src="/img/guides/service-user-ss-1.png" alt="Service User interface screenshot" width="508" height="144" />
 
 Create an authtoken for that Service User and assign it an ACL rule. By assigning an ACL rule, you can restrict what endpoints the Service User with this authtoken can create. Navigate to the authtokens section on your dashboard and click "new authtoken". Assign it an ACL rule as shown below to restrict any agent using it with permission to only create internal endpoints with a URL matching `*.cust1.internal`.
 
-![Service User configuration interface screenshot](/img/guides/service-user-ss-2.png)
+<img src="/img/guides/service-user-ss-2.png" alt="Service User configuration interface screenshot" width="593" height="344" />
 
 ### 2. Install the ngrok Agent within Customer 1's network and configure internal Agent endpoints in ngrok.yml
 
@@ -113,7 +113,7 @@ Cloud Endpoints do not forward their traffic to an agent by default and instead 
 
 Create a kubernetes bound Cloud Endpoint in the ngrok dashboard by navigating to endpoints and clicking "new". Configure it as shown in the screenshot below:
 
-![Cloud endpoint UI screenshot](/img/guides/cloud-endpoint-ss-1.png)
+<img src="/img/guides/cloud-endpoint-ss-1.png" alt="Cloud endpoint UI screenshot" width="1382" height="1092" />
 
 Additionally, create a Cloud Endpoint for the other two services: *"tls://api-cust1.acme-customers"* and *"tcp://database-cust1.acme-customers:5432"*. A v1.Service object is created in the namespace determined by the second part of the kubernetes endpoint URL's hostname (acme-customers). The name of the service is denoted by the first part of the endpoint URL's hostname .
 

--- a/snippets/guides/region-pinning-content.mdx
+++ b/snippets/guides/region-pinning-content.mdx
@@ -16,6 +16,8 @@ The same configuration will soon support [dedicated IP addresses](/universal-gat
 <img 
   src="../img/docs/region_pinning_diagram_how_it_works.png" 
   alt="Region Pinning diagram -- how it works"
+  width={1371}
+  height={1901}
   style={{height: "auto", width: "50%"}}
 />
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,10 @@
+/* Keep content images responsive within their container while preserving
+   the aspect ratio implied by the width/height attributes (prevents CLS). */
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Custom CSS for tooltip styling */
 .tooltip {
   font-weight: bold;

--- a/traffic-policy/identities.mdx
+++ b/traffic-policy/identities.mdx
@@ -21,7 +21,7 @@ Dashboard](https://dashboard.ngrok.com/app-users) or via the [ngrok API](#api).
 Traffic Identities were previously called 'App Users', you may find references with the
 old name while they are being transitioned.
 
-![Identities and Sessions: Conceptual Architecture](/img/docs/app_user_session_diagram.png)
+<img src="/img/docs/app_user_session_diagram.png" alt="Identities and Sessions: Conceptual Architecture" width="1600" height="830" />
 
 ## Managing sessions from the Dashboard
 

--- a/using-ngrok-with/using-mcp.mdx
+++ b/using-ngrok-with/using-mcp.mdx
@@ -11,7 +11,7 @@ Using ngrok's identity, Traffic Policy, and observability features, you can ensu
 
 ## Architectural reference
 
-![MCP architectural reference diagram.](./img/architecture.png)
+<img src="./img/architecture.png" alt="MCP architectural reference diagram." width="4200" height="1163" />
 
 ## What you'll need
 


### PR DESCRIPTION
dupe of #2007 where mintlify wasn't cooperating. Starting fresh here. This PR adds minHeight dimensions to divs that take up a lot of vertical space, and replaces all markdown images with HTML elements that have defined dimensions (plus a CSS rule to ensure they don't break out of their containers). This prevents layout shift and improves SEO.