### PR TITLE
Refocus Linux device gateway guide's next steps on the fleet journey

### DIFF
--- a/guides/device-gateway/linux.mdx
+++ b/guides/device-gateway/linux.mdx
@@ -8,7 +8,7 @@ ngrok allows you to create secure ingress to any app, device, or service without
 
 What is ngrok? ngrok is an all-in-one cloud networking platform that secures, transforms, and routes traffic to services running anywhere.
 
-In this guide, you'll walk through the process of installing the ngrok agent on a remote Linux device, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and integrating traffic events with your preferred logging tool.
+In this guide, you'll walk through the process of installing the ngrok agent on a remote Linux device, ensuring the agent runs integrated into your operating system, restricting traffic to trusted origins, and preparing to scale from a single device to a full fleet.
 
 ## 1. Install the ngrok Agent
 
@@ -152,18 +152,23 @@ ssh -p NGROK_PORT user@NGROK_TCP_ADDRESS
 
 ## What's next?
 
-Now that your device is integrated to ngrok, you can ​​execute tasks at the ngrok dashboard to operationalize your fleet:
+You've connected one device. The next step is understanding how ngrok works when that one device becomes ten, a hundred, or ten thousand.
 
-### Logging traffic from ngrok
+### Learn the device gateway model
 
-Each action that happens in ngrok is published as a log, and [Log Exporting](/obs/) allows you to subscribe to the logs that are relevant to you and write them to one or more destinations.
+The [Device Gateway guide](/guides/device-gateway/overview) walks through the full picture: giving every device a secure, addressable endpoint, keeping access policy in the cloud so you can update it without firmware pushes or truck rolls, and managing your entire fleet programmatically through [the ngrok API](/api/).
 
-A Log Export is made up of a set of log sources (some of which can be filtered), and log destinations. Each export can send logs to one or more destinations, such as Amazon CloudWatch Logs, Amazon Kinesis (as a data stream), or Amazon Kinesis Firehose (as a delivery stream).
+### Scaling from one device to a fleet
 
-Log Exports can be configured through the [ngrok Dashboard](https://dashboard.ngrok.com/log-exporting) or the [ngrok API](/api-reference/eventdestinations).
+When your devices live in networks you don't own—kiosks in stores, POS terminals, medical devices in clinics, industrial controllers on factory floors—ngrok is a better fit than a mesh VPN. Enrolling each device into a VPN mesh means placing your network inside someone else's, at fleet scale. ngrok's model avoids that entirely:
 
-You can also forward all or some of your traffic logs from [ngrok to your preferred logging tool](/obs/).
+- A lightweight agent on each device dials out, so it traverses CGNAT and hostile firewalls by default—no inbound ports or firewall changes on networks you don't control.
+- Each device gets one named endpoint, addressable by your cloud, technicians, and customers.
+- Each device gets its own credentials, which you can revoke individually without touching the rest of the fleet.
+- Everything is automatable via the API across thousands of units, including [remote health checks, stop, start, and updates](/api-reference/tunnelsessions/restart) for every agent in your fleet.
 
-### Remote checks, stop, start, and updates
+For a deeper comparison of the two models, see [ngrok vs. Tailscale](https://ngrok.com/compare/tailscale).
 
-ngrok provides [APIs](/api-reference/tunnelsessions/restart) and a [dashboard UI](https://dashboard.ngrok.com/agents) for you to monitor the health of ngrok agents running in your fleet. The interfaces also allow you to remotely stop, start, and update agents.
+### Talk to us about fleet pricing
+
+Running ngrok across a fleet doesn't have to mean list pricing. [Contact our sales team](https://ngrok.com/contact) to discuss per-device and fleet pricing for your deployment.


### PR DESCRIPTION
## What

Rewrites the "What's next?" section of `guides/device-gateway/linux.mdx` to follow the actual user journey of someone getting started with devices, instead of pivoting into logging/observability.

## Changes

- **Learn the device gateway model** — links to the [Device Gateway overview](https://ngrok.com/docs/guides/device-gateway/overview) as the natural next read.
- **Scaling from one device to a fleet** — explains why ngrok beats a mesh VPN for devices in networks you don't own (outbound-only agent, one named endpoint per device, individually revocable credentials, API automation), using only claims already verified on the [ngrok vs. Tailscale compare page](https://ngrok.com/compare/tailscale), which it links to. The old remote checks/stop/start/updates API link is folded into this list.
- **Talk to us about fleet pricing** — contact-sales CTA (https://ngrok.com/contact) for per-device and fleet pricing.
- Intro paragraph updated to match (it previously promised the removed logging content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)