### PR TITLE
Add request webhook info to the docs

### DIFF
--- a/gateway/examples/webhook-gateway.mdx
+++ b/gateway/examples/webhook-gateway.mdx
@@ -7,6 +7,7 @@ sidebar_label: "Webhook Gateway"
 import ReserveDomain from "/snippets/gateway/_reserve-domain.mdx";
 import CloudEndpoint from "/snippets/gateway/_cloud-endpoint.mdx";
 import TryOut from "/snippets/gateway/_try-out.mdx";
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 
 
 Instead of implementing webhook validation and routing logic separately in every service, a webhook gateway provides a single, secure entry point for all third-party webhooks from providers like Stripe, Twilio, Slack, and GitHub. This centralized approach validates webhook signatures, prevents tampering, and routes authenticated requests to the appropriate internal services in production environments.
@@ -18,6 +19,8 @@ With this setup, you can:
 - Prevent webhook spoofing and tampering with cryptographic verification
 - Standardize webhook handling across your entire infrastructure
 - Apply consistent logging and monitoring to all webhook traffic
+
+<RequestWebhookProvider />
 
 ## 1. Create endpoints for your services
 

--- a/integrations/webhooks/aftership-webhooks.mdx
+++ b/integrations/webhooks/aftership-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: AfterShip
 description: Develop and test AfterShip webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive AfterShip webhooks on your localhost app.
 

--- a/integrations/webhooks/airship-webhooks.mdx
+++ b/integrations/webhooks/airship-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Airship
 description: Develop and test Airship webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Airship webhook notifications on your localhost app.
 

--- a/integrations/webhooks/alchemy-webhooks.mdx
+++ b/integrations/webhooks/alchemy-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Alchemy
 description: Develop and test Alchemy webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Alchemy webhooks on your localhost app.
 

--- a/integrations/webhooks/amazon-sns-webhooks.mdx
+++ b/integrations/webhooks/amazon-sns-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Amazon SNS
 description: Develop and test Amazon SNS webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Amazon SNS topic notifications on your localhost app.
 

--- a/integrations/webhooks/autodesk-webhooks.mdx
+++ b/integrations/webhooks/autodesk-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Autodesk Platform Services
 description: Develop and test Autodesk webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Autodesk Platform Services webhooks on your localhost app.
 

--- a/integrations/webhooks/bitbucket-webhooks.mdx
+++ b/integrations/webhooks/bitbucket-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Bitbucket Repository
 description: Develop and test Bitbucket webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Bitbucket repository webhooks on your localhost app.
 

--- a/integrations/webhooks/box-webhooks.mdx
+++ b/integrations/webhooks/box-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Box
 description: Develop and test Box webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Box webhooks on your localhost app.
 

--- a/integrations/webhooks/brex-webhooks.mdx
+++ b/integrations/webhooks/brex-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Brex
 description: Develop and test Brex webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Brex webhooks on your localhost app.
 

--- a/integrations/webhooks/buildkite-webhooks.mdx
+++ b/integrations/webhooks/buildkite-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Buildkite
 description: Develop and test Buildkite webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Buildkite webhooks on your localhost app.
 

--- a/integrations/webhooks/calendly-webhooks.mdx
+++ b/integrations/webhooks/calendly-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Calendly
 description: Develop and test Calendly webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Calendly webhooks on your localhost app.
 

--- a/integrations/webhooks/castle-webhooks.mdx
+++ b/integrations/webhooks/castle-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Castle
 description: Develop and test Castle webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Castle webhooks on your localhost app.
 

--- a/integrations/webhooks/chargify-webhooks.mdx
+++ b/integrations/webhooks/chargify-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Chargify
 description: Develop and test Chargify webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Chargify webhooks on your localhost app.
 

--- a/integrations/webhooks/circleci-webhooks.mdx
+++ b/integrations/webhooks/circleci-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: CircleCI
 description: Develop and test CircleCI webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive CircleCI webhooks on your localhost app.
 

--- a/integrations/webhooks/clearbit-webhooks.mdx
+++ b/integrations/webhooks/clearbit-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Clearbit
 description: Develop and test Clearbit webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Clearbit webhooks on your localhost app.
 

--- a/integrations/webhooks/clerk-webhooks.mdx
+++ b/integrations/webhooks/clerk-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Clerk
 description: Develop and test Clerk webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Clerk webhooks on your localhost app.
 

--- a/integrations/webhooks/coinbase-webhooks.mdx
+++ b/integrations/webhooks/coinbase-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Coinbase
 description: Develop and test Coinbase webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Coinbase webhooks on your localhost app.
 

--- a/integrations/webhooks/contentful-webhooks.mdx
+++ b/integrations/webhooks/contentful-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Contentful
 description: Develop and test Contentful webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Contentful webhooks on your localhost app.
 

--- a/integrations/webhooks/docusign-webhooks.mdx
+++ b/integrations/webhooks/docusign-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: DocuSign
 description: Develop and test DocuSign webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive DocuSign webhooks on your localhost app.
 

--- a/integrations/webhooks/dropbox-webhooks.mdx
+++ b/integrations/webhooks/dropbox-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Dropbox
 description: Develop and test Dropbox webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Dropbox webhooks on your localhost app.
 

--- a/integrations/webhooks/facebook-messenger-webhooks.mdx
+++ b/integrations/webhooks/facebook-messenger-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Facebook Messenger
 description: Develop and test Facebook Messenger webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Facebook Messenger webhooks on your localhost app.
 

--- a/integrations/webhooks/facebook-webhooks.mdx
+++ b/integrations/webhooks/facebook-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Facebook
 description: Develop and test Facebook webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Facebook webhooks on your localhost app.
 

--- a/integrations/webhooks/frameio-webhooks.mdx
+++ b/integrations/webhooks/frameio-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Frame.io
 description: Develop and test Frame.io webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Frame.io webhooks on your localhost app.
 

--- a/integrations/webhooks/github-webhooks.mdx
+++ b/integrations/webhooks/github-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: GitHub Repository
 description: Develop and test GitHub webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive GitHub repository webhooks on your localhost app.
 

--- a/integrations/webhooks/gitlab-webhooks.mdx
+++ b/integrations/webhooks/gitlab-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: GitLab Repository
 description: Develop and test GitLab webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive GitLab webhooks on your localhost app.
 

--- a/integrations/webhooks/heroku-webhooks.mdx
+++ b/integrations/webhooks/heroku-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Heroku
 description: Develop and test Heroku webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Heroku webhooks on your localhost app.
 

--- a/integrations/webhooks/hostedhooks-webhooks.mdx
+++ b/integrations/webhooks/hostedhooks-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: HostedHooks
 description: Develop and test HostedHooks webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive HostedHooks webhooks on your localhost app.
 

--- a/integrations/webhooks/hubspot-webhooks.mdx
+++ b/integrations/webhooks/hubspot-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: HubSpot
 description: Develop and test HubSpot webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive HubSpot webhooks on your localhost app.
 

--- a/integrations/webhooks/hygraph-webhooks.mdx
+++ b/integrations/webhooks/hygraph-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Hygraph
 description: Develop and test Hygraph webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Hygraph webhooks on your localhost app.
 

--- a/integrations/webhooks/instagram-webhooks.mdx
+++ b/integrations/webhooks/instagram-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Instagram
 description: Develop and test Instagram webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Instagram webhooks on your localhost app.
 

--- a/integrations/webhooks/intercom-webhooks.mdx
+++ b/integrations/webhooks/intercom-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Intercom
 description: Develop and test Intercom webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Intercom webhooks on your localhost app.
 

--- a/integrations/webhooks/jira-webhooks.mdx
+++ b/integrations/webhooks/jira-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Jira
 description: Develop and test Jira webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Jira webhooks on your localhost app.
 

--- a/integrations/webhooks/launchdarkly-webhooks.mdx
+++ b/integrations/webhooks/launchdarkly-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: LaunchDarkly
 description: Develop and test LaunchDarkly webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive LaunchDarkly webhooks on your localhost app.
 

--- a/integrations/webhooks/linear-webhooks.mdx
+++ b/integrations/webhooks/linear-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Linear
 description: Develop and test Linear webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Linear webhooks on your localhost app.
 

--- a/integrations/webhooks/mailchimp-webhooks.mdx
+++ b/integrations/webhooks/mailchimp-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Mailchimp
 description: Develop and test Mailchimp webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Mailchimp webhooks on your localhost app.
 

--- a/integrations/webhooks/mailgun-webhooks.mdx
+++ b/integrations/webhooks/mailgun-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Mailgun
 description: Develop and test Mailgun webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Mailgun webhooks on your localhost app.
 

--- a/integrations/webhooks/modern-treasury-webhooks.mdx
+++ b/integrations/webhooks/modern-treasury-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Modern Treasury
 description: Develop and test Modern Treasury webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Modern Treasury webhooks on your localhost app.
 

--- a/integrations/webhooks/mongodb-webhooks.mdx
+++ b/integrations/webhooks/mongodb-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: MongoDB
 description: Develop and test MongoDB webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive MongoDB webhooks on your localhost app.
 

--- a/integrations/webhooks/mux-webhooks.mdx
+++ b/integrations/webhooks/mux-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Mux
 description: Develop and test Mux webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Mux webhooks on your localhost app.
 

--- a/integrations/webhooks/okta-webhooks.mdx
+++ b/integrations/webhooks/okta-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Okta
 description: Develop and test Okta webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Okta webhooks on your localhost app.
 

--- a/integrations/webhooks/orbit-webhooks.mdx
+++ b/integrations/webhooks/orbit-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Orbit
 description: Develop and test Orbit webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Orbit webhooks on your localhost app.
 

--- a/integrations/webhooks/pagerduty-webhooks.mdx
+++ b/integrations/webhooks/pagerduty-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: PagerDuty
 description: Develop and test PagerDuty webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive PagerDuty webhooks on your localhost app.
 

--- a/integrations/webhooks/pinwheel-webhooks.mdx
+++ b/integrations/webhooks/pinwheel-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Pinwheel
 description: Develop and test Pinwheel webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Pinwheel webhooks on your localhost app.
 

--- a/integrations/webhooks/plivo-webhooks.mdx
+++ b/integrations/webhooks/plivo-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Plivo
 description: Develop and test Plivo webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Plivo webhooks on your localhost app.
 

--- a/integrations/webhooks/pusher-webhooks.mdx
+++ b/integrations/webhooks/pusher-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Pusher
 description: Develop and test Pusher webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Pusher webhooks on your localhost app.
 

--- a/integrations/webhooks/sendgrid-webhooks.mdx
+++ b/integrations/webhooks/sendgrid-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: SendGrid
 description: Develop and test SendGrid webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive SendGrid webhooks on your localhost app.
 

--- a/integrations/webhooks/sentry-webhooks.mdx
+++ b/integrations/webhooks/sentry-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Sentry
 description: Develop and test Sentry webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Sentry webhooks on your localhost app.
 

--- a/integrations/webhooks/shopify-webhooks.mdx
+++ b/integrations/webhooks/shopify-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Shopify
 description: Develop and test Shopify webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Shopify webhooks on your localhost app.
 

--- a/integrations/webhooks/signalsciences-webhooks.mdx
+++ b/integrations/webhooks/signalsciences-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Signal Sciences
 description: Develop and test Signal Sciences webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Signal Sciences webhooks on your localhost app.
 

--- a/integrations/webhooks/slack-webhooks.mdx
+++ b/integrations/webhooks/slack-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Slack
 description: Develop and test Slack webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Slack webhooks on your localhost app.
 Slack requires your application to be available at an HTTPS endpoint.

--- a/integrations/webhooks/sonatype-nexus-webhooks.mdx
+++ b/integrations/webhooks/sonatype-nexus-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Sonatype Nexus
 description: Develop and test Sonatype Nexus webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Sonatype Nexus webhooks on your localhost app.
 

--- a/integrations/webhooks/square-webhooks.mdx
+++ b/integrations/webhooks/square-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Square
 description: Develop and test Square webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Square webhooks on your localhost app.
 

--- a/integrations/webhooks/stripe-webhooks.mdx
+++ b/integrations/webhooks/stripe-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Stripe
 description: Develop and test Stripe webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Stripe webhooks on your localhost app.
 Stripe requires your application to be available at an HTTPS endpoint.

--- a/integrations/webhooks/svix-webhooks.mdx
+++ b/integrations/webhooks/svix-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Svix
 description: Develop and test Svix webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Svix incoming webhooks on your localhost app.
 

--- a/integrations/webhooks/teams-webhooks.mdx
+++ b/integrations/webhooks/teams-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Microsoft Teams
 description: Develop and test Microsoft Teams webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Microsoft Teams webhooks on your localhost app.
 

--- a/integrations/webhooks/terraform-webhooks.mdx
+++ b/integrations/webhooks/terraform-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Terraform Cloud
 description: Develop and test Terraform webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Terraform Cloud webhooks on your localhost app.
 

--- a/integrations/webhooks/tiktok-webhooks.mdx
+++ b/integrations/webhooks/tiktok-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: TikTok
 description: Develop and test TikTok webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive TikTok webhooks on your localhost app.
 

--- a/integrations/webhooks/trendmicro-webhooks.mdx
+++ b/integrations/webhooks/trendmicro-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Trend Micro
 description: Develop and test Trend Micro webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Trend Micro Cloud One Conformity webhooks on your localhost app.
 

--- a/integrations/webhooks/twilio-webhooks.mdx
+++ b/integrations/webhooks/twilio-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Twilio SMS
 description: Develop and test Twilio webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive [Twilio SMS webhooks](https://www.twilio.com/docs/usage/webhooks/sms-webhooks) on your localhost app.
 

--- a/integrations/webhooks/twitter-webhooks.mdx
+++ b/integrations/webhooks/twitter-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: X (Twitter)
 description: Develop and test X (formerly Twitter) webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive X (formerly Twitter) webhooks on your localhost app.
 

--- a/integrations/webhooks/typeform-webhooks.mdx
+++ b/integrations/webhooks/typeform-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Typeform
 description: Develop and test Typeform webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Typeform webhooks on your localhost app.
 

--- a/integrations/webhooks/vmware-webhooks.mdx
+++ b/integrations/webhooks/vmware-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: VMware Workspace ONE
 description: Develop and test VMware webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive VMware Workspace ONE webhooks on your localhost app.
 

--- a/integrations/webhooks/webex-webhooks.mdx
+++ b/integrations/webhooks/webex-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Cisco Webex
 description: Develop and test Webex webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Cisco Webex webhooks on your localhost app.
 

--- a/integrations/webhooks/whatsapp-webhooks.mdx
+++ b/integrations/webhooks/whatsapp-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: WhatsApp
 description: Develop and test WhatsApp webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive WhatsApp webhooks on your localhost app.
 

--- a/integrations/webhooks/worldline-webhooks.mdx
+++ b/integrations/webhooks/worldline-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Worldline
 description: Develop and test Worldline webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Worldline webhooks on your localhost app.
 

--- a/integrations/webhooks/xero-webhooks.mdx
+++ b/integrations/webhooks/xero-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Xero
 description: Develop and test Xero webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide walks you through using ngrok to receive Xero webhooks on your localhost app.
 

--- a/integrations/webhooks/zendesk-webhooks.mdx
+++ b/integrations/webhooks/zendesk-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Zendesk
 description: Develop and test Zendesk webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide explains how to use ngrok to receive Zendesk webhooks on your localhost app.
 

--- a/integrations/webhooks/zoom-webhooks.mdx
+++ b/integrations/webhooks/zoom-webhooks.mdx
@@ -4,8 +4,11 @@ sidebarTitle: Zoom
 description: Develop and test Zoom webhooks from localhost.
 ---
 
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 import InspectingRequests from "/snippets/integrations/_inspecting-requests.mdx";
 import ReplayingRequests from "/snippets/integrations/_replaying-requests.mdx";
+
+<RequestWebhookProvider />
 
 This guide shows you how to use ngrok to receive Zoom webhooks on your localhost app.
 

--- a/snippets/_request-webhook-provider.mdx
+++ b/snippets/_request-webhook-provider.mdx
@@ -1,4 +1,4 @@
 <Note title="Need a different webhook provider?">
 
-If you don't see your provider, you can [request support for it](https://dashboard.ngrok.com/early-access#webhook-providers). 
+If you don't see your preferred webhook provider, you can [request support for it](https://dashboard.ngrok.com/early-access#webhook-providers). 
 </Note>

--- a/snippets/_request-webhook-provider.mdx
+++ b/snippets/_request-webhook-provider.mdx
@@ -1,0 +1,4 @@
+<Note title="Need a different webhook provider?">
+
+If you don't see your provider, you can [request support for it](https://dashboard.ngrok.com/early-access#webhook-providers). 
+</Note>

--- a/traffic-policy/actions/verify-webhook.mdx
+++ b/traffic-policy/actions/verify-webhook.mdx
@@ -6,6 +6,7 @@ description: Validate incoming webhook signatures against a known secret to ensu
 
 import ActionVariablesDescription from "/snippets/traffic-policy/common/action-variables-description.mdx";
 import NonTerminatingExplanation from "/snippets/traffic-policy/common/non-terminating-explanation.mdx";
+import RequestWebhookProvider from "/snippets/_request-webhook-provider.mdx";
 
 import { ConfigField } from "/snippets/ConfigTable.jsx";
 import { ConfigChildren } from "/snippets/ConfigChildren.jsx";
@@ -29,7 +30,7 @@ reference for this action.
 
     <ConfigField title="provider" type="string" required={true}>
         <p>The name of the provider to verify webhook requests from.</p>
-        <p>Value must be a [supported provider](#supported-providers) identifier.</p>
+        <p>Value must be a [supported provider](#supported-providers) identifier. Don't see your provider? [Request support for it here](https://dashboard.ngrok.com/early-access#webhook-providers).</p>
     </ConfigField>
 
     <ConfigField title="secret" type="string" required={true} cel={true}>
@@ -149,6 +150,8 @@ Currently, these integration guides refer to modules.
 | Xero                        | `xero`                  | [Documentation](/integrations/webhooks/xero-webhooks)                                                   |
 | Zendesk                     | `zendesk`               | [Documentation](/integrations/webhooks/zendesk-webhooks)                                                |
 | Zoom                        | `zoom`                  | [Documentation](/integrations/webhooks/zoom-webhooks)                                                   |
+
+<RequestWebhookProvider />
 
 ## Examples
 


### PR DESCRIPTION
Don't be intimidated by the large files changed.

Related to this discussion:

https://ngrok.slack.com/archives/C03LRGNSG6A/p1784260188290599?thread_ts=1784164983.012919&cid=C03LRGNSG6A

This PR:

1. Adds a note about our webhook provider request form to all the webhook integration docs. [Example here](https://ngrok-shaquil-doc-612-add-request-a-provider-button-to-docs.mintlify.site/integrations/webhooks/airship-webhooks)
<img width="1592" height="508" alt="image" src="https://github.com/user-attachments/assets/d4f2ad4a-75cb-4971-8fd2-0d7deb5f74d3" />


2. Also mentions it in [the verify webhooks action](https://ngrok-shaquil-doc-612-add-request-a-provider-button-to-docs.mintlify.site/traffic-policy/actions/verify-webhook#config-provider)
<img width="1378" height="456" alt="image" src="https://github.com/user-attachments/assets/08014a48-5661-48c0-84ab-a0ac1d347b15" />

3. Also mentions it in [the webhook gateway docs](https://ngrok-shaquil-doc-612-add-request-a-provider-button-to-docs.mintlify.site/gateway/examples/webhook-gateway)
<img width="1590" height="1338" alt="image" src="https://github.com/user-attachments/assets/99a14b21-e00b-421e-a693-21db8917d2e9" />
