### PR TITLE
Update AI Gateway provider models and aliases to render from source data

### DIFF
--- a/ai-gateway/reference/model-catalog.mdx
+++ b/ai-gateway/reference/model-catalog.mdx
@@ -4,6 +4,8 @@ icon: book
 description: Built-in providers and models available on ngrok.ai.
 ---
 
+import { AIGatewayModelCatalogModelAliases, AIGatewayModelCatalogProvider, AIGatewayModelCatalogProviderAliases } from "/snippets/ai-gateway/AIGatewayModelCatalogProvider.jsx";
+
 ngrok.ai maintains a catalog of known providers and models. This catalog enables automatic model resolution, routing, model validation, and rich metadata for selection strategies.
 
 ## How the catalog works
@@ -39,218 +41,39 @@ Some built-in providers don’t need a provider key. You can spot them in the ta
 
 Other providers do need a key. For those, add your provider key in app.ngrok.ai. The provider will bill you directly for model usage, and your credits will cover the gateway fee. This is often called BYOK (bring your own key).
 
-### OpenAI
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `openai` |
-| **Aliases** | `openAI`, `open-ai`, `open-AI` |
-| **Base URL** | `https://api.openai.com/v1/` |
-| **Website** | [openai.com](https://openai.com/) |
-| **Provider key required** | No |
-
-[How to use OpenAI →](/ai-gateway/providers/openai)
-
-#### OpenAI models
-
-| Model ID | Display Name | Context Window | Output Tokens | Modalities |
-|----------|--------------|----------------|---------------|------------|
-| `gpt-5.4-pro` | GPT-5.4 Pro | 1,050,000 | 128,000 | text, image |
-| `gpt-5.4` | GPT-5.4 | 1,050,000 | 128,000 | text, image |
-| `gpt-5.3-codex` | GPT-5.3-Codex | 400,000 | 128,000 | text, image |
-| `gpt-5.2-codex` | GPT-5.2-Codex | 400,000 | 128,000 | text, image |
-| `gpt-5.2-pro` | GPT-5.2 Pro | 400,000 | 100,000 | text, image |
-| `gpt-5.2` | GPT-5.2 | 400,000 | 128,000 | text, image |
-| `gpt-5.2-chat-latest` | GPT-5.2 Chat Latest | 400,000 | 128,000 | text, image |
-| `gpt-5.1` | GPT-5.1 | 400,000 | 128,000 | text, image |
-| `gpt-5.1-chat-latest` | GPT-5.1 Chat Latest | 256,000 | 32,768 | text, image |
-| `gpt-5` | GPT-5 | 400,000 | 128,000 | text, image |
-| `gpt-5-mini` | GPT-5 Mini | 400,000 | 128,000 | text, image |
-| `gpt-5-nano` | GPT-5 Nano | 400,000 | 128,000 | text, image |
-| `gpt-5-chat-latest` | GPT-5 Chat | 400,000 | 128,000 | text, image |
-| `gpt-4.1` | GPT-4.1 | 1,000,000 | - | text, image |
-| `gpt-4.1-mini` | GPT-4.1 mini | 1,000,000 | - | text, image |
-| `gpt-4.1-nano` | GPT-4.1 nano | 1,000,000 | - | text, image |
-| `gpt-4o` | GPT-4o | 128,000 | 16,384 | text, image, audio |
-| `gpt-4o-mini` | GPT-4o Mini | 128,000 | 16,384 | text, image |
-| `o4-mini` | O4-Mini | 200,000 | 100,000 | text |
-| `o4-mini-deep-research` | O4-Mini-Deep-Research | 200,000 | 100,000 | text |
-| `o3-pro` | O3-Pro | 128,000 | 100,000 | text |
-| `o3` | O3 | 128,000 | 100,000 | text |
-| `o3-mini` | O3 Mini | 200,000 | 100,000 | text |
-| `o3-deep-research` | O3-Deep-Research | 200,000 | 100,000 | text |
-| `o1-pro` | O1-Pro | 200,000 | 100,000 | text |
-| `o1` | O1 | 128,000 | 100,000 | text |
-| `gpt-4-turbo` | GPT-4 Turbo | 128,000 | 4,096 | text, image |
-| `gpt-4` | GPT-4 | 8,192 | 8,192 | text |
-| `gpt-3.5-turbo` | GPT-3.5 Turbo _(deprecated, retires September 28, 2026)_ | 16,385 | 4,096 | text |
+<AIGatewayModelCatalogProvider providerId="openai" />
 
 ---
 
-### Anthropic
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `anthropic` |
-| **Aliases** | `Anthropic` |
-| **Base URL** | `https://api.anthropic.com/v1/` |
-| **Website** | [anthropic.com](https://anthropic.com/) |
-| **Provider key required** | No |
-
-[How to use Anthropic →](/ai-gateway/providers/anthropic)
-
-#### Anthropic models
-
-| Model ID | Display Name | Context Window | Output Tokens | Modalities |
-|----------|--------------|----------------|---------------|------------|
-| `claude-opus-4-6` | Claude Opus 4.6 | 1,000,000 | 128,000 | text, image |
-| `claude-sonnet-4-6` | Claude Sonnet 4.6 | 1,000,000 | 64,000 | text, image |
-| `claude-haiku-4-5` | Claude Haiku 4.5 | 200,000 | 64,000 | text, image |
-| `claude-sonnet-4-5` | Claude Sonnet 4.5 | 1,000,000 | 64,000 | text, image |
-| `claude-opus-4-5` | Claude Opus 4.5 | 200,000 | 64,000 | text, image |
-| `claude-opus-4-1` | Claude Opus 4.1 | 200,000 | 32,000 | text, image |
-| `claude-sonnet-4-0` | Claude Sonnet 4 | 1,000,000 | 64,000 | text, image |
-| `claude-opus-4-0` | Claude Opus 4 | 200,000 | 32,000 | text, image |
-| `claude-3-haiku-20240307` | Claude Haiku 3 _(deprecated, retires April 20, 2026)_ | 200,000 | 4,096 | text, image |
+<AIGatewayModelCatalogProvider providerId="anthropic" />
 
 ---
 
-### Google
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `google` |
-| **Aliases** | `Google`, `gemini` |
-| **Base URL** | `https://generativelanguage.googleapis.com/v1beta/openai/` |
-| **Website** | [aistudio.google.com](https://aistudio.google.com/) |
-| **Provider key required** | Yes |
-
-[How to use Google →](/ai-gateway/providers/google)
-
-#### Google models
-
-| Model ID | Display Name | Context Window | Output Tokens | Modalities |
-|----------|--------------|----------------|---------------|------------|
-| `gemini-2.5-pro` | Gemini 2.5 Pro | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.5-flash` | Gemini 2.5 Flash | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.0-flash` | Gemini 2.0 Flash | 1,048,576 | 8,192 | text, image, audio, video, file |
-| `gemini-2.0-flash-lite` | Gemini 2.0 Flash-Lite | 1,048,576 | 8,192 | text, image, audio, video, file |
-| `gemini-3-pro-preview` | Gemini 3 Pro Preview | 1,000,000 | 65,536 | text, image, audio, video, file |
+<AIGatewayModelCatalogProvider providerId="google" />
 
 ---
 
-### DeepSeek
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `deepseek` |
-| **Aliases** | `DeepSeek`, `deep-seek` |
-| **Base URL** | `https://api.deepseek.com` |
-| **Website** | [deepseek.com](https://www.deepseek.com/) |
-| **Provider key required** | Yes |
-
-[How to use DeepSeek →](/ai-gateway/providers/deepseek)
-
-#### DeepSeek models
-
-| Model ID | Display Name | Context Window | Output Tokens | Modalities |
-|----------|--------------|----------------|---------------|------------|
-| `deepseek-reasoner` | deepseek-reasoner | 128,000 | 64,000 | text |
-| `deepseek-chat` | deepseek-chat | 128,000 | 8,192 | text |
+<AIGatewayModelCatalogProvider providerId="deepseek" />
 
 ---
 
-### Groq
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `groq` |
-| **Base URL** | `https://api.groq.com/openai/v1` |
-| **Website** | [groq.com](https://groq.com/) |
-| **Provider key required** | Yes |
-
-[How to use Groq →](/ai-gateway/providers/groq)
-
-Groq provides AI inference powered by their custom LPU (Language Processing Unit) hardware.
-
-#### Groq models
-
-| Model ID | Display Name | Context Window | Output Tokens | Modalities |
-|----------|--------------|----------------|---------------|------------|
-| `meta-llama/llama-3.1-8b-instant` | Llama 3.1 8B Instant | 131,072 | 131,072 | text |
-| `meta-llama/llama-3.3-70b-versatile` | Llama 3.3 70B Versatile | 131,072 | 32,768 | text |
-| `meta-llama/llama-prompt-guard-2-22m` | Llama Prompt Guard 2 22M | 512 | 512 | text |
-| `meta-llama/llama-prompt-guard-2-86m` | Llama Prompt Guard 2 86M | 512 | 512 | text |
-| `meta-llama/llama-guard-4-12b` | Llama Guard 4 12B | 131,072 | 1,024 | text, image |
-| `meta-llama/llama-4-maverick-17b-128e-instruct` | Llama 4 Maverick 17B 128E Instruct | 131,072 | 8,192 | text, image |
-| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout 17B 16E Instruct | 131,072 | 8,192 | text, image |
-| `moonshotai/kimi-k2-instruct-0905` | Kimi K2 | 262,144 | 16,384 | text |
-| `openai/gpt-oss-120b` | GPT OSS 120B | 131,072 | 131,072 | text |
-| `openai/gpt-oss-20b` | GPT OSS 20B | 131,072 | 131,072 | text |
-| `openai/gpt-oss-safeguard-20b` | Safety GPT OSS 20B | 131,072 | 65,536 | text |
-| `qwen/qwen3-32b` | Qwen3-32B | 131,072 | 40,960 | text |
+<AIGatewayModelCatalogProvider providerId="groq" />
 
 ---
 
-### OpenRouter
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `openrouter` |
-| **Base URL** | `https://openrouter.ai/api/v1/` |
-| **Website** | [openrouter.ai](https://openrouter.ai/) |
-| **Provider key required** | Yes |
-
-[How to use OpenRouter →](/ai-gateway/providers/openrouter)
-
-OpenRouter is a unified API that provides access to multiple AI models from various providers through a single endpoint.
+<AIGatewayModelCatalogProvider providerId="openrouter" />
 
 ---
 
-### Hyperbolic
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `hyperbolic` |
-| **Base URL** | `https://api.hyperbolic.xyz/v1/` |
-| **Website** | [hyperbolic.xyz](https://hyperbolic.xyz/) |
-| **Provider key required** | Yes |
-
-[How to use Hyperbolic →](/ai-gateway/providers/hyperbolic)
-
-Hyperbolic provides high-performance inference for open-source models.
+<AIGatewayModelCatalogProvider providerId="hyperbolic" />
 
 ---
 
-### InceptionLabs
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `inceptionlabs` |
-| **Website** | [inceptionlabs.ai](https://www.inceptionlabs.ai/) |
-| **Provider key required** | Yes |
-
-[How to use InceptionLabs →](/ai-gateway/providers/inceptionlabs)
-
-InceptionLabs develops diffusion-based language models for fast, efficient text generation.
+<AIGatewayModelCatalogProvider providerId="inceptionlabs" />
 
 ---
 
-### Inference.net
-
-| Field | Value |
-|-------|-------|
-| **Provider ID** | `inference-net` |
-| **Base URL** | `https://api.inference.net/v1/` |
-| **Website** | [inference.net](https://inference.net/) |
-| **Provider key required** | Yes |
-
-[How to use Inference.net →](/ai-gateway/providers/inference-net)
-
-Inference.net provides a distributed inference network for running AI models at scale.
-
----
+<AIGatewayModelCatalogProvider providerId="inference.net" />
 
 ## Using models from the catalog
 
@@ -289,98 +112,19 @@ The model catalog is updated periodically to include new models and providers. F
 ---
 
 ## Aliases reference
+
 Model and provider names are not case-sensitive. For example, `gpt-4o`, `GPT-4o`, and `Gpt-4O` all resolve to the same model.
 
 The following aliases are available in addition to the primary IDs listed above.
 
-### Provider aliases
+<AIGatewayModelCatalogProviderAliases />
 
-| Provider ID | Aliases |
-|-------------|---------|
-| `openai` | `openAI`, `open-ai`, `open-AI` |
-| `anthropic` | `Anthropic` |
-| `google` | `gemini` |
-| `deepseek` | `deep-seek` |
-| `openrouter` | `open-router` |
-| `inceptionlabs` | `inception-labs`, `inception` |
-| `inference.net` | `inference-net`, `inference_net` |
-| `groq` | `groqcloud` |
+<AIGatewayModelCatalogModelAliases authorId="openai" />
 
-### OpenAI model aliases
+<AIGatewayModelCatalogModelAliases authorId="anthropic" />
 
-| Alias | Resolves to |
-|-------|-------------|
-| `gpt-4-omni` | `gpt-4o` |
-| `gpt-4o-2024-05-13` | `gpt-4o` |
-| `gpt-4o-2024-08-06` | `gpt-4o` |
-| `gpt-4o-2024-11-20` | `gpt-4o` |
-| `chatgpt-4o-latest` | `gpt-4o` |
-| `gpt-4o-mini-2024-07-18` | `gpt-4o-mini` |
-| `gpt-4-turbo-2024-04-09` | `gpt-4-turbo` |
-| `gpt-4-turbo-preview` | `gpt-4-turbo` |
-| `gpt-4-1106-preview` | `gpt-4-turbo` |
-| `gpt-4-0125-preview` | `gpt-4-turbo` |
-| `gpt-4-0613` | `gpt-4` |
-| `gpt-4-0314` | `gpt-4` |
-| `gpt-4-32k` | `gpt-4` |
-| `gpt-4.1-2025-04-14` | `gpt-4.1` |
-| `gpt-4.1-mini-2025-04-14` | `gpt-4.1-mini` |
-| `gpt-4.1-nano-2025-04-14` | `gpt-4.1-nano` |
-| `gpt-5.1-2025-11-13` | `gpt-5.1` |
-| `gpt-5.4-2026-03-05` | `gpt-5.4` |
-| `gpt-5.4-pro-2026-03-05` | `gpt-5.4-pro` |
-| `gpt-5.2-pro-2025-12-11` | `gpt-5.2-pro` |
-| `GPT-5.3-Codex` | `gpt-5.3-codex` |
-| `gpt-5.3-Codex` | `gpt-5.3-codex` |
-| `gpt5.3-codex` | `gpt-5.3-codex` |
-| `GPT-5 mini` | `gpt-5-mini` |
-| `GPT-5 nano` | `gpt-5-nano` |
-| `GPT-5 Chat` | `gpt-5-chat-latest` |
-| `gpt-3.5-turbo-0125` | `gpt-3.5-turbo` |
-| `gpt-3.5-turbo-16k` | `gpt-3.5-turbo` |
-| `o4-mini-2025-04-16` | `o4-mini` |
-| `o4-mini-deep-research-2025-06-26` | `o4-mini-deep-research` |
-| `o3-pro-2025-06-10` | `o3-pro` |
-| `o3-2025-04-16` | `o3` |
-| `o3-mini-2025-01-31` | `o3-mini` |
+<AIGatewayModelCatalogModelAliases authorId="google" />
 
-### Anthropic model aliases
+<AIGatewayModelCatalogModelAliases authorId="meta-llama" />
 
-| Alias | Resolves to |
-|-------|-------------|
-| `claude-opus-4-6-20260205` | `claude-opus-4-6` |
-| `claude-sonnet-4-6-20260217` | `claude-sonnet-4-6` |
-| `claude-haiku-4-5-20251001` | `claude-haiku-4-5` |
-| `claude-sonnet-4-5-20250929` | `claude-sonnet-4-5` |
-| `claude-opus-4-5-20251101` | `claude-opus-4-5` |
-| `claude-opus-4-1-20250805` | `claude-opus-4-1` |
-| `claude-opus-4.1` | `claude-opus-4-1` |
-| `claude-sonnet-4-20250514` | `claude-sonnet-4-0` |
-| `claude-sonnet-4` | `claude-sonnet-4-0` |
-| `claude-opus-4-20250514` | `claude-opus-4-0` |
-| `claude-opus-4` | `claude-opus-4-0` |
-| `claude-haiku-3` | `claude-3-haiku-20240307` |
-
-### Google model aliases
-
-| Alias | Resolves to |
-|-------|-------------|
-| `gemini-3` | `gemini-3-pro-preview` |
-| `gemini-3-pro` | `gemini-3-pro-preview` |
-
-### Meta model aliases
-
-| Alias | Resolves to |
-|-------|-------------|
-| `llama-3.1-8b` | `llama-3.1-8b-instant` |
-| `llama-3.3-70b` | `llama-3.3-70b-versatile` |
-| `llama-4-maverick-17b-128e` | `llama-4-maverick-17b-128e-instruct` |
-| `llama-4-scout-17b-16e` | `llama-4-scout-17b-16e-instruct` |
-
-### Moonshot AI model aliases
-
-| Alias | Resolves to |
-|-------|-------------|
-| `kimi-k2-instruct` | `kimi-k2` |
-| `kimi-k2-instruct-0905` | `kimi-k2` |
-| `moonshotai/kimi-k2-instruct-0905` | `kimi-k2` |
+<AIGatewayModelCatalogModelAliases authorId="moonshotai" />

--- a/custom/scripts/build-ai-gateway-model-catalog.js
+++ b/custom/scripts/build-ai-gateway-model-catalog.js
@@ -1,0 +1,869 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const yaml = require("js-yaml");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PROVIDER_DATA_FILE_PATH = path.join(
+  REPO_ROOT,
+  "snippets",
+  "ai-gateway",
+  "AIGatewayModelCatalogProvider.jsx",
+);
+const GENERATED_DATA_START_MARKER = "//-- GENERATED PROVIDERS DATA START --//";
+const GENERATED_DATA_END_MARKER = "//-- GENERATED PROVIDERS DATA END --//";
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+// The docs UI expects a stable provider order instead of raw filesystem order.
+const PROVIDER_OUTPUT_ORDER = [
+  "openai",
+  "anthropic",
+  "google",
+  "deepseek",
+  "groq",
+  "openrouter",
+  "hyperbolic",
+  "inceptionlabs",
+  "inference.net",
+];
+// Requests to these providers can be billed through ngrok.ai inference, so they
+// do not require a user-supplied upstream provider key in the catalog output.
+const NGROK_MANAGED_PROVIDER_IDS = new Set(["openai", "anthropic"]);
+class CatalogError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CatalogError";
+  }
+}
+
+class Helpers {
+  static toUniqueStrings(values) {
+    return [...new Set((values ?? []).map(String))];
+  }
+
+  static combineModalities(modelData) {
+    return Helpers.toUniqueStrings([
+      ...(modelData.input_modalities ?? []),
+      ...(modelData.output_modalities ?? []),
+    ]);
+  }
+
+  static normalizeOptionalNumber(value) {
+    // In the source catalog, 0 is used as a sentinel for "not specified".
+    return value === 0 ? null : value ?? null;
+  }
+
+  static displayPath(filePath, inputRoot) {
+    const repoRelativePath = path.relative(REPO_ROOT, filePath);
+
+    if (!repoRelativePath.startsWith("..") && !path.isAbsolute(repoRelativePath)) {
+      return Helpers.toPosixPath(repoRelativePath);
+    }
+
+    return Helpers.toPosixPath(
+      path.join(path.basename(inputRoot), path.relative(inputRoot, filePath)),
+    );
+  }
+
+  static isPlainObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  static compareStrings(left, right) {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+
+  static refKey(authorId, modelId) {
+    // A single delimiter keeps alias/snapshot lookups in one flat map.
+    return `${authorId}\u0000${modelId}`;
+  }
+
+  static asString(value, fallback) {
+    return value === undefined || value === null || value === ""
+      ? String(fallback)
+      : String(value);
+  }
+
+  static indentBlock(value, spaces) {
+    const prefix = " ".repeat(spaces);
+    return value
+      .split("\n")
+      .map((line) => `${prefix}${line}`)
+      .join("\n");
+  }
+
+  static escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  static formatError(error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  static toPosixPath(filePath) {
+    return filePath.split(path.sep).join("/");
+  }
+
+  static providerSlug(providerId, sourcePath) {
+    return providerId === "inference.net"
+      ? "inference-net"
+      : path.basename(sourcePath, ".yaml");
+  }
+}
+
+class Cli {
+  static parseArguments(rawArgs) {
+    const args = rawArgs.filter((arg) => arg !== "--");
+
+    if (args.length !== 1) {
+      throw new CatalogError(
+        "usage: node custom/scripts/build-ai-gateway-model-catalog.js <catalog-root>",
+      );
+    }
+
+    return path.resolve(process.cwd(), args[0]);
+  }
+}
+
+class SourceCatalog {
+  constructor({ inputRoot, authorsById, modelsByReference, providerFiles }) {
+    this.inputRoot = inputRoot;
+    this.authorsById = authorsById;
+    this.modelsByReference = modelsByReference;
+    this.providerFiles = providerFiles;
+  }
+}
+
+class ProviderFile {
+  constructor({ sourceIndex, sourcePath, data }) {
+    this.sourceIndex = sourceIndex;
+    this.sourcePath = sourcePath;
+    this.data = data;
+  }
+}
+
+class ModelRecord {
+  constructor({ authorId, modelId, sourcePath, data }) {
+    this.authorId = authorId;
+    this.modelId = modelId;
+    this.sourcePath = sourcePath;
+    this.data = data;
+  }
+
+  get ref() {
+    return `${this.authorId}/${this.modelId}`;
+  }
+}
+
+class AuthorRecord {
+  constructor({ authorId, sourcePath, data }) {
+    this.authorId = authorId;
+    this.sourcePath = sourcePath;
+    this.data = data;
+  }
+}
+
+class CatalogSummary {
+  constructor({ providerCount, modelCount }) {
+    this.provider_count = providerCount;
+    this.model_count = modelCount;
+  }
+}
+
+class CatalogModel {
+  constructor({
+    id,
+    ref,
+    authorId,
+    providerId,
+    providerDisplayName,
+    displayName,
+    releasedAt,
+    deprecatedAt,
+    retiredAt,
+    aliases,
+    modalities,
+    maxContextWindow,
+    maxOutputTokens,
+    catalogIndex,
+  }) {
+    this.id = id;
+    this.ref = ref;
+    this.author_id = authorId;
+    this.provider_id = providerId;
+    this.provider_display_name = providerDisplayName;
+    this.display_name = displayName;
+    this.released_at = releasedAt;
+    this.deprecated_at = deprecatedAt;
+    this.retired_at = retiredAt;
+    this.aliases = aliases;
+    this.modalities = modalities;
+    this.max_context_window = maxContextWindow;
+    this.max_output_tokens = maxOutputTokens;
+    this.sort = {
+      catalog_index: catalogIndex,
+      provider_index: 0,
+    };
+  }
+
+  toOutputData() {
+    return {
+      id: this.id,
+      display_name: this.display_name,
+      author_id: this.author_id,
+      released_at: this.released_at,
+      deprecated_at: this.deprecated_at,
+      retired_at: this.retired_at,
+      aliases: this.aliases,
+      modalities: this.modalities,
+      max_context_window: this.max_context_window,
+      max_output_tokens: this.max_output_tokens,
+    };
+  }
+}
+
+class CatalogProvider {
+  constructor({
+    id,
+    slug,
+    displayName,
+    baseUrl,
+    website,
+    aliases,
+    providerKeyRequired,
+    source,
+    models,
+  }) {
+    this.id = id;
+    this.slug = slug;
+    this.display_name = displayName;
+    this.base_url = baseUrl;
+    this.website = website;
+    this.aliases = aliases;
+    this.provider_key_required = providerKeyRequired;
+    this.source = source;
+    this.models = models;
+  }
+
+  get modelCount() {
+    return this.models.length;
+  }
+
+  toOutputData() {
+    return {
+      id: this.id,
+      slug: this.slug,
+      display_name: this.display_name,
+      base_url: this.base_url,
+      website: this.website,
+      aliases: this.aliases,
+      provider_key_required: this.provider_key_required,
+      description: this.source.provider_description ?? "",
+      models: [...this.models]
+        .sort(CatalogBuilder.compareModelsDescendingForOutput)
+        .map((model) => model.toOutputData()),
+    };
+  }
+}
+
+class CatalogData {
+  constructor({ schemaVersion, generatedFrom, providers, authorsById }) {
+    this.schema_version = schemaVersion;
+    this.generated_from = generatedFrom;
+    this.providers = providers;
+    this.authorsById = authorsById;
+    this.summary = new CatalogSummary({
+      providerCount: providers.length,
+      modelCount: providers.reduce((sum, provider) => sum + provider.modelCount, 0),
+    });
+  }
+
+  toOutputData() {
+    return {
+      schema_version: this.schema_version,
+      generated_from: this.generated_from,
+      providers: this.providers.map((provider) => provider.toOutputData()),
+      summary: this.summary,
+    };
+  }
+}
+
+class SourceCatalogLoader {
+  static load(inputRoot) {
+    const authorsDirectory = path.join(inputRoot, "authors");
+    const providersDirectory = path.join(inputRoot, "providers");
+
+    SourceCatalogLoader.assertDirectoryExists(authorsDirectory, inputRoot, "authors");
+    SourceCatalogLoader.assertDirectoryExists(providersDirectory, inputRoot, "providers");
+
+    return new SourceCatalog({
+      inputRoot,
+      authorsById: SourceCatalogLoader.loadAuthorsById(authorsDirectory, inputRoot),
+      modelsByReference: SourceCatalogLoader.loadModelsByReference(
+        authorsDirectory,
+        inputRoot,
+      ),
+      providerFiles: SourceCatalogLoader.loadProviderFiles(providersDirectory, inputRoot),
+    });
+  }
+
+  static assertDirectoryExists(directoryPath, inputRoot, label) {
+    let stats;
+
+    try {
+      stats = fs.statSync(directoryPath);
+    } catch {
+      throw new CatalogError(
+        `Missing required input directory under ${inputRoot}: ${label}`,
+      );
+    }
+
+    if (!stats.isDirectory()) {
+      throw new CatalogError(
+        `Missing required input directory under ${inputRoot}: ${label}`,
+      );
+    }
+  }
+
+  static loadProviderFiles(providersDirectory, inputRoot) {
+    return SourceCatalogLoader.listYamlFiles(providersDirectory)
+      // Provider definitions live directly under providers/, not nested below it.
+      .filter((filePath) => path.dirname(filePath) === providersDirectory)
+      .map((sourcePath, sourceIndex) => new ProviderFile({
+        sourceIndex,
+        sourcePath,
+        data: SourceCatalogLoader.loadYamlFile(sourcePath, inputRoot),
+      }));
+  }
+
+  static loadAuthorsById(authorsDirectory, inputRoot) {
+    const authorsById = new Map();
+
+    for (const sourcePath of SourceCatalogLoader.listYamlFiles(authorsDirectory)) {
+      const authorLocation = SourceCatalogLoader.inferAuthorLocation(
+        sourcePath,
+        authorsDirectory,
+      );
+
+      if (!authorLocation) {
+        continue;
+      }
+
+      authorsById.set(authorLocation.authorId, new AuthorRecord({
+        authorId: authorLocation.authorId,
+        sourcePath,
+        data: SourceCatalogLoader.loadYamlFile(sourcePath, inputRoot),
+      }));
+    }
+
+    return authorsById;
+  }
+
+  static loadModelsByReference(authorsDirectory, inputRoot) {
+    const modelsByReference = new Map();
+
+    for (const sourcePath of SourceCatalogLoader.listYamlFiles(authorsDirectory)) {
+      const modelLocation = SourceCatalogLoader.inferModelLocation(
+        sourcePath,
+        authorsDirectory,
+      );
+
+      if (!modelLocation) {
+        continue;
+      }
+
+      const data = SourceCatalogLoader.loadYamlFile(sourcePath, inputRoot);
+      const modelId = Helpers.asString(data.id, path.basename(sourcePath, ".yaml"));
+      const modelRecord = new ModelRecord({
+        authorId: modelLocation.authorId,
+        modelId,
+        sourcePath,
+        data,
+      });
+
+      for (const key of SourceCatalogLoader.buildModelReferenceKeys(
+        modelLocation.authorId,
+        modelId,
+        data,
+      )) {
+        modelsByReference.set(key, modelRecord);
+      }
+    }
+
+    return modelsByReference;
+  }
+
+  static buildModelReferenceKeys(authorId, modelId, data) {
+    const keys = new Set([Helpers.refKey(authorId, modelId)]);
+
+    // Provider catalog refs may point at the canonical ID, an alias, or a snapshot.
+    for (const alias of Helpers.toUniqueStrings(data.id_aliases)) {
+      keys.add(Helpers.refKey(authorId, alias));
+    }
+
+    for (const snapshot of data.snapshots ?? []) {
+      if (Helpers.isPlainObject(snapshot) && snapshot.id) {
+        keys.add(Helpers.refKey(authorId, String(snapshot.id)));
+      }
+    }
+
+    return keys;
+  }
+
+  static inferModelLocation(sourcePath, authorsDirectory) {
+    const relativeParts = path.relative(authorsDirectory, sourcePath).split(path.sep);
+
+    // Only authors/<author>/models/*.yaml files define catalog-resolvable models.
+    if (relativeParts.length < 2 || relativeParts[1] !== "models") {
+      return null;
+    }
+
+    return { authorId: relativeParts[0] };
+  }
+
+  static inferAuthorLocation(sourcePath, authorsDirectory) {
+    const relativeParts = path.relative(authorsDirectory, sourcePath).split(path.sep);
+
+    // Author metadata lives at authors/<author>/<author>.yaml.
+    if (
+      relativeParts.length !== 2 ||
+      relativeParts[1] !== `${relativeParts[0]}.yaml`
+    ) {
+      return null;
+    }
+
+    return { authorId: relativeParts[0] };
+  }
+
+  static loadYamlFile(sourcePath, inputRoot) {
+    const contents = fs.readFileSync(sourcePath, "utf8");
+    const value = yaml.load(contents) ?? {};
+
+    if (!Helpers.isPlainObject(value)) {
+      throw new CatalogError(
+        `${Helpers.displayPath(sourcePath, inputRoot)} must contain a YAML mapping`,
+      );
+    }
+
+    return value;
+  }
+
+  static listYamlFiles(rootDirectory) {
+    const yamlFiles = [];
+    const pendingDirectories = [rootDirectory];
+
+    while (pendingDirectories.length > 0) {
+      const currentDirectory = pendingDirectories.pop();
+      const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+
+      entries.sort((left, right) => Helpers.compareStrings(left.name, right.name));
+
+      for (const entry of entries) {
+        const entryPath = path.join(currentDirectory, entry.name);
+
+        if (entry.isDirectory()) {
+          pendingDirectories.push(entryPath);
+        } else if (entry.isFile() && entry.name.endsWith(".yaml")) {
+          yamlFiles.push(entryPath);
+        }
+      }
+    }
+
+    yamlFiles.sort(Helpers.compareStrings);
+    return yamlFiles;
+  }
+}
+
+class CatalogBuilder {
+  static build(sourceCatalog) {
+    const errors = [];
+    const providers = sourceCatalog.providerFiles.map((providerFile) =>
+      CatalogBuilder.buildProvider(providerFile, sourceCatalog, errors),
+    );
+
+    if (errors.length > 0) {
+      throw new CatalogError(errors.join("\n"));
+    }
+
+    return new CatalogData({
+      schemaVersion: 1,
+      generatedFrom: path.basename(sourceCatalog.inputRoot),
+      providers,
+      authorsById: sourceCatalog.authorsById,
+    });
+  }
+
+  static buildProvider(providerFile, sourceCatalog, errors) {
+    const providerId = Helpers.asString(
+      providerFile.data.id,
+      path.basename(providerFile.sourcePath, ".yaml"),
+    );
+    const catalogEntries = Array.isArray(providerFile.data.catalog)
+      ? providerFile.data.catalog
+      : [];
+    const models = [];
+
+    for (const [catalogIndex, catalogEntry] of catalogEntries.entries()) {
+      if (!Helpers.isPlainObject(catalogEntry)) {
+        continue;
+      }
+
+      const model = CatalogBuilder.resolveProviderModel({
+        providerFile,
+        providerId,
+        inputRoot: sourceCatalog.inputRoot,
+        catalogEntry,
+        catalogIndex,
+        modelsByReference: sourceCatalog.modelsByReference,
+        errors,
+      });
+
+      if (model) {
+        models.push(model);
+      }
+    }
+
+    models.sort(CatalogBuilder.compareModelsAscendingByRelease);
+
+    return new CatalogProvider({
+      id: providerId,
+      slug: Helpers.providerSlug(providerId, providerFile.sourcePath),
+      displayName: Helpers.asString(providerFile.data.display_name, providerId),
+      baseUrl: providerFile.data.base_url ?? null,
+      website: providerFile.data.website ?? null,
+      aliases: Helpers.toUniqueStrings(providerFile.data.id_aliases),
+      providerKeyRequired: !NGROK_MANAGED_PROVIDER_IDS.has(providerId),
+      source: {
+        provider_file: Helpers.displayPath(providerFile.sourcePath, sourceCatalog.inputRoot),
+        provider_index: providerFile.sourceIndex,
+        provider_description: providerFile.data.description ?? null,
+      },
+      models,
+    });
+  }
+
+  static resolveProviderModel({
+    providerFile,
+    providerId,
+    inputRoot,
+    catalogEntry,
+    catalogIndex,
+    modelsByReference,
+    errors,
+  }) {
+    const reference = Helpers.asString(catalogEntry.ref, "");
+
+    // Catalog refs are always author/model so they can resolve through the shared model index.
+    if (!reference.includes("/")) {
+      errors.push(
+        `${Helpers.displayPath(providerFile.sourcePath, inputRoot)}: invalid catalog ref ${JSON.stringify(reference)}`,
+      );
+      return null;
+    }
+
+    const [authorId, modelId] = reference.split("/", 2);
+    const modelRecord = modelsByReference.get(Helpers.refKey(authorId, modelId));
+
+    if (!modelRecord) {
+      errors.push(
+        `${Helpers.displayPath(providerFile.sourcePath, inputRoot)}: unresolved catalog ref ${JSON.stringify(reference)}`,
+      );
+      return null;
+    }
+
+    try {
+      return CatalogBuilder.buildModel({
+        providerId,
+        providerDisplayName: Helpers.asString(providerFile.data.display_name, providerId),
+        inputRoot,
+        catalogIndex,
+        modelRecord,
+      });
+    } catch (error) {
+      errors.push(Helpers.formatError(error));
+      return null;
+    }
+  }
+
+  static buildModel({
+    providerId,
+    providerDisplayName,
+    inputRoot,
+    catalogIndex,
+    modelRecord,
+  }) {
+    const modelData = modelRecord.data;
+    const modelSourcePath = modelRecord.sourcePath;
+
+    return new CatalogModel({
+      id: modelRecord.modelId,
+      ref: modelRecord.ref,
+      authorId: modelRecord.authorId,
+      providerId,
+      providerDisplayName,
+      displayName: Helpers.asString(modelData.display_name, modelRecord.modelId),
+      releasedAt: CatalogBuilder.normalizeDate(
+        modelData.released_at,
+        "released_at",
+        true,
+        modelSourcePath,
+        inputRoot,
+      ),
+      deprecatedAt: CatalogBuilder.normalizeDate(
+        modelData.deprecated_at,
+        "deprecated_at",
+        false,
+        modelSourcePath,
+        inputRoot,
+      ),
+      retiredAt: CatalogBuilder.normalizeDate(
+        modelData.retired_at,
+        "retired_at",
+        false,
+        modelSourcePath,
+        inputRoot,
+      ),
+      aliases: CatalogBuilder.collectModelAliases(modelData),
+      modalities: Helpers.combineModalities(modelData),
+      maxContextWindow: Helpers.normalizeOptionalNumber(modelData.max_context_window),
+      maxOutputTokens: Helpers.normalizeOptionalNumber(modelData.max_output_tokens),
+      catalogIndex,
+    });
+  }
+
+  static collectModelAliases(modelData) {
+    const aliases = [
+      ...Helpers.toUniqueStrings(modelData.id_aliases),
+      ...(modelData.snapshots ?? [])
+        .filter((snapshot) => Helpers.isPlainObject(snapshot) && snapshot.id)
+        .map((snapshot) => String(snapshot.id)),
+    ];
+
+    return Helpers.toUniqueStrings(aliases).sort(Helpers.compareStrings);
+  }
+
+  static normalizeDate(value, fieldName, required, sourcePath, inputRoot) {
+    if (value === null || value === undefined || value === "") {
+      if (required) {
+        throw new CatalogError(
+          `${Helpers.displayPath(sourcePath, inputRoot)}: missing required ${fieldName}`,
+        );
+      }
+
+      return null;
+    }
+
+    const normalizedValue = String(value);
+
+    if (!DATE_PATTERN.test(normalizedValue)) {
+      throw new CatalogError(
+        `${Helpers.displayPath(sourcePath, inputRoot)}: ${fieldName} must be YYYY-MM-DD, got ${JSON.stringify(normalizedValue)}`,
+      );
+    }
+
+    return normalizedValue;
+  }
+
+  static compareModelsAscendingByRelease(left, right) {
+    return (
+      // Ties fall back to provider catalog order so output stays stable across runs.
+      Helpers.compareStrings(left.released_at, right.released_at) ||
+      left.sort.catalog_index - right.sort.catalog_index ||
+      Helpers.compareStrings(left.id, right.id)
+    );
+  }
+
+  static compareModelsDescendingForOutput(left, right) {
+    return (
+      Helpers.compareStrings(right.released_at, left.released_at) ||
+      right.sort.catalog_index - left.sort.catalog_index ||
+      Helpers.compareStrings(left.id, right.id)
+    );
+  }
+}
+
+class ProviderDataFileBuilder {
+  static shouldIncludeModelAlias(alias, resolvesTo) {
+    // Only drop exact self-aliases (including casing-only variants). Punctuation
+    // changes like "claude-opus-4.7" -> "claude-opus-4-7" are meaningful aliases.
+    return alias.toLowerCase() !== resolvesTo.toLowerCase();
+  }
+
+  static buildFileContents(catalogData) {
+    const fileTemplate = fs.readFileSync(PROVIDER_DATA_FILE_PATH, "utf8");
+    const serializedData = Helpers.indentBlock(
+      JSON.stringify(ProviderDataFileBuilder.buildOutputData(catalogData), null, 2),
+      2,
+    );
+
+    return ProviderDataFileBuilder.replaceGeneratedSection(
+      fileTemplate,
+      GENERATED_DATA_START_MARKER,
+      GENERATED_DATA_END_MARKER,
+      serializedData,
+      PROVIDER_DATA_FILE_PATH,
+    );
+  }
+
+  static buildOutputData(catalogData) {
+    const providersById = new Map(
+      catalogData.providers.map((provider) => [provider.id, provider]),
+    );
+    const extraProviders = catalogData.providers.filter(
+      (provider) => !PROVIDER_OUTPUT_ORDER.includes(provider.id),
+    );
+    const orderedProviders = [
+      ...PROVIDER_OUTPUT_ORDER.map((providerId) => providersById.get(providerId)).filter(Boolean),
+      ...extraProviders,
+    ];
+
+    return {
+      schema_version: catalogData.schema_version,
+      generated_from: catalogData.generated_from,
+      providers: orderedProviders.map((provider) => provider.toOutputData()),
+      aliases: ProviderDataFileBuilder.buildAliasesOutput(catalogData, orderedProviders),
+      summary: catalogData.summary,
+    };
+  }
+
+  static buildAliasesOutput(catalogData, orderedProviders) {
+    const modelAliasGroups = new Map();
+    const seenModels = new Set();
+
+    for (const provider of orderedProviders) {
+      for (const model of [...provider.models].sort(
+        CatalogBuilder.compareModelsDescendingForOutput,
+      )) {
+        const modelKey = `${model.author_id}\u0000${model.id}`;
+
+        if (seenModels.has(modelKey) || model.aliases.length === 0) {
+          continue;
+        }
+
+        seenModels.add(modelKey);
+
+        const existingGroup = modelAliasGroups.get(model.author_id);
+        const authorDisplayName = Helpers.asString(
+          catalogData.authorsById.get(model.author_id)?.data?.display_name,
+          model.author_id,
+        );
+        const group = existingGroup ?? {
+          author_id: model.author_id,
+          author_display_name: authorDisplayName,
+          aliases: [],
+        };
+        const resolvesTo = model.id;
+
+        for (const alias of model.aliases) {
+          if (!ProviderDataFileBuilder.shouldIncludeModelAlias(alias, resolvesTo)) {
+            continue;
+          }
+
+          group.aliases.push({
+            alias,
+            resolves_to: resolvesTo,
+          });
+        }
+
+        modelAliasGroups.set(model.author_id, group);
+      }
+    }
+
+    return {
+      provider_aliases: orderedProviders
+        .filter((provider) => provider.aliases.length > 0)
+        .map((provider) => ({
+          provider_id: provider.id,
+          aliases: provider.aliases,
+        })),
+      model_alias_groups: [...modelAliasGroups.values()]
+        .map((group) => ({
+          ...group,
+          aliases: [...new Map(
+            group.aliases.map((entry) => [
+              `${entry.alias}\u0000${entry.resolves_to}`,
+              entry,
+            ]),
+          ).values()],
+        }))
+        .sort((left, right) =>
+          Helpers.compareStrings(left.author_display_name, right.author_display_name) ||
+          Helpers.compareStrings(left.author_id, right.author_id),
+        ),
+    };
+  }
+
+  static replaceGeneratedSection(
+    source,
+    startMarker,
+    endMarker,
+    replacement,
+    sourcePath,
+  ) {
+    const pattern = new RegExp(
+      `(${Helpers.escapeRegExp(startMarker)}\\n)([\\s\\S]*?)(\\n\\s*${Helpers.escapeRegExp(endMarker)})`,
+    );
+
+    if (!pattern.test(source)) {
+      throw new CatalogError(
+        `${path.relative(REPO_ROOT, sourcePath)} is missing generated data markers`,
+      );
+    }
+
+    return source.replace(pattern, `$1${replacement}$3`);
+  }
+}
+
+class SummaryReporter {
+  static print(catalogData) {
+    const providersById = new Map(
+      catalogData.providers.map((provider) => [provider.id, provider]),
+    );
+    const extraProviders = catalogData.providers.filter(
+      (provider) => !PROVIDER_OUTPUT_ORDER.includes(provider.id),
+    );
+    const orderedProviders = [
+      ...PROVIDER_OUTPUT_ORDER.map((providerId) => providersById.get(providerId)).filter(Boolean),
+      ...extraProviders,
+    ];
+
+    console.log(`providers: ${catalogData.summary.provider_count}`);
+    console.log(`models: ${catalogData.summary.model_count}`);
+
+    for (const provider of orderedProviders) {
+      console.log(`- ${provider.id}: ${provider.models.length} models`);
+
+      if (provider.models.length === 0) {
+        continue;
+      }
+
+      for (const model of [...provider.models].reverse()) {
+        console.log(`  - ${model.id} (${model.released_at})`);
+      }
+    }
+  }
+}
+
+function writeProviderDataFile(providerDataFileContents) {
+  fs.mkdirSync(path.dirname(PROVIDER_DATA_FILE_PATH), { recursive: true });
+  fs.writeFileSync(PROVIDER_DATA_FILE_PATH, providerDataFileContents, "utf8");
+}
+
+function main() {
+  try {
+    const inputRoot = Cli.parseArguments(process.argv.slice(2));
+    const sourceCatalog = SourceCatalogLoader.load(inputRoot);
+    const catalogData = CatalogBuilder.build(sourceCatalog);
+    const providerDataFileContents = ProviderDataFileBuilder.buildFileContents(catalogData);
+
+    writeProviderDataFile(providerDataFileContents);
+    SummaryReporter.print(catalogData);
+
+    console.log(`\nwrote ${path.relative(REPO_ROOT, PROVIDER_DATA_FILE_PATH)}`);
+  } catch (error) {
+    process.exitCode = 1;
+    console.error(Helpers.formatError(error));
+  }
+}
+
+main();

--- a/snippets/ai-gateway/AIGatewayModelCatalogProvider.jsx
+++ b/snippets/ai-gateway/AIGatewayModelCatalogProvider.jsx
@@ -1,0 +1,2214 @@
+/*
+ * This file owns the rendering and helper logic for the AI Gateway model catalog UI.
+ *
+ * scripts/build-ai-gateway-model-catalog.js does not regenerate this module. It only
+ * replaces the catalog object between the generated data markers below.
+ */
+
+export const AIGatewayModelCatalogProvider = ({
+  providerId,
+  section,
+  authorId,
+}) => {
+  const aiGatewayModelCatalog =
+    //-- GENERATED PROVIDERS DATA START --//
+  {
+    "schema_version": 1,
+    "generated_from": "data",
+    "providers": [
+      {
+        "id": "openai",
+        "slug": "openai",
+        "display_name": "OpenAI",
+        "base_url": "https://api.openai.com/v1/",
+        "website": "https://openai.com/",
+        "aliases": [
+          "openAI",
+          "open-ai",
+          "open-AI"
+        ],
+        "provider_key_required": false,
+        "description": "OpenAI is an AI research organization that develops advanced artificial intelligence models, including GPT, for natural language understanding, generation, and other AI applications.",
+        "models": [
+          {
+            "id": "gpt-5.5-pro",
+            "display_name": "GPT-5.5 Pro",
+            "author_id": "openai",
+            "released_at": "2026-04-23",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.5-pro-2026-04-23"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1050000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.5",
+            "display_name": "GPT-5.5",
+            "author_id": "openai",
+            "released_at": "2026-04-23",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.5-2026-04-23"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1050000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.4-nano",
+            "display_name": "GPT-5.4 Nano",
+            "author_id": "openai",
+            "released_at": "2026-03-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.4-nano-2026-03-17"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "display_name": "GPT-5.4 Mini",
+            "author_id": "openai",
+            "released_at": "2026-03-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.4-mini-2026-03-17"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.3-codex",
+            "display_name": "GPT-5.3-Codex",
+            "author_id": "openai",
+            "released_at": "2026-03-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5.3-Codex",
+              "gpt-5.3-Codex",
+              "gpt-5.3-codex-2026-03-05",
+              "gpt5.3-codex"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.4-pro",
+            "display_name": "GPT-5.4 Pro",
+            "author_id": "openai",
+            "released_at": "2026-03-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.4-pro-2026-03-05"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1050000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.4",
+            "display_name": "GPT-5.4",
+            "author_id": "openai",
+            "released_at": "2026-03-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.4-2026-03-05"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1050000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.2-codex",
+            "display_name": "GPT-5.2-Codex",
+            "author_id": "openai",
+            "released_at": "2025-12-18",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5.2-Codex",
+              "gpt-5.2-Codex",
+              "gpt5.2-codex"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.2-pro",
+            "display_name": "GPT-5.2 Pro",
+            "author_id": "openai",
+            "released_at": "2025-12-11",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5.2-pro-2025-12-11"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "gpt-5.1",
+            "display_name": "GPT-5.1",
+            "author_id": "openai",
+            "released_at": "2025-11-12",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5.1",
+              "gpt-5.1-2025-11-13"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5-pro",
+            "display_name": "GPT-5 Pro",
+            "author_id": "openai",
+            "released_at": "2025-10-06",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-5-pro-2025-10-06"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 272000
+          },
+          {
+            "id": "gpt-5.2-chat-latest",
+            "display_name": "GPT-5.2 Chat Latest",
+            "author_id": "openai",
+            "released_at": "2025-10-01",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5.2",
+            "display_name": "GPT-5.2",
+            "author_id": "openai",
+            "released_at": "2025-10-01",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5-chat-latest",
+            "display_name": "GPT-5 Chat",
+            "author_id": "openai",
+            "released_at": "2025-08-07",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5 Chat",
+              "GPT-5-chat",
+              "gpt-5-chat-latest-2025-08-07"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5-nano",
+            "display_name": "GPT-5 Nano",
+            "author_id": "openai",
+            "released_at": "2025-08-07",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5 nano",
+              "GPT-5-nano",
+              "gpt-5-nano",
+              "gpt-5-nano-2025-08-07"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5-mini",
+            "display_name": "GPT-5 Mini",
+            "author_id": "openai",
+            "released_at": "2025-08-07",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5 mini",
+              "GPT-5-mini",
+              "gpt-5-mini",
+              "gpt-5-mini-2025-08-07"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "gpt-5",
+            "display_name": "GPT-5",
+            "author_id": "openai",
+            "released_at": "2025-08-07",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-5",
+              "gpt-5",
+              "gpt-5-2025-08-07"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 400000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "o4-mini-deep-research",
+            "display_name": "O4-Mini-Deep-Research",
+            "author_id": "openai",
+            "released_at": "2025-06-26",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o4-mini-deep-research",
+              "o4-mini-deep-research-2025-06-26"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "o3-deep-research",
+            "display_name": "O3-Deep-Research",
+            "author_id": "openai",
+            "released_at": "2025-06-25",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o3-deep-research",
+              "o3-deep-research-2025-06-25"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "o3-pro",
+            "display_name": "O3-Pro",
+            "author_id": "openai",
+            "released_at": "2025-06-10",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o3-pro",
+              "o3-pro-2025-06-10"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "gpt-5.1-chat-latest",
+            "display_name": "GPT-5.1 Chat Latest",
+            "author_id": "openai",
+            "released_at": "2025-06-01",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 256000,
+            "max_output_tokens": 32768
+          },
+          {
+            "id": "o3",
+            "display_name": "O3",
+            "author_id": "openai",
+            "released_at": "2025-04-16",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o3",
+              "o3-2025-04-16"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "o4-mini",
+            "display_name": "O4-Mini",
+            "author_id": "openai",
+            "released_at": "2025-04-16",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o4-mini",
+              "o4-mini-2025-04-16"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "gpt-4.1-nano",
+            "display_name": "GPT-4.1 nano",
+            "author_id": "openai",
+            "released_at": "2025-04-14",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-4.1-nano",
+              "gpt-4.1-nano",
+              "gpt-4.1-nano-2025-04-14"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": null
+          },
+          {
+            "id": "gpt-4.1-mini",
+            "display_name": "GPT-4.1 mini",
+            "author_id": "openai",
+            "released_at": "2025-04-14",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-4.1-mini",
+              "gpt-4.1-mini",
+              "gpt-4.1-mini-2025-04-14"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": null
+          },
+          {
+            "id": "gpt-4.1",
+            "display_name": "GPT-4.1",
+            "author_id": "openai",
+            "released_at": "2025-04-14",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-4.1",
+              "gpt-4.1",
+              "gpt-4.1-2025-04-14"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": null
+          },
+          {
+            "id": "o3-mini",
+            "display_name": "O3 Mini",
+            "author_id": "openai",
+            "released_at": "2025-01-31",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o3-mini-2025-01-31"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "o1",
+            "display_name": "O1",
+            "author_id": "openai",
+            "released_at": "2024-12-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o1-2024-12-17"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "o1-pro",
+            "display_name": "O1-Pro",
+            "author_id": "openai",
+            "released_at": "2024-12-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "o1-pro-2025-03-19"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 100000
+          },
+          {
+            "id": "gpt-4o-mini",
+            "display_name": "GPT-4o Mini",
+            "author_id": "openai",
+            "released_at": "2024-07-18",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-4o-mini-2024-07-18"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 16384
+          },
+          {
+            "id": "gpt-4o",
+            "display_name": "GPT-4o",
+            "author_id": "openai",
+            "released_at": "2024-05-13",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-4o",
+              "chatgpt-4o-latest",
+              "gpt-4-omni",
+              "gpt-4o",
+              "gpt-4o-2024-08-06",
+              "gpt-4o-2024-11-20"
+            ],
+            "modalities": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 16384
+          },
+          {
+            "id": "gpt-4-turbo",
+            "display_name": "GPT-4 Turbo",
+            "author_id": "openai",
+            "released_at": "2024-04-09",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-4-0125-preview",
+              "gpt-4-1106-preview",
+              "gpt-4-turbo-2024-04-09",
+              "gpt-4-turbo-preview"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 128000,
+            "max_output_tokens": 4096
+          },
+          {
+            "id": "gpt-3.5-turbo-instruct",
+            "display_name": "GPT-3.5 Turbo Instruct",
+            "author_id": "openai",
+            "released_at": "2023-09-19",
+            "deprecated_at": "2025-09-26",
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 4096,
+            "max_output_tokens": 4096
+          },
+          {
+            "id": "gpt-4",
+            "display_name": "GPT-4",
+            "author_id": "openai",
+            "released_at": "2023-03-14",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gpt-4-0314",
+              "gpt-4-0613"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 8192,
+            "max_output_tokens": 8192
+          },
+          {
+            "id": "gpt-3.5-turbo",
+            "display_name": "GPT-3.5 Turbo",
+            "author_id": "openai",
+            "released_at": "2022-11-30",
+            "deprecated_at": "2025-09-26",
+            "retired_at": null,
+            "aliases": [
+              "gpt-3.5-turbo-0125",
+              "gpt-3.5-turbo-16k"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 16385,
+            "max_output_tokens": 4096
+          }
+        ]
+      },
+      {
+        "id": "anthropic",
+        "slug": "anthropic",
+        "display_name": "Anthropic",
+        "base_url": "https://api.anthropic.com/v1/",
+        "website": "https://anthropic.com/",
+        "aliases": [
+          "Anthropic"
+        ],
+        "provider_key_required": false,
+        "description": "Anthropic is an AI safety startup focused on developing safe, beneficial AI systems. Known for the Claude family of large language models.",
+        "models": [
+          {
+            "id": "claude-sonnet-5",
+            "display_name": "Claude Sonnet 5",
+            "author_id": "anthropic",
+            "released_at": "2026-06-30",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-sonnet-5-20260630",
+              "claude-sonnet.5"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "claude-fable-5",
+            "display_name": "Claude Fable 5",
+            "author_id": "anthropic",
+            "released_at": "2026-06-09",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-fable-5-20260609",
+              "claude-fable.5"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "claude-opus-4-8",
+            "display_name": "Claude Opus 4.8",
+            "author_id": "anthropic",
+            "released_at": "2026-05-28",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-opus-4-8-20260528",
+              "claude-opus-4.8"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "claude-opus-4-7",
+            "display_name": "Claude Opus 4.7",
+            "author_id": "anthropic",
+            "released_at": "2026-04-16",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-opus-4-7-20260416",
+              "claude-opus-4.7"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "claude-sonnet-4-6",
+            "display_name": "Claude Sonnet 4.6",
+            "author_id": "anthropic",
+            "released_at": "2026-02-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-sonnet-4-6-20260217",
+              "claude-sonnet-4.6"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 64000
+          },
+          {
+            "id": "claude-opus-4-6",
+            "display_name": "Claude Opus 4.6",
+            "author_id": "anthropic",
+            "released_at": "2026-02-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-opus-4-6-20260205",
+              "claude-opus-4.6"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 128000
+          },
+          {
+            "id": "claude-opus-4-5",
+            "display_name": "Claude Opus 4.5",
+            "author_id": "anthropic",
+            "released_at": "2025-11-24",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-opus-4-5-20251101",
+              "claude-opus-4.5"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "display_name": "Claude Haiku 4.5",
+            "author_id": "anthropic",
+            "released_at": "2025-10-01",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-haiku-4-5-20251001",
+              "claude-haiku-4.5"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 64000
+          },
+          {
+            "id": "claude-sonnet-4-5",
+            "display_name": "Claude Sonnet 4.5",
+            "author_id": "anthropic",
+            "released_at": "2025-09-29",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-sonnet-4-5-20250929",
+              "claude-sonnet-4.5"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 64000
+          },
+          {
+            "id": "claude-opus-4-1",
+            "display_name": "Claude Opus 4.1",
+            "author_id": "anthropic",
+            "released_at": "2025-08-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "claude-opus-4-1-20250805",
+              "claude-opus-4.1"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 200000,
+            "max_output_tokens": 32000
+          }
+        ]
+      },
+      {
+        "id": "google",
+        "slug": "google",
+        "display_name": "Google",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "website": "https://aistudio.google.com/",
+        "aliases": [
+          "Google",
+          "gemini"
+        ],
+        "provider_key_required": true,
+        "description": "Google's AI services including Gemini models for natural language understanding, generation, and multimodal AI applications.",
+        "models": [
+          {
+            "id": "gemini-3.5-flash",
+            "display_name": "Gemini 3.5 Flash",
+            "author_id": "google",
+            "released_at": "2026-05-19",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gemini-3.1-flash-lite",
+            "display_name": "Gemini 3.1 Flash-Lite",
+            "author_id": "google",
+            "released_at": "2026-05-07",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gemini-3.1-pro-preview",
+            "display_name": "Gemini 3.1 Pro Preview",
+            "author_id": "google",
+            "released_at": "2026-02-19",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gemini-3.1-pro"
+            ],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gemini-2.5-flash-lite",
+            "display_name": "Gemini 2.5 Flash-Lite",
+            "author_id": "google",
+            "released_at": "2025-06-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gemini-2.5-flash",
+            "display_name": "Gemini 2.5 Flash",
+            "author_id": "google",
+            "released_at": "2025-06-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gemini-2.5-pro",
+            "display_name": "Gemini 2.5 Pro",
+            "author_id": "google",
+            "released_at": "2025-06-17",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "gemini-2.5-pro"
+            ],
+            "modalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "file"
+            ],
+            "max_context_window": 1048576,
+            "max_output_tokens": 65536
+          }
+        ]
+      },
+      {
+        "id": "deepseek",
+        "slug": "deepseek",
+        "display_name": "DeepSeek",
+        "base_url": "https://api.deepseek.com/v1",
+        "website": "https://www.deepseek.com/",
+        "aliases": [
+          "DeepSeek",
+          "deep-seek"
+        ],
+        "provider_key_required": true,
+        "description": "DeepSeek is an AI company focused on advancing artificial general intelligence through cutting-edge research and development of large language models.",
+        "models": [
+          {
+            "id": "deepseek-v4-flash",
+            "display_name": "deepseek-v4-flash",
+            "author_id": "deepseek",
+            "released_at": "2026-04-24",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 384000
+          },
+          {
+            "id": "deepseek-v4-pro",
+            "display_name": "deepseek-v4-pro",
+            "author_id": "deepseek",
+            "released_at": "2026-04-24",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 1000000,
+            "max_output_tokens": 384000
+          }
+        ]
+      },
+      {
+        "id": "groq",
+        "slug": "groq",
+        "display_name": "Groq",
+        "base_url": "https://api.groq.com/openai/v1",
+        "website": "https://groq.com/",
+        "aliases": [
+          "Groq",
+          "GroqCloud"
+        ],
+        "provider_key_required": true,
+        "description": "Groq provides ultra-fast AI inference powered by their custom LPU (Language Processing Unit) hardware, offering the fastest token generation speeds for large language models.",
+        "models": [
+          {
+            "id": "gpt-oss-safeguard-20b",
+            "display_name": "Safety GPT OSS 20B",
+            "author_id": "openai",
+            "released_at": "2025-08-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gpt-oss-20b",
+            "display_name": "GPT OSS 20B",
+            "author_id": "openai",
+            "released_at": "2025-08-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-OSS-20B",
+              "gpt-oss-20b"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 65536
+          },
+          {
+            "id": "gpt-oss-120b",
+            "display_name": "GPT OSS 120B",
+            "author_id": "openai",
+            "released_at": "2025-08-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "GPT-OSS-120B",
+              "gpt-oss-120b"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 131072
+          },
+          {
+            "id": "qwen3-32b",
+            "display_name": "Qwen3-32B",
+            "author_id": "qwen",
+            "released_at": "2025-04-29",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 40960
+          },
+          {
+            "id": "llama-prompt-guard-2-86m",
+            "display_name": "Llama Prompt Guard 2 86M",
+            "author_id": "meta-llama",
+            "released_at": "2025-04-29",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 512,
+            "max_output_tokens": 512
+          },
+          {
+            "id": "llama-prompt-guard-2-22m",
+            "display_name": "Llama Prompt Guard 2 22M",
+            "author_id": "meta-llama",
+            "released_at": "2025-04-29",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 512,
+            "max_output_tokens": 512
+          },
+          {
+            "id": "llama-4-scout-17b-16e-instruct",
+            "display_name": "Llama 4 Scout 17B 16E Instruct",
+            "author_id": "meta-llama",
+            "released_at": "2025-04-05",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "llama-4-scout-17b-16e"
+            ],
+            "modalities": [
+              "text",
+              "image"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 8192
+          },
+          {
+            "id": "llama-3.3-70b-versatile",
+            "display_name": "Llama 3.3 70B Versatile",
+            "author_id": "meta-llama",
+            "released_at": "2024-12-06",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "llama-3.3-70b"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 32768
+          },
+          {
+            "id": "llama-3.1-8b-instant",
+            "display_name": "Llama 3.1 8B Instant",
+            "author_id": "meta-llama",
+            "released_at": "2024-07-23",
+            "deprecated_at": null,
+            "retired_at": null,
+            "aliases": [
+              "llama-3.1-8b"
+            ],
+            "modalities": [
+              "text"
+            ],
+            "max_context_window": 131072,
+            "max_output_tokens": 131072
+          }
+        ]
+      },
+      {
+        "id": "openrouter",
+        "slug": "openrouter",
+        "display_name": "OpenRouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "website": "https://openrouter.ai/",
+        "aliases": [
+          "OpenRouter",
+          "open-router"
+        ],
+        "provider_key_required": true,
+        "description": "OpenRouter is an AI model router that provides access to multiple AI providers and models through a unified API interface with competitive pricing.",
+        "models": []
+      },
+      {
+        "id": "hyperbolic",
+        "slug": "hyperbolic",
+        "display_name": "Hyperbolic",
+        "base_url": "https://api.hyperbolic.xyz/v1",
+        "website": "https://hyperbolic.xyz/",
+        "aliases": [
+          "Hyperbolic"
+        ],
+        "provider_key_required": true,
+        "description": "Hyperbolic provides high-performance AI inference services with fast response times and competitive pricing for various language models.",
+        "models": []
+      },
+      {
+        "id": "inceptionlabs",
+        "slug": "inceptionlabs",
+        "display_name": "InceptionLabs",
+        "base_url": "https://api.inceptionlabs.ai/v1",
+        "website": "https://inceptionlabs.ai/",
+        "aliases": [
+          "InceptionLabs",
+          "inception-labs",
+          "inception"
+        ],
+        "provider_key_required": true,
+        "description": "InceptionLabs provides AI infrastructure and model serving capabilities for various language models with focus on performance and reliability.",
+        "models": []
+      },
+      {
+        "id": "inference.net",
+        "slug": "inference-net",
+        "display_name": "Inference.net",
+        "base_url": "https://api.inference.net/v1",
+        "website": "https://inference.net/",
+        "aliases": [
+          "inference-net",
+          "inference_net",
+          "InferenceNet"
+        ],
+        "provider_key_required": true,
+        "description": "Inference.net provides AI model inference services with competitive pricing and performance for various language models.",
+        "models": []
+      }
+    ],
+    "aliases": {
+      "provider_aliases": [
+        {
+          "provider_id": "openai",
+          "aliases": [
+            "openAI",
+            "open-ai",
+            "open-AI"
+          ]
+        },
+        {
+          "provider_id": "anthropic",
+          "aliases": [
+            "Anthropic"
+          ]
+        },
+        {
+          "provider_id": "google",
+          "aliases": [
+            "Google",
+            "gemini"
+          ]
+        },
+        {
+          "provider_id": "deepseek",
+          "aliases": [
+            "DeepSeek",
+            "deep-seek"
+          ]
+        },
+        {
+          "provider_id": "groq",
+          "aliases": [
+            "Groq",
+            "GroqCloud"
+          ]
+        },
+        {
+          "provider_id": "openrouter",
+          "aliases": [
+            "OpenRouter",
+            "open-router"
+          ]
+        },
+        {
+          "provider_id": "hyperbolic",
+          "aliases": [
+            "Hyperbolic"
+          ]
+        },
+        {
+          "provider_id": "inceptionlabs",
+          "aliases": [
+            "InceptionLabs",
+            "inception-labs",
+            "inception"
+          ]
+        },
+        {
+          "provider_id": "inference.net",
+          "aliases": [
+            "inference-net",
+            "inference_net",
+            "InferenceNet"
+          ]
+        }
+      ],
+      "model_alias_groups": [
+        {
+          "author_id": "anthropic",
+          "author_display_name": "Anthropic",
+          "aliases": [
+            {
+              "alias": "claude-sonnet-5-20260630",
+              "resolves_to": "claude-sonnet-5"
+            },
+            {
+              "alias": "claude-sonnet.5",
+              "resolves_to": "claude-sonnet-5"
+            },
+            {
+              "alias": "claude-fable-5-20260609",
+              "resolves_to": "claude-fable-5"
+            },
+            {
+              "alias": "claude-fable.5",
+              "resolves_to": "claude-fable-5"
+            },
+            {
+              "alias": "claude-opus-4-8-20260528",
+              "resolves_to": "claude-opus-4-8"
+            },
+            {
+              "alias": "claude-opus-4.8",
+              "resolves_to": "claude-opus-4-8"
+            },
+            {
+              "alias": "claude-opus-4-7-20260416",
+              "resolves_to": "claude-opus-4-7"
+            },
+            {
+              "alias": "claude-opus-4.7",
+              "resolves_to": "claude-opus-4-7"
+            },
+            {
+              "alias": "claude-sonnet-4-6-20260217",
+              "resolves_to": "claude-sonnet-4-6"
+            },
+            {
+              "alias": "claude-sonnet-4.6",
+              "resolves_to": "claude-sonnet-4-6"
+            },
+            {
+              "alias": "claude-opus-4-6-20260205",
+              "resolves_to": "claude-opus-4-6"
+            },
+            {
+              "alias": "claude-opus-4.6",
+              "resolves_to": "claude-opus-4-6"
+            },
+            {
+              "alias": "claude-opus-4-5-20251101",
+              "resolves_to": "claude-opus-4-5"
+            },
+            {
+              "alias": "claude-opus-4.5",
+              "resolves_to": "claude-opus-4-5"
+            },
+            {
+              "alias": "claude-haiku-4-5-20251001",
+              "resolves_to": "claude-haiku-4-5"
+            },
+            {
+              "alias": "claude-haiku-4.5",
+              "resolves_to": "claude-haiku-4-5"
+            },
+            {
+              "alias": "claude-sonnet-4-5-20250929",
+              "resolves_to": "claude-sonnet-4-5"
+            },
+            {
+              "alias": "claude-sonnet-4.5",
+              "resolves_to": "claude-sonnet-4-5"
+            },
+            {
+              "alias": "claude-opus-4-1-20250805",
+              "resolves_to": "claude-opus-4-1"
+            },
+            {
+              "alias": "claude-opus-4.1",
+              "resolves_to": "claude-opus-4-1"
+            }
+          ]
+        },
+        {
+          "author_id": "google",
+          "author_display_name": "Google",
+          "aliases": [
+            {
+              "alias": "gemini-3.1-pro",
+              "resolves_to": "gemini-3.1-pro-preview"
+            }
+          ]
+        },
+        {
+          "author_id": "meta-llama",
+          "author_display_name": "Meta",
+          "aliases": [
+            {
+              "alias": "llama-4-scout-17b-16e",
+              "resolves_to": "llama-4-scout-17b-16e-instruct"
+            },
+            {
+              "alias": "llama-3.3-70b",
+              "resolves_to": "llama-3.3-70b-versatile"
+            },
+            {
+              "alias": "llama-3.1-8b",
+              "resolves_to": "llama-3.1-8b-instant"
+            }
+          ]
+        },
+        {
+          "author_id": "openai",
+          "author_display_name": "OpenAI",
+          "aliases": [
+            {
+              "alias": "gpt-5.5-pro-2026-04-23",
+              "resolves_to": "gpt-5.5-pro"
+            },
+            {
+              "alias": "gpt-5.5-2026-04-23",
+              "resolves_to": "gpt-5.5"
+            },
+            {
+              "alias": "gpt-5.4-nano-2026-03-17",
+              "resolves_to": "gpt-5.4-nano"
+            },
+            {
+              "alias": "gpt-5.4-mini-2026-03-17",
+              "resolves_to": "gpt-5.4-mini"
+            },
+            {
+              "alias": "gpt-5.3-codex-2026-03-05",
+              "resolves_to": "gpt-5.3-codex"
+            },
+            {
+              "alias": "gpt5.3-codex",
+              "resolves_to": "gpt-5.3-codex"
+            },
+            {
+              "alias": "gpt-5.4-pro-2026-03-05",
+              "resolves_to": "gpt-5.4-pro"
+            },
+            {
+              "alias": "gpt-5.4-2026-03-05",
+              "resolves_to": "gpt-5.4"
+            },
+            {
+              "alias": "gpt5.2-codex",
+              "resolves_to": "gpt-5.2-codex"
+            },
+            {
+              "alias": "gpt-5.2-pro-2025-12-11",
+              "resolves_to": "gpt-5.2-pro"
+            },
+            {
+              "alias": "gpt-5.1-2025-11-13",
+              "resolves_to": "gpt-5.1"
+            },
+            {
+              "alias": "gpt-5-pro-2025-10-06",
+              "resolves_to": "gpt-5-pro"
+            },
+            {
+              "alias": "GPT-5 Chat",
+              "resolves_to": "gpt-5-chat-latest"
+            },
+            {
+              "alias": "GPT-5-chat",
+              "resolves_to": "gpt-5-chat-latest"
+            },
+            {
+              "alias": "gpt-5-chat-latest-2025-08-07",
+              "resolves_to": "gpt-5-chat-latest"
+            },
+            {
+              "alias": "GPT-5 nano",
+              "resolves_to": "gpt-5-nano"
+            },
+            {
+              "alias": "gpt-5-nano-2025-08-07",
+              "resolves_to": "gpt-5-nano"
+            },
+            {
+              "alias": "GPT-5 mini",
+              "resolves_to": "gpt-5-mini"
+            },
+            {
+              "alias": "gpt-5-mini-2025-08-07",
+              "resolves_to": "gpt-5-mini"
+            },
+            {
+              "alias": "gpt-5-2025-08-07",
+              "resolves_to": "gpt-5"
+            },
+            {
+              "alias": "o4-mini-deep-research-2025-06-26",
+              "resolves_to": "o4-mini-deep-research"
+            },
+            {
+              "alias": "o3-deep-research-2025-06-25",
+              "resolves_to": "o3-deep-research"
+            },
+            {
+              "alias": "o3-pro-2025-06-10",
+              "resolves_to": "o3-pro"
+            },
+            {
+              "alias": "o3-2025-04-16",
+              "resolves_to": "o3"
+            },
+            {
+              "alias": "o4-mini-2025-04-16",
+              "resolves_to": "o4-mini"
+            },
+            {
+              "alias": "gpt-4.1-nano-2025-04-14",
+              "resolves_to": "gpt-4.1-nano"
+            },
+            {
+              "alias": "gpt-4.1-mini-2025-04-14",
+              "resolves_to": "gpt-4.1-mini"
+            },
+            {
+              "alias": "gpt-4.1-2025-04-14",
+              "resolves_to": "gpt-4.1"
+            },
+            {
+              "alias": "o3-mini-2025-01-31",
+              "resolves_to": "o3-mini"
+            },
+            {
+              "alias": "o1-2024-12-17",
+              "resolves_to": "o1"
+            },
+            {
+              "alias": "o1-pro-2025-03-19",
+              "resolves_to": "o1-pro"
+            },
+            {
+              "alias": "gpt-4o-mini-2024-07-18",
+              "resolves_to": "gpt-4o-mini"
+            },
+            {
+              "alias": "chatgpt-4o-latest",
+              "resolves_to": "gpt-4o"
+            },
+            {
+              "alias": "gpt-4-omni",
+              "resolves_to": "gpt-4o"
+            },
+            {
+              "alias": "gpt-4o-2024-08-06",
+              "resolves_to": "gpt-4o"
+            },
+            {
+              "alias": "gpt-4o-2024-11-20",
+              "resolves_to": "gpt-4o"
+            },
+            {
+              "alias": "gpt-4-0125-preview",
+              "resolves_to": "gpt-4-turbo"
+            },
+            {
+              "alias": "gpt-4-1106-preview",
+              "resolves_to": "gpt-4-turbo"
+            },
+            {
+              "alias": "gpt-4-turbo-2024-04-09",
+              "resolves_to": "gpt-4-turbo"
+            },
+            {
+              "alias": "gpt-4-turbo-preview",
+              "resolves_to": "gpt-4-turbo"
+            },
+            {
+              "alias": "gpt-4-0314",
+              "resolves_to": "gpt-4"
+            },
+            {
+              "alias": "gpt-4-0613",
+              "resolves_to": "gpt-4"
+            },
+            {
+              "alias": "gpt-3.5-turbo-0125",
+              "resolves_to": "gpt-3.5-turbo"
+            },
+            {
+              "alias": "gpt-3.5-turbo-16k",
+              "resolves_to": "gpt-3.5-turbo"
+            }
+          ]
+        }
+      ]
+    },
+    "summary": {
+      "provider_count": 9,
+      "model_count": 62
+    }
+  }
+  //-- GENERATED PROVIDERS DATA END --//;
+
+  /*
+   * Presentation-only copy overrides
+   */
+  const PROVIDER_COPY_OVERRIDES = Object.freeze({
+    openai: "", // Previously manually updated page had no description
+    anthropic: "", // Previously manually updated page had no description
+    google: "", // Previously manually updated page had no description
+    deepseek: "", // Previously manually updated page had no description
+  });
+
+  /*
+   * Some model notes in the old hard-coded doc were hand-written rather than derivable
+   * from the source catalog. Keep those doc-specific annotations here so we can preserve
+   * reader-facing wording without teaching the build step about presentation concerns.
+   */
+  const MODEL_COPY_OVERRIDES = Object.freeze({
+    "openai/gpt-3.5-turbo": {
+      notes: ["deprecated", "retires September 28, 2026"],
+    },
+  });
+
+  /*
+   * These rows restore legacy models that were shown in the old hard-coded page but are
+   * no longer present in the current generated catalog. They are intentionally manual and
+   * component-local so docs can keep backward-looking context without mutating source data.
+   */
+  const EXTRA_MODELS_BY_PROVIDER = Object.freeze({
+    anthropic: [
+      {
+        author_id: "anthropic",
+        id: "claude-sonnet-4-0",
+        display_name: "Claude Sonnet 4",
+        max_context_window: 1000000,
+        max_output_tokens: 64000,
+        modalities: ["text", "image"],
+      },
+      {
+        author_id: "anthropic",
+        id: "claude-opus-4-0",
+        display_name: "Claude Opus 4",
+        max_context_window: 200000,
+        max_output_tokens: 32000,
+        modalities: ["text", "image"],
+      },
+      {
+        author_id: "anthropic",
+        id: "claude-3-haiku-20240307",
+        display_name: "Claude Haiku 3",
+        max_context_window: 200000,
+        max_output_tokens: 4096,
+        modalities: ["text", "image"],
+        notes: ["deprecated", "retires April 20, 2026"],
+      },
+    ],
+    google: [
+      {
+        author_id: "google",
+        id: "gemini-2.0-flash",
+        display_name: "Gemini 2.0 Flash",
+        max_context_window: 1048576,
+        max_output_tokens: 8192,
+        modalities: ["text", "image", "audio", "video", "file"],
+      },
+      {
+        author_id: "google",
+        id: "gemini-2.0-flash-lite",
+        display_name: "Gemini 2.0 Flash-Lite",
+        max_context_window: 1048576,
+        max_output_tokens: 8192,
+        modalities: ["text", "image", "audio", "video", "file"],
+      },
+      {
+        author_id: "google",
+        id: "gemini-3-pro-preview",
+        display_name: "Gemini 3 Pro Preview",
+        max_context_window: 1000000,
+        max_output_tokens: 65536,
+        modalities: ["text", "image", "audio", "video", "file"],
+      },
+    ],
+    deepseek: [
+      {
+        author_id: "deepseek",
+        id: "deepseek-reasoner",
+        display_name: "deepseek-reasoner",
+        max_context_window: 128000,
+        max_output_tokens: 64000,
+        modalities: ["text"],
+      },
+      {
+        author_id: "deepseek",
+        id: "deepseek-chat",
+        display_name: "deepseek-chat",
+        max_context_window: 128000,
+        max_output_tokens: 8192,
+        modalities: ["text"],
+      },
+    ],
+    groq: [
+      {
+        author_id: "meta-llama",
+        id: "llama-guard-4-12b",
+        display_name: "Llama Guard 4 12B",
+        max_context_window: 131072,
+        max_output_tokens: 1024,
+        modalities: ["text", "image"],
+      },
+      {
+        author_id: "meta-llama",
+        id: "llama-4-maverick-17b-128e-instruct",
+        display_name: "Llama 4 Maverick 17B 128E Instruct",
+        max_context_window: 131072,
+        max_output_tokens: 8192,
+        modalities: ["text", "image"],
+      },
+      {
+        author_id: "moonshotai",
+        id: "moonshotai/kimi-k2-instruct-0905",
+        display_name: "Kimi K2",
+        max_context_window: 262144,
+        max_output_tokens: 16384,
+        modalities: ["text"],
+      },
+    ],
+  });
+
+  /*
+   * These alias rows preserve legacy docs entries not present in the current catalog data.
+   */
+  const EXTRA_MODEL_ALIASES_BY_PROVIDER = Object.freeze({
+    anthropic: [
+      {
+        alias: "claude-sonnet-4-20250514",
+        resolves_to: "claude-sonnet-4-0",
+      },
+      {
+        alias: "claude-sonnet-4",
+        resolves_to: "claude-sonnet-4-0",
+      },
+      {
+        alias: "claude-opus-4-20250514",
+        resolves_to: "claude-opus-4-0",
+      },
+      {
+        alias: "claude-opus-4",
+        resolves_to: "claude-opus-4-0",
+      },
+      {
+        alias: "claude-haiku-3",
+        resolves_to: "claude-3-haiku-20240307",
+      },
+    ],
+    google: [
+      {
+        alias: "gemini-3",
+        resolves_to: "gemini-3-pro-preview",
+      },
+      {
+        alias: "gemini-3-pro",
+        resolves_to: "gemini-3-pro-preview",
+      },
+    ],
+    "meta-llama": [
+      {
+        alias: "llama-4-maverick-17b-128e",
+        resolves_to: "llama-4-maverick-17b-128e-instruct",
+      },
+    ],
+    moonshotai: [
+      {
+        alias: "kimi-k2-instruct",
+        resolves_to: "kimi-k2",
+      },
+      {
+        alias: "kimi-k2-instruct-0905",
+        resolves_to: "kimi-k2",
+      },
+      {
+        alias: "moonshotai/kimi-k2-instruct-0905",
+        resolves_to: "kimi-k2",
+      },
+    ],
+  });
+
+  const EXTRA_MODEL_ALIAS_DISPLAY_NAMES = Object.freeze({
+    moonshotai: "Moonshot AI",
+  });
+
+  const PROVIDER_MODEL_DISPLAY_FORMAT = Object.freeze({
+    default: "provider:author/model",
+    openai: "author/model",
+    anthropic: "author/model",
+    google: "author/model",
+    deepseek: "author/model",
+  });
+
+  function formatWebsiteLabel(website) {
+    return String(website)
+      .replace(/^https?:\/\//, "")
+      .replace(/^www\./, "")
+      .replace(/\/$/, "");
+  }
+
+  function formatLongDate(value) {
+    const [year, month, day] = String(value).split("-").map(Number);
+    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString(
+      "en-US",
+      {
+        day: "numeric",
+        month: "long",
+        timeZone: "UTC",
+        year: "numeric",
+      },
+    );
+  }
+
+  function formatNumber(value) {
+    if (value === null || value === undefined || value === "") {
+      return "-";
+    }
+
+    return typeof value === "number"
+      ? value.toLocaleString("en-US")
+      : String(value);
+  }
+
+  function formatCanonicalModelId(authorId, modelId) {
+    return modelId.startsWith(`${authorId}/`)
+      ? modelId
+      : `${authorId}/${modelId}`;
+  }
+
+  function getProviderModelDisplayFormat(providerId) {
+    return (
+      PROVIDER_MODEL_DISPLAY_FORMAT[providerId] ??
+      PROVIDER_MODEL_DISPLAY_FORMAT.default
+    );
+  }
+
+  function formatDisplayedModelId(providerId, authorId, modelId) {
+    const canonicalModelId = formatCanonicalModelId(authorId, modelId);
+    const displayFormat = getProviderModelDisplayFormat(providerId);
+
+    if (displayFormat === "provider:author/model") {
+      return `${providerId}:${canonicalModelId}`;
+    }
+
+    if (displayFormat === "author/model") {
+      return canonicalModelId;
+    }
+
+    if (displayFormat === "model") {
+      return modelId;
+    }
+
+    throw new Error(
+      `Unknown provider model display format for ${providerId}: ${displayFormat}`,
+    );
+  }
+
+  function parseQualifiedModelId(value) {
+    const separatorIndex = value.indexOf(":");
+
+    if (separatorIndex === -1) {
+      return null;
+    }
+
+    const providerId = value.slice(0, separatorIndex);
+    const canonicalModelId = value.slice(separatorIndex + 1);
+    const slashIndex = canonicalModelId.indexOf("/");
+
+    if (slashIndex === -1) {
+      return {
+        providerId,
+        authorId: canonicalModelId,
+        modelId: canonicalModelId,
+      };
+    }
+
+    return {
+      providerId,
+      authorId: canonicalModelId.slice(0, slashIndex),
+      modelId: canonicalModelId,
+    };
+  }
+
+  function formatDisplayedAliasTarget(value) {
+    const parsed = parseQualifiedModelId(value);
+
+    if (!parsed) {
+      return value;
+    }
+
+    return parsed.modelId;
+  }
+
+  function normalizeAliasEntry(entry) {
+    const resolvesTo = formatDisplayedAliasTarget(entry.resolves_to);
+
+    if (entry.alias.toLowerCase() === resolvesTo.toLowerCase()) {
+      return null;
+    }
+
+    return {
+      ...entry,
+      resolves_to: resolvesTo,
+    };
+  }
+
+  function buildPresentationModel(provider, model) {
+    const override = MODEL_COPY_OVERRIDES[`${provider.id}/${model.id}`];
+    const notes = [];
+
+    if (model.deprecated_at) {
+      notes.push("deprecated");
+    }
+
+    if (model.retired_at) {
+      notes.push(`retires ${formatLongDate(model.retired_at)}`);
+    }
+
+    const presentationNotes = override?.notes ?? model.notes ?? notes;
+
+    return {
+      ...model,
+      displayedId: formatDisplayedModelId(
+        provider.id,
+        model.author_id,
+        model.id,
+      ),
+      contextWindow: formatNumber(model.max_context_window),
+      outputTokens: formatNumber(model.max_output_tokens),
+      notes: presentationNotes,
+    };
+  }
+
+  function getExtraModels(provider) {
+    const generatedModelIds = new Set(provider.models.map((model) => model.id));
+
+    return (EXTRA_MODELS_BY_PROVIDER[provider.id] ?? [])
+      .filter((model) => !generatedModelIds.has(model.id))
+      .map((model) => buildPresentationModel(provider, model));
+  }
+
+  // Keep the component API tiny by turning a provider id into a render-ready view model.
+  function getProvider(id) {
+    const provider = aiGatewayModelCatalog.providers.find(
+      (entry) => entry.id === id,
+    );
+
+    if (!provider) {
+      throw new Error(`Unknown AI Gateway model catalog provider: ${id}`);
+    }
+
+    return {
+      ...provider,
+      guideHref: `/ai-gateway/providers/${provider.slug}`,
+      websiteLabel: provider.website
+        ? formatWebsiteLabel(provider.website)
+        : null,
+      copy: {
+        description:
+          PROVIDER_COPY_OVERRIDES[provider.id] ?? provider.description ?? "",
+      },
+      models: [
+        ...provider.models.map((model) =>
+          buildPresentationModel(provider, model),
+        ),
+        ...getExtraModels(provider),
+      ],
+    };
+  }
+
+  function getAliasesData() {
+    const generatedGroups =
+      aiGatewayModelCatalog.aliases?.model_alias_groups ?? [];
+    const groupsByAuthorId = new Map(
+      generatedGroups.map((group) => [
+        group.author_id,
+        {
+          ...group,
+          aliases: group.aliases
+            .map(normalizeAliasEntry)
+            .filter(Boolean),
+        },
+      ]),
+    );
+
+    for (const [authorId, aliases] of Object.entries(
+      EXTRA_MODEL_ALIASES_BY_PROVIDER,
+    )) {
+      const group = groupsByAuthorId.get(authorId) ?? {
+        author_id: authorId,
+        author_display_name:
+          EXTRA_MODEL_ALIAS_DISPLAY_NAMES[authorId] ?? authorId,
+        aliases: [],
+      };
+
+      group.aliases.push(...aliases);
+      group.aliases = [
+        ...new Map(
+          group.aliases
+            .map(normalizeAliasEntry)
+            .filter(Boolean)
+            .map((entry) => [`${entry.alias}\u0000${entry.resolves_to}`, entry]),
+        ).values(),
+      ];
+
+      groupsByAuthorId.set(authorId, group);
+    }
+
+    return {
+      providerAliases: aiGatewayModelCatalog.aliases?.provider_aliases ?? [],
+      modelAliasGroups: [...groupsByAuthorId.values()].sort(
+        (left, right) =>
+          left.author_display_name.localeCompare(right.author_display_name) ||
+          left.author_id.localeCompare(right.author_id),
+      ),
+    };
+  }
+
+  if (section === "provider-aliases") {
+    const aliases = getAliasesData();
+
+    return (
+      <>
+        {aliases.providerAliases.length > 0 ? (
+          <>
+            <h3>Provider aliases</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Provider ID</th>
+                  <th>Aliases</th>
+                </tr>
+              </thead>
+              <tbody>
+                {aliases.providerAliases.map((provider) => (
+                  <tr key={provider.provider_id}>
+                    <td>
+                      <code>{provider.provider_id}</code>
+                    </td>
+                    <td>
+                      {provider.aliases.map((alias, index) => (
+                        <span key={alias}>
+                          {index > 0 ? ", " : null}
+                          <code>{alias}</code>
+                        </span>
+                      ))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        ) : null}
+      </>
+    );
+  }
+
+  if (section === "model-aliases") {
+    const aliases = getAliasesData();
+    const group = aliases.modelAliasGroups.find(
+      (entry) => entry.author_id === authorId,
+    );
+
+    if (!group) {
+      throw new Error(`Unknown AI Gateway model alias group: ${authorId}`);
+    }
+
+    return (
+      <>
+        <h3>{group.author_display_name} model aliases</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Alias</th>
+              <th>Resolves to</th>
+            </tr>
+          </thead>
+          <tbody>
+            {group.aliases.map((entry) => (
+              <tr key={`${entry.alias}:${entry.resolves_to}`}>
+                <td>
+                  <code>{entry.alias}</code>
+                </td>
+                <td>
+                  <code>{formatDisplayedAliasTarget(entry.resolves_to)}</code>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+  }
+
+  const provider = getProvider(providerId);
+
+  return (
+    <>
+      <h3 id={provider.slug}>{provider.display_name}</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong>Provider ID</strong>
+            </td>
+            <td>
+              <code>
+                {provider.id === "inference.net" ? provider.slug : provider.id}
+              </code>
+            </td>
+          </tr>
+          {provider.aliases.length > 0 ? (
+            <tr>
+              <td>
+                <strong>Aliases</strong>
+              </td>
+              <td>
+                {provider.aliases.map((alias, index) => (
+                  <span key={alias}>
+                    {index > 0 ? ", " : null}
+                    <code>{alias}</code>
+                  </span>
+                ))}
+              </td>
+            </tr>
+          ) : null}
+          {provider.base_url ? (
+            <tr>
+              <td>
+                <strong>Base URL</strong>
+              </td>
+              <td>
+                <code>{provider.base_url}</code>
+              </td>
+            </tr>
+          ) : null}
+          {provider.website ? (
+            <tr>
+              <td>
+                <strong>Website</strong>
+              </td>
+              <td>
+                <a href={provider.website}>{provider.websiteLabel}</a>
+              </td>
+            </tr>
+          ) : null}
+          <tr>
+            <td>
+              <strong>Provider key required</strong>
+            </td>
+            <td>{provider.provider_key_required ? "Yes" : "No"}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        <a href={provider.guideHref}>How to use {provider.display_name} →</a>
+      </p>
+      {provider.copy.description ? <p>{provider.copy.description}</p> : null}
+      {provider.models.length > 0 ? (
+        <>
+          <h4>{provider.display_name} models</h4>
+          {/* Keep lower-signal columns nearby for easy restoration if we decide
+              the table can afford more width than long canonical IDs allow today. */}
+          <table>
+            <thead>
+              <tr>
+                <th>Model ID</th>
+                {/* <th>Display Name</th> */}
+                <th>Context Window</th>
+                <th>Output Tokens</th>
+                {/* <th>Modalities</th> */}
+              </tr>
+            </thead>
+            <tbody>
+              {provider.models.map((model) => (
+                <tr key={model.id}>
+                  <td>
+                    <code>{model.displayedId}</code>
+                  </td>
+                  {/* <td>
+                    {model.display_name}
+                    {model.notes.length > 0 ? (
+                      <>
+                        {" "}
+                        <em>({model.notes.join(", ")})</em>
+                      </>
+                    ) : null}
+                  </td> */}
+                  <td>{model.contextWindow}</td>
+                  <td>{model.outputTokens}</td>
+                  {/* <td>{model.modalities}</td> */}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : null}
+    </>
+  );
+};
+
+export const AIGatewayModelCatalogProviderAliases = () => (
+  <AIGatewayModelCatalogProvider section="provider-aliases" />
+);
+
+export const AIGatewayModelCatalogModelAliases = ({ authorId }) => (
+  <AIGatewayModelCatalogProvider section="model-aliases" authorId={authorId} />
+);


### PR DESCRIPTION
This change replaces the hard-coded provider model tables in `model-catalog.mdx` with a custom component backed by model catalog data.

A new build script reads the AI Gateway provider and author catalog source files and regenerates only the embedded data section in `AIGatewayModelCatalogProvider.jsx`. The component’s rendering logic and manual doc-specific overrides are manually maintained.

The rendered catalog is intended to stay visually close to the previous docs page, but it now tracks the source catalog more closely. Provider descriptions may differ where the source data changed, though doc-specific copy overrides can still be applied in `AIGatewayModelCatalogProvider.jsx`.

To make room for fuller model ID values without wrapping, the provider model tables now comment out the `Display Name` and `Modalities` columns. This keeps the `Model ID` column readable while preserving those columns nearby in the component for easy restoration if we want them back later.

Some legacy models and aliases are still maintained manually because they do not exist in the source catalog. These are defined in `EXTRA_MODELS_BY_PROVIDER` and `EXTRA_MODEL_ALIASES_BY_PROVIDER`. Before merging, reviewers should validate the manual fallback entries in `EXTRA_MODELS_BY_PROVIDER` and `EXTRA_MODEL_ALIASES_BY_PROVIDER` to confirm they are still valid and worth including.

The regeneration workflow is intended for internal maintainers and is run by passing the build script the directory containing the AI Gateway author and provider source files.

## Why the data Is embedded in the component

When you first look at A`IGatewayModelCatalogProvider.jsx`, you’ll probably wonder why a large data blob is embedded directly inside a custom component.

Originally, the build script wrote that data to a separate component. Unfortunately, that does not work reliably in this Mint/MDX render path.

When aiGatewayModelCatalog, getProvider, or similar helpers are defined outside AIGatewayModelCatalogProvider, the page may compile successfully but then fail at runtime with errors like ReferenceError: aiGatewayModelCatalog is not defined or ReferenceError: getProvider is not defined.

Because of that, the generated catalog data is intentionally embedded inside AIGatewayModelCatalogProvider, and the small render helpers live there as well. It is not the cleanest solution, but it works.
