### PR TITLE
Add ngrok video to the start page

### DIFF
--- a/start.mdx
+++ b/start.mdx
@@ -4,7 +4,11 @@ description: ngrok makes it easy to put your apps, APIs, and services online.
 mode: center
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 ngrok is an all-in-one cloud networking platform that secures, transforms, and routes your traffic to services running anywhere. From sharing localhost to production API gateways, ngrok handles it all.
+
+<YouTubeEmbed videoId="trXqyNXJa1k" title="Here’s how teams are using ngrok in ways you might not expect." />
 
 ## Problems we solve
 


### PR DESCRIPTION
We're experimenting with adding the video to the marketing site home page and wanted to see if we could add it to the docs start page as well.

<img width="1284" height="1124" alt="CleanShot 2026-07-01 at 08 23 10" src="https://github.com/user-attachments/assets/6af1eb57-8a6e-4fcc-b76c-d5ce16cf12a9" />

Unrelated, but I'm currently getting mintlify error when running the dev server that's resolved by removing "download-pdf" from the contextual options list. I just deleted it so I could preview locally and aren't sure whether it's genuinely invalid, or just a local preview restriction for an enterprise feature.

<img width="1543" height="502" alt="CleanShot 2026-07-01 at 08 31 40" src="https://github.com/user-attachments/assets/a5fb9d0f-12ea-4297-8689-6c30b94160f6" />