### PR TITLE
Add restrict by email example throughout the docs

### DIFF
--- a/getting-started/go.mdx
+++ b/getting-started/go.mdx
@@ -207,7 +207,7 @@ In this guide, you learned how to use the Go SDK to an create Agent Endpoint tha
 You saw one way to implement a Traffic Policy directly in your codebase, including an action that adds authentication to your app with no configuration required.
 What else can you do with these features?
 
-- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
+- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#restrict-access-by-email-domain), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
 - Learn more about the [Agent SDKs](/agent-sdks/) to understand how the Go SDK works under the hood.
 - Check out [the ngrok Go SDK repo](https://github.com/ngrok/ngrok-go?tab=readme-ov-file#ngrok-go) for more code examples.
 - If your use case calls for a centrally managed, always-on endpoint instead of one that's only available when an agent is running, you should proceed to [getting started with Cloud Endpoints](/getting-started/cloud-endpoints-quickstart/).

--- a/getting-started/javascript.mdx
+++ b/getting-started/javascript.mdx
@@ -162,7 +162,7 @@ In this guide, you learned how to use the JavaScript SDK to an create Agent Endp
 You saw one way to implement a Traffic Policy directly in your codebase, including an action that adds authentication to your app with no configuration required.
 What else can you do with these features?
 
-- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
+- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#restrict-access-by-email-domain), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
 - Learn more about the [Agent SDKs](/agent-sdks/) to understand how the JavaScript SDK works under the hood.
 - Read [the full JavaScript SDK documentation](https://ngrok.github.io/ngrok-javascript/) for more code examples.
 - If your use case calls for a centrally managed, always-on endpoint instead of one that's only available when an agent is running, you should proceed to [getting started with Cloud Endpoints](/getting-started/cloud-endpoints-quickstart/).

--- a/getting-started/python.mdx
+++ b/getting-started/python.mdx
@@ -174,7 +174,7 @@ In this guide, you learned how to use the Python SDK to an create Agent Endpoint
 You saw one way to implement a Traffic Policy directly in your codebase, including an action that adds authentication to your app with no configuration required.
 What else can you do with these features?
 
-- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
+- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#restrict-access-by-email-domain), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
 - Learn more about the [Agent SDKs](/agent-sdks/) to understand how the Python SDK works under the hood.
 - Read [the full Python SDK documentation](https://ngrok.github.io/ngrok-python/) for more code examples.
 - If your use case calls for a centrally managed, always-on endpoint, instead of one that's only available when an agent is running, you should proceed to [getting started with Cloud Endpoints](/getting-started/cloud-endpoints-quickstart/).

--- a/getting-started/rust.mdx
+++ b/getting-started/rust.mdx
@@ -207,7 +207,7 @@ In this guide, you learned how to use the Rust SDK to an create Agent Endpoint t
 You saw one way to implement a Traffic Policy directly in your codebase, including an action that adds authentication to your app with no configuration required.
 What else can you do with these features?
 
-- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
+- Dig deeper into [Traffic Policies](/traffic-policy/), which enable you to [grant conditional access](/traffic-policy/examples/add-authentication/#restrict-access-by-email-domain), [send custom headers](/traffic-policy/actions/add-headers/#examples), [rewrite URLs](/traffic-policy/actions/url-rewrite/#examples), and more with your endpoints.
 - Learn more about the [Agent SDKs](/agent-sdks/) to understand how the Rust SDK works under the hood.
 - Check out [the ngrok Rust SDK repo](https://github.com/ngrok/ngrok-rust/tree/main?tab=readme-ov-file#ngrok-rust) for more code examples.
 - If your use case calls for a centrally managed, always-on endpoint, instead of one that's only available when an agent is running, you should proceed to [getting started with Cloud Endpoints](/getting-started/cloud-endpoints-quickstart/).

--- a/snippets/traffic-policy/actions/oauth/examples/index.mdx
+++ b/snippets/traffic-policy/actions/oauth/examples/index.mdx
@@ -7,6 +7,6 @@ import CustomProviders from "/snippets/traffic-policy/actions/oauth/examples/cus
 
 ### Restricting access to certain users
 
-See [here](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables) for an example of conditional access based on OAuth result variables.
+See [here](/traffic-policy/examples/add-authentication/#restrict-access-by-email-domain) for an example of conditional access based on OAuth result variables.
 
 <CustomProviders />

--- a/snippets/traffic-policy/actions/oauth/examples/restrict-by-email.mdx
+++ b/snippets/traffic-policy/actions/oauth/examples/restrict-by-email.mdx
@@ -1,0 +1,102 @@
+Use [expressions](/traffic-policy/how-it-works#expressions) to restrict access based on the authenticated user's email, allowing only users from a specific organization.
+
+<CodeGroup>
+
+```yaml policy.yml
+on_http_request:
+  # Authenticate with Google OAuth
+  - actions:
+      - type: oauth
+        config:
+          provider: google
+  # Only allow users with a company email address
+  - expressions:
+      - "!actions.ngrok.oauth.identity.email.endsWith('@your-company.com')"
+    actions:
+      - type: deny
+        config:
+          status_code: 403
+```
+
+```json policy.json
+{
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "oauth",
+          "config": {
+            "provider": "google"
+          }
+        }
+      ]
+    },
+    {
+      "expressions": [
+        "!actions.ngrok.oauth.identity.email.endsWith('@your-company.com')"
+      ],
+      "actions": [
+        {
+          "type": "deny",
+          "config": {
+            "status_code": 403
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeGroup>
+
+To allow only an explicit list of addresses instead of a whole domain, match against a list:
+
+<CodeGroup>
+
+```yaml policy.yml
+on_http_request:
+  - actions:
+      - type: oauth
+        config:
+          provider: google
+  # Only allow specific email addresses
+  - expressions:
+      - "!(actions.ngrok.oauth.identity.email in ['alice@example.com', 'bob@example.com'])"
+    actions:
+      - type: deny
+        config:
+          status_code: 403
+```
+
+```json policy.json
+{
+  "on_http_request": [
+    {
+      "actions": [
+        {
+          "type": "oauth",
+          "config": {
+            "provider": "google"
+          }
+        }
+      ]
+    },
+    {
+      "expressions": [
+        "!(actions.ngrok.oauth.identity.email in ['alice@example.com', 'bob@example.com'])"
+      ],
+      "actions": [
+        {
+          "type": "deny",
+          "config": {
+            "status_code": 403
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeGroup>

--- a/traffic-policy/actions/oauth.mdx
+++ b/traffic-policy/actions/oauth.mdx
@@ -5,6 +5,7 @@ description: The OAuth action restricts access to only authorized users by enfor
 ---
 
 import CustomProviders from "/snippets/traffic-policy/actions/oauth/examples/custom-providers.mdx";
+import RestrictByEmail from "/snippets/traffic-policy/actions/oauth/examples/restrict-by-email.mdx";
 import ManagedProvider from "/snippets/traffic-policy/actions/oauth/managed-provider.mdx";
 import NonTerminatingExplanation from "/snippets/traffic-policy/common/non-terminating-explanation.mdx";
 import TrafficIdentities from "/snippets/gateway/shared/traffic-identities.mdx"
@@ -247,9 +248,11 @@ Cookie values are opaque to the upstream service and must not be modified.
 
 <ManagedProvider />
 
-### Restricting access to certain users
+### Restricting access by email
 
-See [this authentication example](/traffic-policy/examples/add-authentication/#conditional-access-using-oauth-variables) to learn how to restrict access based on OAuth result variables.
+<RestrictByEmail />
+
+For more ways to restrict access based on OAuth result variables, see [the Add Authentication example](/traffic-policy/examples/add-authentication/#oauth).
 
 <CustomProviders />
 

--- a/traffic-policy/examples/add-authentication.mdx
+++ b/traffic-policy/examples/add-authentication.mdx
@@ -3,6 +3,8 @@ title: Add Authentication
 description: Learn how to add authentication to your endpoints using Traffic Policy with Basic Auth, OAuth, OIDC, JWT validation, and more.
 ---
 
+import RestrictByEmail from "/snippets/traffic-policy/actions/oauth/examples/restrict-by-email.mdx";
+
 Traffic Policy gives you powerful options for adding authentication to your endpoints—without touching your application code.
 Whether you need a quick login prompt for a demo, OAuth for production apps, or JWT validation for APIs, ngrok has you covered.
 
@@ -123,57 +125,7 @@ on_http_request:
 
 ### Restrict access by email domain
 
-Use [expressions](/traffic-policy/how-it-works#expressions) to restrict access based on email domain, allowing only users from specific organizations.
-
-<CodeGroup>
-
-```yaml policy.yml
-on_http_request:
-  # Authenticate with Google OAuth
-  - actions:
-      - type: oauth
-        config:
-          provider: google
-  # Only allow users with company email addresses
-  - expressions:
-      - "!actions.ngrok.oauth.identity.email.endsWith('@your-company.com')"
-    actions:
-      - type: deny
-        config:
-          status_code: 403
-```
-
-```json policy.json
-{
-  "on_http_request": [
-    {
-      "actions": [
-        {
-          "type": "oauth",
-          "config": {
-            "provider": "google"
-          }
-        }
-      ]
-    },
-    {
-      "expressions": [
-        "!actions.ngrok.oauth.identity.email.endsWith('@your-company.com')"
-      ],
-      "actions": [
-        {
-          "type": "deny",
-          "config": {
-            "status_code": 403
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-</CodeGroup>
+<RestrictByEmail />
 
 For more OAuth examples—including session controls, multiple email domains, custom OAuth apps, and login/logout flows—see the [`oauth` action docs](/traffic-policy/actions/oauth/) and the [OAuth protection guide](/traffic-policy/examples/oauth-protection/).
 

--- a/traffic-policy/examples/oauth-protection.mdx
+++ b/traffic-policy/examples/oauth-protection.mdx
@@ -4,7 +4,7 @@ sidebarTitle: OAuth Protection
 description: Learn how to add OAuth authentication to your ngrok endpoints using Traffic Policy.
 ---
 
-
+import RestrictByEmail from "/snippets/traffic-policy/actions/oauth/examples/restrict-by-email.mdx";
 
 Sometimes you don't want everyone to be able to access the app at your [Endpoints](/gateway/endpoints).
 
@@ -90,6 +90,12 @@ ngrok start endpoint-name-here
 Open your app's URL (for example `https://myapp.ngrok.app`).
 
 You should be immediately redirected to the Google sign-in page, and after authenticating you'll land back on your app.
+
+## Restrict access by email
+
+Authenticating users is often only half of what you want: a common next step is to allow only users from your own organization, so that anyone with a Google account can't get in.
+
+<RestrictByEmail />
 
 ## Explore more and fine-tune with Traffic Policy
 


### PR DESCRIPTION

This PR just creates a snippet with examples of restricting oauth access to endpoints based on the visitor's email address, and then adds that snippet everywhere relevant.

Also fixes some broken hash links.

Based on this feedback: https://ngrok.slack.com/archives/C03LRGNSG6A/p1784132369148439
