### PR TITLE
Fix broken and stale dashboard.ngrok.com links

### DIFF
--- a/agent/config/v2.mdx
+++ b/agent/config/v2.mdx
@@ -29,7 +29,7 @@ To activate a specific option or tunnel, simply uncomment the relevant lines by 
 #      https://dashboard.ngrok.com/get-started/your-authtoken
 #
 #  (2) You can view and generate authtokens through the dashboard
-#      https://dashboard.ngrok.com/tunnels/authtokens
+#      https://dashboard.ngrok.com/authtokens
 
 #authtoken: 4nq9771bPxe8ctg7LKr_2ClH7Y15Zqe4bWLWF9p
 
@@ -484,7 +484,7 @@ You can configure a single ngrok agent to tunnel to multiple services within a s
 | `circuit_breaker`                                                                      | Float                                                                        | Reject requests when 5XX responses exceed this ratio                                                                                                                                                                                                                                              |
 | `compression`                                                                          | `true`, `false`                                                              | gzip compress HTTP responses from your web service                                                                                                                                                                                                                                                |
 | `host_header`                                                                          | `rewrite`, `preserve`, custom                                                | Rewrite the HTTP Host header to this value, or `preserve` to leave it unchanged. The `rewrite` option will rewrite the host header to match the hostname of the upstream service you are sending traffic to.                                                                                      |
-| `domain`                                                                               | Any valid domain or hostname that you have previously registered with ngrok. | The domain to request. If using a custom domain, this requires registering in the [ngrok dashboard](https://dashboard.ngrok.com/cloud-edge/domains) and setting a DNS CNAME value. When creating wildcard endpoints, you will need to surround the value with single quotes (domain: '\*.example.com'). |
+| `domain`                                                                               | Any valid domain or hostname that you have previously registered with ngrok. | The domain to request. If using a custom domain, this requires registering in the [ngrok dashboard](https://dashboard.ngrok.com/domains) and setting a DNS CNAME value. When creating wildcard endpoints, you will need to surround the value with single quotes (domain: '\*.example.com'). |
 | `inspect`                                                                              | `true`, `false`                                                              | enable/disable the http request inspection in the web and agent API (default: true)                                                                                                                                                                                                               |
 | `ip_restriction.allow_cidrs`                                                           | Array of CIDRs                                                               | Rejects connections that do not match the given CIDRs                                                                                                                                                                                                                                             |
 | `ip_restriction.deny_cidrs`                                                            | Array of CIDRs                                                               | Rejects connections that match the given CIDRs and allows all other CIDRs.                                                                                                                                                                                                                        |
@@ -539,7 +539,7 @@ You can configure a single ngrok agent to tunnel to multiple services within a s
 | [`policy.outbound.actions.config`](/traffic-policy/actions/)                   | custom                         | `policy` has been renamed to `traffic_policy` in agent version 3.14.0.                                                                                                                                                        |
 | `proto`                                                                        | `tcp`                          | The tunnel protocol name. This defines the type of tunnel you would like to start.                                                                                                                                            |
 | `proxy_proto`                                                                  | String                         | The version of [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) to use with this tunnel, empty if not using. Example values are 1 or 2.                                                         |
-| `remote_addr`                                                                  | A valid TCP address from ngrok | bind the remote TCP address and port. These addresses can be reserved in the [ngrok dashboard](https://dashboard.ngrok.com/cloud-edge/tcp-addresses) to use across sessions. For example: `remote_addr: 2.tcp.ngrok.io:21746` |
+| `remote_addr`                                                                  | A valid TCP address from ngrok | bind the remote TCP address and port. These addresses can be reserved in the [ngrok dashboard](https://dashboard.ngrok.com/tcp-addresses) to use across sessions. For example: `remote_addr: 2.tcp.ngrok.io:21746` |
 | [`traffic_policy.inbound.name`](/traffic-policy/)                              | String                         | The name of an inbound rule that is part of a Traffic Policy                                                                                                                                                                  |
 | [`traffic_policy.inbound.expressions`](/traffic-policy/how-it-works#expressions)  | Array of Strings               | Expressions written using [CEL](https://github.com/google/cel-spec) that filter traffic the inbound policy rule applies to                                                                                                    |
 | [`traffic_policy.inbound.actions.type`](/traffic-policy/actions/)              | String                         | The type of action that should be executed when this inbound policy rule is activated                                                                                                                                         |
@@ -654,7 +654,7 @@ The following is a list of options that can be configured at the root of your co
 
 ### `api_key`
 
-This option specifies the API key used to access the ngrok API through the [`ngrok api`](/agent/cli-api) command. This is only needed when using the [ngrok API](/api) and not the local ngrok agent API (available at `localhost:4040/api`). You can generate an API Key in the [ngrok Dashboard](https://dashboard.ngrok.com/api) and install it using the `ngrok config add-api-key` command.
+This option specifies the API key used to access the ngrok API through the [`ngrok api`](/agent/cli-api) command. This is only needed when using the [ngrok API](/api) and not the local ngrok agent API (available at `localhost:4040/api`). You can generate an API Key in the [ngrok Dashboard](https://dashboard.ngrok.com/api-keys) and install it using the `ngrok config add-api-key` command.
 
 ##### ngrok.yml specifying an API key
 
@@ -785,7 +785,7 @@ _Deprecated_ This is the region where the ngrok agent will connect to. You can o
 
 ### `remote_management`
 
-Set this to `true` to allow the ngrok agent to be remotely managed (stop, restart, update) via the [ngrok API](/api-reference/tunnelsessions/restart) or the [ngrok Dashboard](https://dashboard.ngrok.com/tunnels/agents). Defaults to `true`.
+Set this to `true` to allow the ngrok agent to be remotely managed (stop, restart, update) via the [ngrok API](/api-reference/tunnelsessions/restart) or the [ngrok Dashboard](https://dashboard.ngrok.com/agents). Defaults to `true`.
 
 ### `root_cas`
 

--- a/agent/config/v3.mdx
+++ b/agent/config/v3.mdx
@@ -121,7 +121,7 @@ The authentication token used to authenticate this agent when it connects to the
 
 ##### Deploying on multiple devices
 
-Your default authtoken will work on multiple machines or devices. However, if you want more control and security across many devices, you can generate a unique authtoken for each device in the [ngrok Dashboard](https://dashboard.ngrok.com/tunnels/authtokens) or via the `ngrok api credentials` command.
+Your default authtoken will work on multiple machines or devices. However, if you want more control and security across many devices, you can generate a unique authtoken for each device in the [ngrok Dashboard](https://dashboard.ngrok.com/authtokens) or via the `ngrok api credentials` command.
 
 ##### Example
 
@@ -260,7 +260,7 @@ This is the URL of an HTTP or SOCKS5 proxy to use for establishing the tunnel co
 
 #### `remote_management`
 
-Set this to `true` to allow the ngrok agent to be remotely managed (stop, restart, update) via the [ngrok API](/api-reference/tunnelsessions/restart) or the [ngrok Dashboard](https://dashboard.ngrok.com/tunnels/agents). Defaults to `true`.
+Set this to `true` to allow the ngrok agent to be remotely managed (stop, restart, update) via the [ngrok API](/api-reference/tunnelsessions/restart) or the [ngrok Dashboard](https://dashboard.ngrok.com/agents). Defaults to `true`.
 
 #### `update_channel`
 

--- a/agent/ssh-reverse-tunnel-agent.mdx
+++ b/agent/ssh-reverse-tunnel-agent.mdx
@@ -75,7 +75,7 @@ ssh -R 443:localhost:80 v2@connect.eu.ngrok-agent.com http
 Instead of an ngrok authtoken, when you use ngrok via the SSH reverse tunnel
 agent, it uses a public key for authentication. You'll first need to upload
 yours to the [SSH Public Keys page on your ngrok
-dashboard](https://dashboard.ngrok.com/tunnels/ssh-keys).
+dashboard](https://dashboard.ngrok.com/ssh-keys).
 
 Copy your default SSH public key with:
 

--- a/api/index.mdx
+++ b/api/index.mdx
@@ -35,7 +35,7 @@ Terraform Provider.
 
 ## Quickstart 
 
-Start by [generating a new API key](https://dashboard.ngrok.com/api) in the ngrok Dashboard.
+Start by [generating a new API key](https://dashboard.ngrok.com/api-keys) in the ngrok Dashboard.
 
 ##### Access the API with curl
 
@@ -68,7 +68,7 @@ ngrok api endpoints list
 Requests to the API must include an API key as a bearer token in the
 `Authorization` header.
 
-- **[API Keys on the ngrok dashboard](https://dashboard.ngrok.com/api)**: Provision your first API key from your ngrok dashboard.
+- **[API Keys on the ngrok dashboard](https://dashboard.ngrok.com/api-keys)**: Provision your first API key from your ngrok dashboard.
 - **[API keys API Resource](/api-reference/apikeys/list)**: Once you have an API key, you may provision additional API keys programmatically.
 
 ## Content types 
@@ -129,7 +129,7 @@ well.
 IP Restrictions can be configured manually on the ngrok dashboard or
 programmatically via API with a `type` of `api`.
 
-- **[IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/security/ip-restrictions)**
+- **[IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/ip-restrictions)**
 - **[IP Restrictions API Resource](/api-reference/iprestrictions/list/)**
 
 ## Errors

--- a/gateway/cloud-endpoints/forwarding-and-load-balancing.mdx
+++ b/gateway/cloud-endpoints/forwarding-and-load-balancing.mdx
@@ -18,11 +18,11 @@ To follow this guide, you will need a local computer with `ngrok` installed. [Yo
 
 If you are going to be following along using the **ngrok CLI**, you will need:
 
-- An [ngrok API key](https://dashboard.ngrok.com/api) configured on your [ngrok agent](/agent/#api-keys).
+- An [ngrok API key](https://dashboard.ngrok.com/api-keys) configured on your [ngrok agent](/agent/#api-keys).
 
 If you are going to be following along using **CURL**, you will need:
 
-- An [ngrok API key](https://dashboard.ngrok.com/api) as an environment variable named `NGROK_API_KEY`.
+- An [ngrok API key](https://dashboard.ngrok.com/api-keys) as an environment variable named `NGROK_API_KEY`.
 
 ## 1. Create an internal endpoint
 

--- a/gateway/cloud-endpoints/routing-and-policy-decentralization.mdx
+++ b/gateway/cloud-endpoints/routing-and-policy-decentralization.mdx
@@ -18,11 +18,11 @@ To follow this guide, you will need a local computer with `ngrok` installed [by 
 
 If you are going to be following along using **ngrok CLI**, you will need:
 
-- An [ngrok API key](https://dashboard.ngrok.com/api) configured on your [ngrok agent](/agent/#api).
+- An [ngrok API key](https://dashboard.ngrok.com/api-keys) configured on your [ngrok agent](/agent/#api).
 
 If you are going to be following along using **CURL**, you will need:
 
-- An [ngrok API key](https://dashboard.ngrok.com/api) as an environment variable named `NGROK_API_KEY`.
+- An [ngrok API key](https://dashboard.ngrok.com/api-keys) as an environment variable named `NGROK_API_KEY`.
 
 ## 1. Create an internal endpoint for the homepage
 

--- a/gateway/dedicated-ips.mdx
+++ b/gateway/dedicated-ips.mdx
@@ -9,7 +9,7 @@ This feature is in Early Access and under active development.
 Behavior, supported fields, and limits may change before General Availability (GA). 
 This guide provides forward-looking context for evaluation and feedback.
 
-[Visit your dashboard](https://dashboard.ngrok.com/developer-preview) to sign up for Early Access, or to send your feedback via the "Let us know" link.
+[Visit your dashboard](https://dashboard.ngrok.com/early-access) to sign up for Early Access, or to send your feedback via the "Let us know" link.
 </Warning>
 
 Dedicated IPs let you configure static IP addresses that are exclusively assigned to your account for receiving traffic to your [domains](/gateway/domains/) and [agent connections](/agent/connect-url/). 
@@ -151,7 +151,7 @@ See the [Pricing page](https://ngrok.com/pricing) for details.
 
 ### How do I get dedicated IPs?
 
-Dedicated IPs are in Early Access. [Sign up for access](https://dashboard.ngrok.com/developer-preview) through your ngrok dashboard.
+Dedicated IPs are in Early Access. [Sign up for access](https://dashboard.ngrok.com/early-access) through your ngrok dashboard.
 
 ### Can I use dedicated IPs with TCP endpoints?
 

--- a/gateway/domains.mdx
+++ b/gateway/domains.mdx
@@ -128,8 +128,8 @@ point of presence.
 
 <Info title="Coming Soon">
 
-Per-region global load balancer configuration is coming soon, [request access
-to the developer preview](https://dashboard.ngrok.com/early-access).
+Per-region global load balancer configuration is coming soon, [request Early
+Access](https://dashboard.ngrok.com/early-access).
 
 </Info>
 
@@ -156,7 +156,7 @@ See the [Dedicated IPs](/gateway/dedicated-ips/) documentation for detailed info
 <Info title="Coming Soon">
 
 Dedicated, static IPs for your domains are in Early Access.
-[Request access to the developer preview](https://dashboard.ngrok.com/early-access).
+[Request Early Access](https://dashboard.ngrok.com/early-access).
 
 </Info>
 

--- a/gateway/domains.mdx
+++ b/gateway/domains.mdx
@@ -129,7 +129,7 @@ point of presence.
 <Info title="Coming Soon">
 
 Per-region global load balancer configuration is coming soon, [request access
-to the developer preview](https://dashboard.ngrok.com/developer-preview).
+to the developer preview](https://dashboard.ngrok.com/early-access).
 
 </Info>
 
@@ -156,7 +156,7 @@ See the [Dedicated IPs](/gateway/dedicated-ips/) documentation for detailed info
 <Info title="Coming Soon">
 
 Dedicated, static IPs for your domains are in Early Access.
-[Request access to the developer preview](https://dashboard.ngrok.com/developer-preview).
+[Request access to the developer preview](https://dashboard.ngrok.com/early-access).
 
 </Info>
 

--- a/gateway/edges.mdx
+++ b/gateway/edges.mdx
@@ -6,7 +6,7 @@ description: "Reference documentation for deprecated Edges feature. Edges have b
 ---
 
 <Warning>
-Edges, Routes, Modules, Backends, and Labeled Tunnels have been deprecated since December 31st, 2025. The dashboard [Endpoints page](https://dashboard.ngrok.com/endpoints) no longer shows edge endpoints. If you still have edges configured, you can manage them from the [Edges page](https://dashboard.ngrok.com/edges).
+Edges, Routes, Modules, Backends, and Labeled Tunnels have been deprecated since December 31st, 2025. The dashboard [Endpoints page](https://dashboard.ngrok.com/endpoints) no longer shows edge endpoints. If you still have edges configured, you can manage them via the [Edges API](/api-reference/edgeshttps/list).
 </Warning>
 
 ## Migration guide

--- a/gateway/edges.mdx
+++ b/gateway/edges.mdx
@@ -6,7 +6,7 @@ description: "Reference documentation for deprecated Edges feature. Edges have b
 ---
 
 <Warning>
-Edges, Routes, Modules, Backends, and Labeled Tunnels have been deprecated since December 31st, 2025. The dashboard [Endpoints page](https://dashboard.ngrok.com/endpoints) no longer shows edge endpoints. If you still have edges configured, you can manage them via the [Edges API](/api-reference/edgeshttps/list).
+Edges, Routes, Modules, Backends, and Labeled Tunnels have been deprecated since December 31st, 2025. The dashboard [Endpoints page](https://dashboard.ngrok.com/endpoints) no longer shows edge endpoints. If you still have edges configured, you can manage them via the Edges API ([HTTPS](/api-reference/edgeshttps/list), [TCP](/api-reference/edgestcp/list), [TLS](/api-reference/edgestls/list)).
 </Warning>
 
 ## Migration guide

--- a/gateway/endpoint-pooling.mdx
+++ b/gateway/endpoint-pooling.mdx
@@ -220,7 +220,7 @@ the `forward-internal` Traffic Policy action configuration.
 <Info title="Coming Soon">
 
 Custom load balancing strategies are not yet generally available, but you can
-request early access to the developer preview in your [ngrok
+request Early Access in your [ngrok
 dashboard](https://dashboard.ngrok.com/early-access).
 
 </Info>

--- a/gateway/endpoint-pooling.mdx
+++ b/gateway/endpoint-pooling.mdx
@@ -221,7 +221,7 @@ the `forward-internal` Traffic Policy action configuration.
 
 Custom load balancing strategies are not yet generally available, but you can
 request early access to the developer preview in your [ngrok
-dashboard](https://dashboard.ngrok.com/developer-preview).
+dashboard](https://dashboard.ngrok.com/early-access).
 
 </Info>
 

--- a/gateway/ip-addresses.mdx
+++ b/gateway/ip-addresses.mdx
@@ -20,7 +20,7 @@ These can be configured for [Domains](/gateway/dedicated-ips/) and [Agent Connec
 <Info title="Coming Soon">
 
 Dedicated, static IPs for public endpoints are in Early Access.
-[Request access to the developer preview](https://dashboard.ngrok.com/developer-preview).
+[Request access to the developer preview](https://dashboard.ngrok.com/early-access).
 
 </Info>
 

--- a/gateway/ip-addresses.mdx
+++ b/gateway/ip-addresses.mdx
@@ -20,7 +20,7 @@ These can be configured for [Domains](/gateway/dedicated-ips/) and [Agent Connec
 <Info title="Coming Soon">
 
 Dedicated, static IPs for public endpoints are in Early Access.
-[Request access to the developer preview](https://dashboard.ngrok.com/early-access).
+[Request Early Access](https://dashboard.ngrok.com/early-access).
 
 </Info>
 

--- a/gateway/load-balancing-multiple-clouds.mdx
+++ b/gateway/load-balancing-multiple-clouds.mdx
@@ -234,7 +234,7 @@ Now when you make a request to your URL, your traffic is first routed through th
 
 Custom load balancing strategies are not yet generally available, but you can
 request early access to the developer preview in your [ngrok
-dashboard](https://dashboard.ngrok.com/developer-preview).
+dashboard](https://dashboard.ngrok.com/early-access).
 
 With custom load balancing strategies, you'll be able to decide exactly what happens to load-balanced traffic in certain scenarios, like:
 

--- a/gateway/load-balancing-multiple-clouds.mdx
+++ b/gateway/load-balancing-multiple-clouds.mdx
@@ -233,7 +233,7 @@ Now when you make a request to your URL, your traffic is first routed through th
 <Info title="Coming soon!">
 
 Custom load balancing strategies are not yet generally available, but you can
-request early access to the developer preview in your [ngrok
+request Early Access in your [ngrok
 dashboard](https://dashboard.ngrok.com/early-access).
 
 With custom load balancing strategies, you'll be able to decide exactly what happens to load-balanced traffic in certain scenarios, like:

--- a/guides/api-gateway/get-started.mdx
+++ b/guides/api-gateway/get-started.mdx
@@ -435,7 +435,7 @@ That said, your journey into deploying and securing services
 with ngrok's API gateway is just beginning. Next up:
 
 1. Check out your [Traffic
-   Inspector](https://dashboard.ngrok.com/observability/traffic-inspector)
+   Inspector](https://dashboard.ngrok.com/traffic-inspector)
    ([documentation](/obs/traffic-inspection#ngrok-traffic-inspector)) to
    observe, modify, and replay requests across your API gateway.
 2. Explore other opportunities to manage and take action on API traffic in the

--- a/guides/api-gateway/multicloud.mdx
+++ b/guides/api-gateway/multicloud.mdx
@@ -26,7 +26,7 @@ You need a way to expose these APIs to the public internet without the complexit
 - An ngrok account. If you don't have one, [sign up](https://dashboard.ngrok.com/signup).
 - Two K8s clusters running on separate VMs (ideally each within a distinct cloud provider).
     - Not running kubernetes? Try [installing the ngrok agent](/getting-started) in your cloud infrastructure directly
-- [An ngrok API Key](https://dashboard.ngrok.com/api/new). You'll need an account first.
+- [An ngrok API Key](https://dashboard.ngrok.com/api-keys/new). You'll need an account first.
 
 ## 1. Install the ngrok operator within each K8s cluster
 

--- a/guides/device-gateway/agent.mdx
+++ b/guides/device-gateway/agent.mdx
@@ -12,7 +12,7 @@ This guide will walk you through an example scenario using ngrok to set up a sec
 
 - An ngrok account. If you don't have one, [sign up](https://dashboard.ngrok.com/signup).
 - An ngrok agent configured on your local machine. See the [getting started guide](/getting-started/) for instructions on how to install the ngrok agent.
-- [An ngrok API Key](https://dashboard.ngrok.com/api/new). You'll need an account first.
+- [An ngrok API Key](https://dashboard.ngrok.com/api-keys/new). You'll need an account first.
 
 ## Example scenario
 

--- a/guides/device-gateway/linux.mdx
+++ b/guides/device-gateway/linux.mdx
@@ -84,7 +84,7 @@ ngrok tcp 22 --cidr-allow ALLOWED_IP_ADDRESS_CIDR
 **Note**: Replace `ALLOWED_IP_ADDRESS_CIDR` with the CIDR notation for the allowed IP Address(es) (that is, `123.123.123.0/24`).
 
 <Tip title="Setting IP restrictions for the entire fleet">
-Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/security/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
+Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
 </Tip>
 
 ## 4. Run ngrok as a service so you don't need to manually restart
@@ -160,10 +160,10 @@ Each action that happens in ngrok is published as a log, and [Log Exporting](/ob
 
 A Log Export is made up of a set of log sources (some of which can be filtered), and log destinations. Each export can send logs to one or more destinations, such as Amazon CloudWatch Logs, Amazon Kinesis (as a data stream), or Amazon Kinesis Firehose (as a delivery stream).
 
-Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/observability/event-subscriptions) or the [ngrok API](/api-reference/eventdestinations).
+Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/log-exporting) or the [ngrok API](/api-reference/eventdestinations).
 
 You can also forward all or some of your traffic logs from [ngrok to your preferred logging tool](/obs/).
 
 ### Remote checks, stop, start, and updates
 
-ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/tunnels/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.
+ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.

--- a/guides/device-gateway/raspberry-pi.mdx
+++ b/guides/device-gateway/raspberry-pi.mdx
@@ -84,7 +84,7 @@ ngrok tcp 22 --cidr-allow ALLOWED_IP_ADDRESS_CIDR
 **Note**: Replace `ALLOWED_IP_ADDRESS_CIDR` with the CIDR notation for the allowed IP Address(es) (that is, `123.123.123.0/24`).
 
 <Tip title="Setting IP restrictions for the entire fleet">
-Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/security/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
+Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
 </Tip>
 
 ## 4. Configure ngrok to recover on outages
@@ -154,10 +154,10 @@ Each action that happens in ngrok is published as a log, and [Log Exporting](/ob
 
 A Log Export is made up of a set of log sources (some of which can be filtered), and log destinations. Each export can send logs to one or more destinations, such as Amazon CloudWatch Logs, Amazon Kinesis (as a data stream), or Amazon Kinesis Firehose (as a delivery stream).
 
-Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/observability/event-subscriptions) or the [ngrok API](/api-reference/eventdestinations).
+Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/log-exporting) or the [ngrok API](/api-reference/eventdestinations).
 
 You can also forward all or some of your traffic logs from [ngrok to your preferred logging tool](/obs/).
 
 ### Remote checks, stop, start, and updates
 
-ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/tunnels/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.
+ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.

--- a/guides/device-gateway/raspbian.mdx
+++ b/guides/device-gateway/raspbian.mdx
@@ -84,7 +84,7 @@ ngrok tcp 22 --cidr-allow ALLOWED_IP_ADDRESS_CIDR
 **Note**: Replace `ALLOWED_IP_ADDRESS_CIDR` with the CIDR notation for the allowed IP Address(es) (that is, `123.123.123.0/24`).
 
 <Tip title="Setting IP restrictions for the entire fleet">
-Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/security/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
+Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
 </Tip>
 
 ## 4. Configure ngrok to recover on outages
@@ -154,10 +154,10 @@ Each action that happens in ngrok is published as a log, and [Log Exporting](/ob
 
 A Log Export is made up of a set of log sources (some of which can be filtered), and log destinations. Each export can send logs to one or more destinations, such as Amazon CloudWatch Logs, Amazon Kinesis (as a data stream), or Amazon Kinesis Firehose (as a delivery stream).
 
-Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/observability/event-subscriptions) or the [ngrok API](/api-reference/eventdestinations).
+Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/log-exporting) or the [ngrok API](/api-reference/eventdestinations).
 
 You can also forward all or some of your traffic logs from [ngrok to your preferred logging tool](/obs/).
 
 ### Remote checks, stop, start, and updates
 
-ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/tunnels/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.
+ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.

--- a/guides/device-gateway/sdk.mdx
+++ b/guides/device-gateway/sdk.mdx
@@ -19,7 +19,7 @@ gateway you wish to connect to:
 
 ## Get an ngrok API key
 
-[Create an ngrok API key](https://dashboard.ngrok.com/api/new) using the ngrok dashboard.
+[Create an ngrok API key](https://dashboard.ngrok.com/api-keys/new) using the ngrok dashboard.
 Make sure you save the API key before you leave the screen because it won't be displayed again.
 
 ## Reserve a domain for wildcard endpoints
@@ -139,7 +139,7 @@ You should receive a `201` response similar to the following:
 
 You should start each agent using a separate authtoken, and that token should belong to a Service User.
 
-To create an authtoken, login to the ngrok dashboard and click [**Authtokens**](https://dashboard.ngrok.com/tunnels/authtokens)
+To create an authtoken, login to the ngrok dashboard and click [**Authtokens**](https://dashboard.ngrok.com/authtokens)
 under _Tunnels_, then click **Add a Tunnel Authtoken**.
 For **Owner**, select the Service User you use created, and select `bind:*.sitea.{YOUR_DOMAIN}` for the ACL Rules.
 This ACL will allow an agent with the authtoken to create tunnels on any subdomain of `sitea.{YOUR_DOMAIN}`.

--- a/guides/device-gateway/windows.mdx
+++ b/guides/device-gateway/windows.mdx
@@ -83,7 +83,7 @@ ngrok tcp 3389 --cidr-allow ALLOWED_IP_ADDRESS_CIDR
 **Note**: Replace `ALLOWED_IP_ADDRESS_CIDR` with the CIDR notation for the allowed IP Address(es) (that is, `123.123.123.0/24`).
 
 <Tip title="Setting IP restrictions for the entire fleet">
-Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/security/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
+Alternatively, you can create an IP policy in the ngrok dashboard (under [Security > IP Restrictions](https://dashboard.ngrok.com/ip-restrictions)), and leverage the same policy to control access to your entire device fleet.
 </Tip>
 
 ## 4. Configure ngrok to recover on outages
@@ -157,10 +157,10 @@ Each action that happens in ngrok is published as a log, and [Log Exporting](/ob
 
 A Log Export is made up of a set of log sources (some of which can be filtered), and log destinations. Each export can send logs to one or more destinations, such as Amazon CloudWatch Logs, Amazon Kinesis (as a data stream), or Amazon Kinesis Firehose (as a delivery stream).
 
-Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/observability/event-subscriptions) or the [ngrok API](/api-reference/eventdestinations).
+Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/log-exporting) or the [ngrok API](/api-reference/eventdestinations).
 
 You can also forward all or some of your traffic logs from [ngrok to your preferred logging tool](/obs/).
 
 ### Remote checks, stop, start, and updates
 
-ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/tunnels/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.
+ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.

--- a/guides/ssh-rdp/index.mdx
+++ b/guides/ssh-rdp/index.mdx
@@ -27,7 +27,7 @@ This setup minimizes security risks, simplifies deployment, and ensures continuo
 
 - An ngrok account. If you don't have one, [sign up](https://dashboard.ngrok.com/signup).
 - An ngrok agent, configured on your edge gateway or remote device/service. See the [getting started guide](/getting-started/) for instructions on how to install the ngrok agent.
-- [An ngrok API Key](https://dashboard.ngrok.com/api/new). You'll need an account first.
+- [An ngrok API Key](https://dashboard.ngrok.com/api-keys/new). You'll need an account first.
 
 ### 1. Create a Service User and authtoken to enable isolated Agent management
 

--- a/iam/service-users.mdx
+++ b/iam/service-users.mdx
@@ -13,7 +13,7 @@ Other platforms sometimes call this concept a _service account_.
 </Info>
 
 You can see and manage your Service Users in the [ngrok
-Dashboard](https://dashboard.ngrok.com/users/bots).
+Dashboard](https://dashboard.ngrok.com/service-users).
 
 ## When to use a Service User 
 

--- a/iam/users.mdx
+++ b/iam/users.mdx
@@ -122,7 +122,7 @@ access to IPs that you can't use.
 IP Restrictions can be configured manually on the ngrok dashboard or
 programmatically via API with a `type` of `dashboard`.
 
-- **[IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/security/ip-restrictions)**
+- **[IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/ip-restrictions)**
 - **[IP Restrictions API Resource](/api-reference/iprestrictions/list/)**
 
 ## Credentials

--- a/integrations/endpoint-sso/azure-sso-saml.mdx
+++ b/integrations/endpoint-sso/azure-sso-saml.mdx
@@ -23,7 +23,7 @@ By integrating Azure AD B2C with ngrok, you can:
 ## 1. Configure ngrok
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Azure AD B2C:

--- a/integrations/endpoint-sso/descope-sso-saml.mdx
+++ b/integrations/endpoint-sso/descope-sso-saml.mdx
@@ -37,7 +37,7 @@ Make sure to leave this page open.
 ## 2. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Descope:

--- a/integrations/endpoint-sso/frontegg-sso-saml.mdx
+++ b/integrations/endpoint-sso/frontegg-sso-saml.mdx
@@ -62,7 +62,7 @@ Anything different may be an error.
 ## 2. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Frontegg:

--- a/integrations/endpoint-sso/jumpcloud-sso-saml.mdx
+++ b/integrations/endpoint-sso/jumpcloud-sso-saml.mdx
@@ -34,7 +34,7 @@ By integrating JumpCloud SSO with ngrok, you can:
 ## 3. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from JumpCloud:

--- a/integrations/endpoint-sso/miniorange-sso-saml.mdx
+++ b/integrations/endpoint-sso/miniorange-sso-saml.mdx
@@ -35,7 +35,7 @@ By integrating miniOrange SSO with ngrok, you can:
 ## 3. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from miniOrange:
@@ -52,7 +52,7 @@ The SAML action generates your ngrok SP Entity ID and ACS URL based on your endp
 
 ## 4. Obtain the SP metadata
 
-The SAML action generates your ngrok SP Entity ID and ACS URL based on your endpoint URL. Once you have [developer preview access](https://dashboard.ngrok.com/developer-preview), refer to the [SAML action documentation](/traffic-policy/actions/saml/) for how to retrieve these values.
+The SAML action generates your ngrok SP Entity ID and ACS URL based on your endpoint URL. Once you have [developer preview access](https://dashboard.ngrok.com/early-access), refer to the [SAML action documentation](/traffic-policy/actions/saml/) for how to retrieve these values.
 
 ## 5. Link miniOrange with ngrok 
 

--- a/integrations/endpoint-sso/ms-entra-sso-saml_edges.mdx
+++ b/integrations/endpoint-sso/ms-entra-sso-saml_edges.mdx
@@ -23,7 +23,7 @@ By integrating Microsoft Entra ID with ngrok, you can:
 ## 1. Configure ngrok
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Microsoft Entra ID:

--- a/integrations/endpoint-sso/okta-sso-saml.mdx
+++ b/integrations/endpoint-sso/okta-sso-saml.mdx
@@ -56,7 +56,7 @@ To test the SSO with ngrok, make sure you're assigned to the app.
 ## 2. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Okta:

--- a/integrations/endpoint-sso/trustelem-sso-saml.mdx
+++ b/integrations/endpoint-sso/trustelem-sso-saml.mdx
@@ -29,7 +29,7 @@ By integrating Wallix Trustelem SSO with ngrok, you can:
 ## 2. Configure ngrok 
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Once you have developer preview access, create a `policy.yaml` file with the following content, replacing `YOUR_IDP_METADATA_XML` with the IdP metadata XML from Wallix Trustelem:

--- a/integrations/kubernetes-ingress/azure-ad-k8s.mdx
+++ b/integrations/kubernetes-ingress/azure-ad-k8s.mdx
@@ -136,7 +136,7 @@ Configure and deploy the [ngrok Kubernetes Operator](https://github.com/ngrok/ng
 ## 3. Enable SAML with a Traffic Policy
 
 <Warning>
-The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/developer-preview) to configure SAML via Traffic Policy.
+The SAML Traffic Policy action is currently in [developer preview](/traffic-policy/actions/saml/). [Request access](https://dashboard.ngrok.com/early-access) to configure SAML via Traffic Policy.
 </Warning>
 
 Your Kubernetes-based app is now publicly accessible through ngrok.

--- a/snippets/gateway/shared/http-start-source.mdx
+++ b/snippets/gateway/shared/http-start-source.mdx
@@ -5,6 +5,6 @@ Serving a web application is as simple as `ngrok http 80`.
 Once your endpoint is running, check out:
 
 - [Traffic Policy](/traffic-policy/) - Add routing, authentication and traffic transformation
-- [Traffic Inspector](https://dashboard.ngrok.com/traffic-inspection/) - Real-time observability with request/response introspection
+- [Traffic Inspector](https://dashboard.ngrok.com/traffic-inspector) - Real-time observability with request/response introspection
 - [Endpoint Pooling](/gateway/endpoint-pooling/) - Load balancing
 

--- a/snippets/guides/agent-content.mdx
+++ b/snippets/guides/agent-content.mdx
@@ -107,7 +107,7 @@ Install it permanently by following the documentation for the [`ngrok completion
 
 The ngrok agent contains a [complete CLI for the ngrok API](/agent/cli-api/).
 
-To use it, [create an API Key on your ngrok dashboard](https://dashboard.ngrok.com/api) and then run:
+To use it, [create an API Key on your ngrok dashboard](https://dashboard.ngrok.com/api-keys) and then run:
 
 ```bash
 ngrok config add-api-key <API KEY>
@@ -398,7 +398,7 @@ All agents must use an authtoken to authenticate with ngrok, but you may also
 further restrict with IP Policies that specify which IPs and CIDRs agents may
 connect to your ngrok account from.
 
-- [IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/security/ip-restrictions)
+- [IP Restrictions on your ngrok dashboard](https://dashboard.ngrok.com/ip-restrictions)
 - [IP Restrictions API Resource](/api-reference/iprestrictions/list/)
 
 ## API

--- a/snippets/guides/customer-networks-content.mdx
+++ b/snippets/guides/customer-networks-content.mdx
@@ -21,7 +21,7 @@ In this guide, walk through setting up remote access to the systems in a single 
 - An ngrok account. If you don't have one, [sign up](https://dashboard.ngrok.com/signup).
 - An ngrok agent configured on a server within customer 1's network. See the [getting started guide](/getting-started/) for instructions on how to install the ngrok agent.
 - The ngrok Operator installed on your local Kubernetes cluster.
-- [An ngrok API Key](https://dashboard.ngrok.com/api/new). You'll need an account first.
+- [An ngrok API Key](https://dashboard.ngrok.com/api-keys/new). You'll need an account first.
 
 ### 1. Create a Service User and authtoken for Customer 1
 

--- a/snippets/guides/docker-content.mdx
+++ b/snippets/guides/docker-content.mdx
@@ -110,7 +110,7 @@ docker pull ngrok/ngrok
 
 #### Traffic Inspector
 
-Use [Traffic Inspector](https://dashboard.ngrok.com/ac_aHNlbPD0YUEUrqWbr9xZQJUflCx/traffic-inspector) on your ngrok dashboard
+Use [Traffic Inspector](https://dashboard.ngrok.com/traffic-inspector) on your ngrok dashboard
 
 #### Local web inspection on localhost:4040 (Legacy)
 

--- a/snippets/guides/events-content.mdx
+++ b/snippets/guides/events-content.mdx
@@ -56,7 +56,7 @@ When you create a Log Export, you select:
 - One or more Log Destinations to publish the subscribed logs to
 
 Log Exports can be created on the [ngrok
-Dashboard](https://dashboard.ngrok.com/events/subscriptions) or via the [
+Dashboard](https://dashboard.ngrok.com/log-exporting) or via the [
 Log Exporting API Resource](/api-reference/eventsubscriptions/create).
 
 ## Log sources 

--- a/snippets/guides/region-pinning-content.mdx
+++ b/snippets/guides/region-pinning-content.mdx
@@ -137,7 +137,7 @@ This feature is in Early Access and under active development.
 Behavior, supported fields, and limits may change before General Availability (GA). 
 This guide provides forward-looking context for evaluation and feedback.
 
-[Visit your dashboard](https://dashboard.ngrok.com/developer-preview) to sign up for Early Access, or to send your feedback via the "Let us know" link.
+[Visit your dashboard](https://dashboard.ngrok.com/early-access) to sign up for Early Access, or to send your feedback via the "Let us know" link.
 </Warning>
 
 Dedicated IPs let you configure a domain to receive traffic on static IP addresses that are exclusively dedicated to your account (instead of ngrok's shared multi-tenant IPs).
@@ -180,7 +180,7 @@ This is the baseline behavior for domains, and is used by the vast majority of c
 
 No, ngrok provides regional aliases as a shortcut to select all PoPs in a given geographic area. 
 
-Aliases are in Preview (see list below). Initial regions will include `european-union` and `united-states`, depending on [customer feedback (click "Let us know")](https://dashboard.ngrok.com/developer-preview).
+Aliases are in Preview (see list below). Initial regions will include `european-union` and `united-states`, depending on [customer feedback (click "Let us know")](https://dashboard.ngrok.com/early-access).
 
 ## Points of presence reference
 

--- a/snippets/k8s/_setup.mdx
+++ b/snippets/k8s/_setup.mdx
@@ -14,7 +14,7 @@ Whenever you want to update the Operator or install a new version, you must run 
 You can get both these from the ngrok dashboard:
 
 - Your [authtoken](https://dashboard.ngrok.com/get-started/your-authtoken)
-- An [API key](https://dashboard.ngrok.com/api)
+- An [API key](https://dashboard.ngrok.com/api-keys)
 
 The ngrok Kubernetes Operator provisions these as a Kubernetes secret, then uses the authtoken to create tunnels.
 The Operator uses your API key to manage resources via the [ngrok API](/api/).

--- a/traffic-policy/actions/saml.mdx
+++ b/traffic-policy/actions/saml.mdx
@@ -8,6 +8,6 @@ tag: Coming Soon
 <Info>
 **Coming Soon**
 
-The SAML Traffic Policy action is not yet generally available, [request access
-to the developer preview](https://dashboard.ngrok.com/early-access).
+The SAML Traffic Policy action is not yet generally available, [request Early
+Access](https://dashboard.ngrok.com/early-access).
 </Info>

--- a/traffic-policy/actions/saml.mdx
+++ b/traffic-policy/actions/saml.mdx
@@ -9,5 +9,5 @@ tag: Coming Soon
 **Coming Soon**
 
 The SAML Traffic Policy action is not yet generally available, [request access
-to the developer preview](https://dashboard.ngrok.com/developer-preview).
+to the developer preview](https://dashboard.ngrok.com/early-access).
 </Info>

--- a/traffic-policy/identities.mdx
+++ b/traffic-policy/identities.mdx
@@ -16,7 +16,7 @@ to:
 - Revoke sessions to forcibly log users out via the dashboard or API
 
 You can manage Identities and Session on your [ngrok
-Dashboard](https://dashboard.ngrok.com/app-users) or via the [ngrok API](#api).
+Dashboard](https://dashboard.ngrok.com/traffic-identities) or via the [ngrok API](#api).
 
 Traffic Identities were previously called 'App Users', you may find references with the
 old name while they are being transitioned.
@@ -29,7 +29,7 @@ old name while they are being transitioned.
 
 To view Traffic Identities and sessions:
 
-1. In the [ngrok Dashboard](https://dashboard.ngrok.com), navigate to **Traffic Policy** > **Identities** (or access the [Identities](https://dashboard.ngrok.com/app-users) page directly)
+1. In the [ngrok Dashboard](https://dashboard.ngrok.com), navigate to **Traffic Policy** > **Identities** (or access the [Identities](https://dashboard.ngrok.com/traffic-identities) page directly)
 
    The users are displayed in the table.
 
@@ -37,7 +37,7 @@ To view Traffic Identities and sessions:
 
 ### View session details
 
-1. Access the [Identities](https://dashboard.ngrok.com/app-users) page.
+1. Access the [Identities](https://dashboard.ngrok.com/traffic-identities) page.
 
 1. On the Identities table, select a user:
    - ngrok displays the table with the user identity overview, including the provider who authenticated your user, basic information about the user, and the identity provider used for login
@@ -53,7 +53,7 @@ Pasting the coordinates into your favorite mapping service will give you more de
 
 ### Revoke sessions
 
-1. Access the [Identities](https://dashboard.ngrok.com/app-users) page and locate your user.
+1. Access the [Identities](https://dashboard.ngrok.com/traffic-identities) page and locate your user.
 
 1. Click the trash can next to the user and then confirm the deletion.
 

--- a/user-management/index.mdx
+++ b/user-management/index.mdx
@@ -24,7 +24,7 @@ ngrok supports two enforcement options once you have configured your identity pr
 
 ### What is a Service User?
 
-A Service User is a service account that owns a set of credentials - authtokens, API keys, and SSH keys - independently of a person. You can see and manage your Service Users in the [ngrok Dashboard](https://dashboard.ngrok.com/users/bots).
+A Service User is a service account that owns a set of credentials - authtokens, API keys, and SSH keys - independently of a person. You can see and manage your Service Users in the [ngrok Dashboard](https://dashboard.ngrok.com/service-users).
 
 Service Users are similar to [Users](/iam/users/) but they are intended for automated
 systems that programmatically interact with your ngrok accounts either by
@@ -55,7 +55,7 @@ Service Users facts and limitations:
 
 You can create a Service User via the dashboard or programmatically through the ngrok API.
 
-In the [ngrok Dashboard](https://dashboard.ngrok.com/users/bots), navigate to the "Users" section of the left hand navigation, and then "Service Users" to create a new Service User.
+In the [ngrok Dashboard](https://dashboard.ngrok.com/service-users), navigate to the "Users" section of the left hand navigation, and then "Service Users" to create a new Service User.
 
 Using the API, you can POST to the [`/service_users` endpoint](/api-reference/service-users).
 
@@ -79,4 +79,4 @@ When a Service User is marked as inactive, they remain in the account, but their
 
 ### Moving former employee credentials (API keys, authtokens, SSH keys) to a Service User
 
-Credentials are assigned an owner when they are created and the owner cannot be changed. Access the [ngrok Dashboard](https://dashboard.ngrok.com/users/bots) to create a new Service User.
+Credentials are assigned an owner when they are created and the owner cannot be changed. Access the [ngrok Dashboard](https://dashboard.ngrok.com/service-users) to create a new Service User.


### PR DESCRIPTION
Resolves DOC-609

## Summary

Audited every `dashboard.ngrok.com` link in the docs against the actual dashboard routes — the neodash route tree (via `react-router routes --json`), the crusty route tree, and the dashboard-gateway routing rules on current `main`. Fixed all links that 404 or point at renamed pages: **42 files, 70 link fixes**.

## Fixes

| Old path | Fixed to |
|---|---|
| `/tunnels/agents`, `/tunnels/authtokens`, `/tunnels/ssh-keys` | `/agents`, `/authtokens`, `/ssh-keys` |
| `/security/ip-restrictions` | `/ip-restrictions` |
| `/api`, `/api/new` | `/api-keys`, `/api-keys/new` |
| `/users/bots` | `/service-users` |
| `/app-users` | `/traffic-identities` |
| `/observability/event-subscriptions`, `/events/subscriptions` | `/log-exporting` |
| `/traffic-inspection/`, `/observability/traffic-inspector` | `/traffic-inspector` |
| `/cloud-edge/domains`, `/cloud-edge/tcp-addresses` | `/domains`, `/tcp-addresses` |
| `/developer-preview` | `/early-access` (already 301s, now canonical) |
| account-scoped `/ac_…/traffic-inspector` | `/traffic-inspector` |
| `/edges` in `gateway/edges.mdx` | Edges API reference (the gateway no longer routes `/edges` to crusty, so the page is unreachable) |

Verified as still valid and left alone: `/get-started/your-authtoken`, `/billing*`, `/domains`, `/endpoints*`, `/traffic-inspector`, `/ip-policies`, `/tls-cert-authorities`, `/connect-urls`, `/vaults`, and the `/settings#id-verification` / `/settings#observability` anchors (confirmed as element IDs in crusty's settings cards).

## Not fixed here (codegen — needs upstream monorepo changes)

- `agent/cli.mdx` / `agent/cli-api.mdx`: `/obs/traffic-inspector`, `/api`, `/api/keys` — source is agent CLI help text (`go/cmd/ngrok/cli/...`)
- `errors/err_ngrok_{314,702}.mdx`: `/billing/plan` (dead) and `err_ngrok_{342,621}.mdx`: `/billing/subscription` (works via 301) — source is `config/src/errors/details/_err_ngrok_*.mdx`

Follow-up idea: add gateway `pathRedirects` for the dead paths so old agent binaries and external links in the wild keep working.