### PR TITLE
Remove temporary free-tier warning for region pinning

### DIFF
--- a/snippets/guides/region-pinning-content.mdx
+++ b/snippets/guides/region-pinning-content.mdx
@@ -204,16 +204,8 @@ The `resolves_to` parameter uses the following PoP names:
 
 ## Limits and pricing
 
-<Warning>
-This feature is temporarily free to use on the Pay-as-you-Go plan. 
-
-Billing & metering will be enabled soon, so if you use this feature, you may start seeing charges at any time. You can monitor your usage [in the ngrok dashboard](https://dashboard.ngrok.com/billing). 
-
-We'll update these docs when this changes. 
-</Warning>
-
 This feature is only available on the Pay-as-you-Go plan. [Learn more about ngrok plans](https://ngrok.com/pricing).
 
 You can have up to 100 region-pinned domains. This is the same as our total domain limit, so most customers should be fine. Feel free to reach out via support if you need more. [Learn more about limits](https://ngrok.com/docs/pricing-limits)
 
-Region pinning will cost **$0.02 per active endpoint hour** (in addition to the standard endpoint rate), per endpoint on a "pinned" domain. An endpoint is considered active if it receives any traffic in a given hour. If your endpoints with pinning enabled don't receive any traffic, you won't incur charges for this feature. [Learn more about pricing](https://ngrok.com/pricing).
+Region pinning costs **$0.02 per active endpoint hour** (in addition to the standard endpoint rate), per endpoint on a "pinned" domain. An endpoint is considered active if it receives any traffic in a given hour. If your endpoints with pinning enabled don't receive any traffic, you won't incur charges for this feature. [Learn more about pricing](https://ngrok.com/pricing).


### PR DESCRIPTION
Resolves [CDATA-878](https://linear.app/ngrok/issue/CDATA-878/update-docs-to-reflect-features-billing-and-cost)

### Why
Region pinning is now billed, so the docs' placeholder warning stating the feature was "temporarily free" and that "billing & metering will be enabled soon" is stale and contradicts the pricing details already on the same page.

### How
Removed the `<Warning>` callout from the "Limits and pricing" section and tightened the existing pricing sentence from "Region pinning will cost..." to "Region pinning costs..." now that billing is live.

### Validation
Confirmed this warning text was the only occurrence in the repo (`gh search code`), so no other doc pages reference the stale free-tier language.