### PR TITLE
DOC-512 document is_on_blocklist and is_tor_node IP intelligence helpers

### DIFF
--- a/snippets/traffic-policy/variables/conn.ip-intel.mdx
+++ b/snippets/traffic-policy/variables/conn.ip-intel.mdx
@@ -1,6 +1,7 @@
 
 
-IP Intelligence provides you with additional information about any IP address you see in ngrok. It includes Autonomous System information, Geolocation data, as well as information fetched from 3rd parties that list IP address for blocklists or allowlists.
+IP Intelligence provides you with additional information about any IP address you see in ngrok.
+It includes Autonomous System information, Geolocation data, as well as information fetched from 3rd parties that list IP address for blocklists or allowlists.
 
 See the full list of [IP Categories available here](#ip-categories).
 
@@ -18,7 +19,8 @@ The following variables are available under the `conn.client_ip` namespace:
 
 ### `conn.client_ip.categories`
 
-The list of categories that classify the `conn.client_ip`. Check out our [full list of categories](#ip-categories).
+The list of categories that classify the `conn.client_ip`.
+Check out our [full list of categories](#ip-categories).
 
 <CodeGroup>
 ```yaml policy.yml
@@ -120,7 +122,8 @@ expressions:
 
 ## Client IP Geo Location
 
-This is the location where the IP address is located, which may be different from where the IP address is registered. For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
+This is the location where the IP address is located, which may be different from where the IP address is registered.
+For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
 
 | Name                                                                                | Type      | Description                                                                                                   |
 | ----------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
@@ -211,7 +214,8 @@ expressions:
 
 ### `conn.client_ip.geo.location.is_eu`
 
-Determines if the `conn.client_ip` is in the EU. Helpful for GDPR compliance.
+Determines if the `conn.client_ip` is in the EU.
+Helpful for GDPR compliance.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -355,7 +359,8 @@ expressions:
 
 ## Client IP Registered Geo Location
 
-This is the location where the IP address is registered, which may be different from where the IP address is located. For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
+This is the location where the IP address is registered, which may be different from where the IP address is located.
+For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
 
 | Name                                                                                                      | Type      | Description                                                                              |
 | --------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
@@ -442,7 +447,8 @@ expressions:
 
 ### `conn.client_ip.geo.registered_location.is_eu`
 
-Determines if the `conn.client_ip` is in the EU. Helpful for GDPR compliance.
+Determines if the `conn.client_ip` is in the EU.
+Helpful for GDPR compliance.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -524,7 +530,8 @@ The following variables are available under the `conn.server_ip` namespace:
 
 ### `conn.server_ip.categories`
 
-The list of categories that classify the `conn.server_ip`. Check out our [full list of categories](#ip-categories).
+The list of categories that classify the `conn.server_ip`.
+Check out our [full list of categories](#ip-categories).
 
 <CodeGroup>
 ```yaml policy.yml
@@ -624,7 +631,8 @@ expressions:
 
 ## Server IP Location Geo
 
-This is the location where the server IP address is located, which may be different from where the IP address is registered. For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
+This is the location where the server IP address is located, which may be different from where the IP address is registered.
+For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
 
 | Name                                                                                | Type      | Description                                                                                                   |
 | ----------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
@@ -715,7 +723,8 @@ expressions:
 
 ### `conn.server_ip.geo.location.is_eu`
 
-Determines if the `conn.server_ip` location is in the EU. Helpful for GDPR compliance.
+Determines if the `conn.server_ip` location is in the EU.
+Helpful for GDPR compliance.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -859,7 +868,8 @@ expressions:
 
 ## Server IP Registered Location Geo
 
-This is the location where the server IP address is registered, which may be different from where the IP address is located. For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
+This is the location where the server IP address is registered, which may be different from where the IP address is located.
+For more details, see the [MaxMind documentation](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation).
 
 | Name                                                                                                      | Type      | Description                                                                              |
 | --------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
@@ -946,7 +956,8 @@ expressions:
 
 ### `conn.server_ip.geo.registered_location.is_eu`
 
-Determines if the `conn.server_ip` is in the EU. Helpful for GDPR compliance.
+Determines if the `conn.server_ip` is in the EU.
+Helpful for GDPR compliance.
 
 <CodeGroup>
 ```yaml policy.yml

--- a/snippets/traffic-policy/variables/conn.ip-intel.mdx
+++ b/snippets/traffic-policy/variables/conn.ip-intel.mdx
@@ -36,7 +36,9 @@ expressions:
 
 ### `conn.client_ip.is_on_blocklist`
 
-`true` when the `conn.client_ip` appears on one of the curated IP reputation blocklists ngrok trusts. These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path. This is a convenience shortcut equivalent to checking `conn.client_ip.categories` for any blocklist category.
+`true` when the `conn.client_ip` appears on one of the curated IP reputation blocklists ngrok trusts.
+These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path.
+This is a convenience shortcut equivalent to checking `conn.client_ip.categories` for any blocklist category.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -54,7 +56,8 @@ expressions:
 
 ### `conn.client_ip.is_tor_node`
 
-`true` when the `conn.client_ip` is a known Tor exit node. This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.client_ip.categories`.
+`true` when the `conn.client_ip` is a known Tor exit node.
+This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.client_ip.categories`.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -539,7 +542,9 @@ expressions:
 
 ### `conn.server_ip.is_on_blocklist`
 
-`true` when the `conn.server_ip` appears on one of the curated IP reputation blocklists ngrok trusts. These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path. This is a convenience shortcut equivalent to checking `conn.server_ip.categories` for any blocklist category.
+`true` when the `conn.server_ip` appears on one of the curated IP reputation blocklists ngrok trusts.
+These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path.
+This is a convenience shortcut equivalent to checking `conn.server_ip.categories` for any blocklist category.
 
 <CodeGroup>
 ```yaml policy.yml
@@ -557,7 +562,8 @@ expressions:
 
 ### `conn.server_ip.is_tor_node`
 
-`true` when the `conn.server_ip` is a known Tor exit node. This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.server_ip.categories`.
+`true` when the `conn.server_ip` is a known Tor exit node.
+This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.server_ip.categories`.
 
 <CodeGroup>
 ```yaml policy.yml

--- a/snippets/traffic-policy/variables/conn.ip-intel.mdx
+++ b/snippets/traffic-policy/variables/conn.ip-intel.mdx
@@ -10,9 +10,11 @@ These variables can be used in Traffic Policy expressions, or they can be used t
 
 The following variables are available under the `conn.client_ip` namespace:
 
-| Name                                                    | Type   | Description                                                                                                         |
-| ------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
-| [`conn.client_ip.categories`](#connclient-ipcategories) | `list` | The list of categories that classify the `conn.client_ip`. Check out our [full list of categories](#ip-categories). |
+| Name                                                            | Type      | Description                                                                                                                                |
+| --------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`conn.client_ip.categories`](#connclient-ipcategories)         | `list`    | The list of categories that classify the `conn.client_ip`. Check out our [full list of categories](#ip-categories).                        |
+| [`conn.client_ip.is_on_blocklist`](#connclient-ipis_on_blocklist) | `boolean` | `true` when the `conn.client_ip` appears on one of the curated IP reputation blocklists ngrok trusts. Convenience shortcut for blocklist checks against `conn.client_ip.categories`. |
+| [`conn.client_ip.is_tor_node`](#connclient-ipis_tor_node)       | `boolean` | `true` when the `conn.client_ip` is a known Tor exit node. Equivalent to checking for `proxy.anonymous.tor` in `conn.client_ip.categories`. |
 
 ### `conn.client_ip.categories`
 
@@ -27,6 +29,42 @@ expressions:
 {
   "expressions": [
     "('proxy.anonymous.tor' in conn.client_ip.categories)"
+  ]
+}
+```
+</CodeGroup>
+
+### `conn.client_ip.is_on_blocklist`
+
+`true` when the `conn.client_ip` appears on one of the curated IP reputation blocklists ngrok trusts. These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path. This is a convenience shortcut equivalent to checking `conn.client_ip.categories` for any blocklist category.
+
+<CodeGroup>
+```yaml policy.yml
+expressions:
+  - "conn.client_ip.is_on_blocklist == true"
+```
+```json policy.json
+{
+  "expressions": [
+    "conn.client_ip.is_on_blocklist == true"
+  ]
+}
+```
+</CodeGroup>
+
+### `conn.client_ip.is_tor_node`
+
+`true` when the `conn.client_ip` is a known Tor exit node. This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.client_ip.categories`.
+
+<CodeGroup>
+```yaml policy.yml
+expressions:
+  - "conn.client_ip.is_tor_node == true"
+```
+```json policy.json
+{
+  "expressions": [
+    "conn.client_ip.is_tor_node == true"
   ]
 }
 ```
@@ -475,9 +513,11 @@ expressions:
 
 The following variables are available under the `conn.server_ip` namespace:
 
-| Name                                                    | Type   | Description                                                                                                         |
-| ------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
-| [`conn.server_ip.categories`](#connserver-ipcategories) | `list` | The list of categories that classify the `conn.server_ip`. Check out our [full list of categories](#ip-categories). |
+| Name                                                              | Type      | Description                                                                                                                                |
+| ----------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`conn.server_ip.categories`](#connserver-ipcategories)           | `list`    | The list of categories that classify the `conn.server_ip`. Check out our [full list of categories](#ip-categories).                        |
+| [`conn.server_ip.is_on_blocklist`](#connserver-ipis_on_blocklist) | `boolean` | `true` when the `conn.server_ip` appears on one of the curated IP reputation blocklists ngrok trusts. Convenience shortcut for blocklist checks against `conn.server_ip.categories`. |
+| [`conn.server_ip.is_tor_node`](#connserver-ipis_tor_node)         | `boolean` | `true` when the `conn.server_ip` is a known Tor exit node. Equivalent to checking for `proxy.anonymous.tor` in `conn.server_ip.categories`. |
 
 ### `conn.server_ip.categories`
 
@@ -492,6 +532,42 @@ expressions:
 {
   "expressions": [
     "('proxy.anonymous.tor' in conn.server_ip.categories)"
+  ]
+}
+```
+</CodeGroup>
+
+### `conn.server_ip.is_on_blocklist`
+
+`true` when the `conn.server_ip` appears on one of the curated IP reputation blocklists ngrok trusts. These are blocklists with low false-positive rates, suitable for blocking traffic on the critical path. This is a convenience shortcut equivalent to checking `conn.server_ip.categories` for any blocklist category.
+
+<CodeGroup>
+```yaml policy.yml
+expressions:
+  - "conn.server_ip.is_on_blocklist == true"
+```
+```json policy.json
+{
+  "expressions": [
+    "conn.server_ip.is_on_blocklist == true"
+  ]
+}
+```
+</CodeGroup>
+
+### `conn.server_ip.is_tor_node`
+
+`true` when the `conn.server_ip` is a known Tor exit node. This is a convenience shortcut equivalent to checking `'proxy.anonymous.tor' in conn.server_ip.categories`.
+
+<CodeGroup>
+```yaml policy.yml
+expressions:
+  - "conn.server_ip.is_tor_node == true"
+```
+```json policy.json
+{
+  "expressions": [
+    "conn.server_ip.is_tor_node == true"
   ]
 }
 ```


### PR DESCRIPTION
Resolves DOC-512

### Why

`conn.client_ip.is_on_blocklist`, `conn.client_ip.is_tor_node`, and the matching `conn.server_ip.*` booleans have been implemented in the traffic policy CEL evaluator for a while (`go/lib/tp/vars/conn.go`), but the docs never picked them up — they only show in the `categories` list shortcut. They've shown up in [external blog posts](https://dev.to/ngrok/doglabbing-ngrok-eyes-only-photo-sharing-with-immich-and-oidc-4oal) before our reference docs, which makes them hard to discover.

### How

Added the four missing variables (client + server × `is_on_blocklist` + `is_tor_node`) to `snippets/traffic-policy/variables/conn.ip-intel.mdx` under the existing Client/Server IP Intelligence sections. Each follows the same shape as `categories`: a row in the namespace table, an `H3` heading section with a short description that cross-references the equivalent `categories` query, and a `<CodeGroup>` with `policy.yml` / `policy.json` examples.

Each section frames the booleans as convenience shortcuts for the equivalent category check — that matches how they're implemented internally (the ipmeta layer treats them as a fast-path optimization over `categories`, see `go/lib/ipmeta/models.go`).

### Validation

- `python3 scripts/validate_policy_snippets.py` → 477/477 pass