### PR TITLE
fix(docs): update traffic inspector dashboard link

### DIFF
--- a/obs/traffic-inspection.mdx
+++ b/obs/traffic-inspection.mdx
@@ -14,7 +14,7 @@ ngrok offers multiple ways to inspect the traffic going to your service.
 |                                                                         |                                                                                                                                                                                            |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [ngrok Agent Local Traffic Inspector](/agent/web-inspection-interface/) | This is available when working with the standalone agent and is usually found at http://localhost:4040. Look for a link in your ngrok agent console.                                       |
-| [ngrok Traffic Inspector](#ngrok-traffic-inspector)                     | A cloud based version of the local Traffic Inspector that is available in your [ngrok Dashboard](https://dashboard.ngrok.com/observability/traffic-inspector). See below for more details. |
+| [ngrok Traffic Inspector](#ngrok-traffic-inspector)                     | A cloud based version of the local Traffic Inspector that is available in your [ngrok Dashboard](https://dashboard.ngrok.com/traffic-inspector). See below for more details. |
 
 ## ngrok Traffic Inspector
 


### PR DESCRIPTION
**The Bug:** On the Traffic Inspection documentation page, the "ngrok Dashboard" link was incorrectly pointing to _https://dashboard.ngrok.com/observability/traffic-inspector_, resulting in a broken or misdirected navigation for users trying to access the Traffic Inspector feature.

**The Root Cause:** The URL was hardcoded with an outdated or incorrect route (/observability/traffic-inspector) inside the Markdown table on the obs/traffic-inspection.mdx file.

**The Fix:** Updated the hardcoded URL in obs/traffic-inspection.mdx to the correct current route: https://dashboard.ngrok.com/traffic-inspector.

**Verification:**

- Ran the built-in mintlify broken link checker (pnpm run test-links); no new errors were introduced.

- Spun up the local development server (pnpm run dev) and manually verified the UI.

- Followed the link locally, successfully authenticated via the dashboard, and observed a proper redirect to the correct Traffic Inspector page.