### PR TITLE
DOC-571: Add YAML indentation gotchas note to agent config and Traffic Policy quickstarts

### DIFF
--- a/agent/config/index.mdx
+++ b/agent/config/index.mdx
@@ -4,11 +4,15 @@ sidebarTitle: Overview
 description: Learn about the ngrok agent configuration file for running multiple tunnels simultaneously and configuring advanced settings.
 ---
 
+import YamlIndentationNote from "/snippets/shared/yaml-indentation-note.mdx";
+
 ## Overview
 
 The ngrok agent supports an optional, YAML configuration file which provides
 you with the power to run multiple tunnels simultaneously as well as to tweak
 some of its more advanced settings.
+
+<YamlIndentationNote />
 
 ## Default locations
 

--- a/agent/config/v3.mdx
+++ b/agent/config/v3.mdx
@@ -4,9 +4,13 @@ sidebarTitle: Version 3
 description: Reference documentation for ngrok Agent Configuration File version 3, including breaking changes, migration guide, and endpoint definitions.
 ---
 
+import YamlIndentationNote from "/snippets/shared/yaml-indentation-note.mdx";
+
 The ngrok agent supports an optional, YAML configuration file which enables you to configure advanced settings and run multiple endpoints simultaneously.
 
 The agent configuration file location depends on your system. You can check the location of your configuration file by running `ngrok config check` or edit the file in your terminal by running `ngrok config edit`.
+
+<YamlIndentationNote />
 
 ## Breaking changes
 

--- a/snippets/shared/yaml-indentation-note.mdx
+++ b/snippets/shared/yaml-indentation-note.mdx
@@ -1,8 +1,7 @@
 <Note>
 
-**YAML gotchas**
-
-YAML is whitespace-sensitive. Use **spaces only** (tabs are not valid in YAML) and keep keys at the same level aligned to the same column.
+YAML is whitespace-sensitive.
+Use spaces only (tabs are not valid in YAML) and keep keys at the same level aligned to the same column.
 
 Valid:
 

--- a/snippets/shared/yaml-indentation-note.mdx
+++ b/snippets/shared/yaml-indentation-note.mdx
@@ -3,7 +3,7 @@
 YAML is whitespace-sensitive.
 Use spaces only (tabs are not valid in YAML) and keep keys at the same level aligned to the same column.
 
-Valid:
+✅ Valid:
 
 ```yaml
 endpoints:
@@ -12,7 +12,7 @@ endpoints:
       url: 80
 ```
 
-Invalid — `upstream` is indented inconsistently and will fail to parse:
+❌ Invalid—`upstream` is indented inconsistently and will fail to parse:
 
 ```yaml
 endpoints:
@@ -20,7 +20,5 @@ endpoints:
      upstream:
       url: 80
 ```
-
-If you hit a parse error, run `ngrok config check` to validate your file.
 
 </Note>

--- a/snippets/shared/yaml-indentation-note.mdx
+++ b/snippets/shared/yaml-indentation-note.mdx
@@ -1,0 +1,27 @@
+<Note>
+
+**YAML gotchas**
+
+YAML is whitespace-sensitive. Use **spaces only** (tabs are not valid in YAML) and keep keys at the same level aligned to the same column.
+
+Valid:
+
+```yaml
+endpoints:
+  - name: example
+    upstream:
+      url: 80
+```
+
+Invalid — `upstream` is indented inconsistently and will fail to parse:
+
+```yaml
+endpoints:
+  - name: example
+     upstream:
+      url: 80
+```
+
+If you hit a parse error, run `ngrok config check` to validate your file.
+
+</Note>

--- a/traffic-policy/getting-started/agent-endpoints.mdx
+++ b/traffic-policy/getting-started/agent-endpoints.mdx
@@ -4,7 +4,11 @@ sidebarTitle: Agent Endpoints
 description: Learn how to set up an Agent Endpoint with a custom Traffic Policy.
 ---
 
+import YamlIndentationNote from "/snippets/shared/yaml-indentation-note.mdx";
+
 [Traffic Policy](/traffic-policy/) enables you to manage traffic to your ngrok endpoints by dynamically implementing logic based on the request before it reaches your upstream services. This guide will teach you how to configure an [Agent Endpoint](/universal-gateway/agent-endpoints) with a custom Traffic Policy using the [ngrok Agent CLI](/agent/cli/).
+
+<YamlIndentationNote />
 
 There are two ways to define your Traffic Policy:
 

--- a/traffic-policy/getting-started/cloud-endpoints.mdx
+++ b/traffic-policy/getting-started/cloud-endpoints.mdx
@@ -4,7 +4,11 @@ sidebarTitle: Cloud Endpoints
 description: Learn how to create Cloud Endpoints with Traffic Policies using the ngrok API for programmatic endpoint management.
 ---
 
+import YamlIndentationNote from "/snippets/shared/yaml-indentation-note.mdx";
+
 [Traffic Policy](/traffic-policy/) enables you to manage traffic to your ngrok endpoints by dynamically implementing logic based on the request before it reaches your upstream services. This guide will teach you how to configure a [Cloud Endpoint](/universal-gateway/cloud-endpoints) with a custom Traffic Policy.
+
+<YamlIndentationNote />
 
 <Tip>
 	This guide walks you through using the ngrok dashboard, which is recommended for most cases. You can also [use the ngrok API](#using-the-api).


### PR DESCRIPTION
## Summary

- Adds a shared `yaml-indentation-note.mdx` snippet covering spaces vs tabs and indentation alignment, with minimal valid and invalid examples.
- Imports it into the agent config overview, v3 reference, and both Traffic Policy quickstarts (agent and cloud endpoints) to reduce YAML parse errors in the highest-traffic config docs.

Resolves [DOC-571](https://linear.app/ngrok/issue/DOC-571/add-yaml-indentation-gotchas-note).

## Test plan

- [ ] Preview the four updated pages and confirm the note renders correctly with the valid/invalid example blocks.
- [ ] Confirm the snippet import path resolves on each page.