### PR TITLE
Add mcp options to the context menu

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -12,17 +12,18 @@
     "options": [
      "copy",
      "view",
+     "mcp",
+     "add-mcp",
+     "claude",
+     "cursor",
+      "vscode",
      "assistant",
      "chatgpt",
-     "claude",
      "perplexity",
      "grok",
      "aistudio",
      "devin",
      "windsurf",
-      "mcp",
-      "cursor",
-      "vscode",
       "devin-mcp",
       "download-spec"
     ]


### PR DESCRIPTION
Adds mcp options to the "Copy page" menu at the top of each page