### PR TITLE
docs(pricing): clarify free plan limits

### DIFF
--- a/pricing-limits/free-plan-limits.mdx
+++ b/pricing-limits/free-plan-limits.mdx
@@ -10,7 +10,8 @@ import FreeResources from '/snippets/shared/limits/free-resources.mdx';
 Learn about the limits and resources included with the free ngrok for developers plan.
 
 <Note>
-Free endpoints have no timeout — they can stay online indefinitely. To keep one running unattended, run it as a [background service](/agent/#background-service).
+Free endpoints have no timeout—they can stay online indefinitely. 
+To keep one running unattended, run it as a [background service](/agent/#background-service).
 </Note>
 
 <Tip>

--- a/pricing-limits/free-plan-limits.mdx
+++ b/pricing-limits/free-plan-limits.mdx
@@ -7,11 +7,10 @@ import FreeResources from '/snippets/shared/limits/free-resources.mdx';
 
 
 
-Learn about the limits enforced in the free ngrok for developers plan.
+Learn about the limits and resources included with the free ngrok for developers plan.
 
 <Note>
-The free tier does NOT have timeouts on endpoints.
-If you'd like to run your endpoint all the time, you can do so, on the free tier, as a [background service](/agent/#background-service).
+Free endpoints have no timeout — they can stay online indefinitely. To keep one running unattended, run it as a [background service](/agent/#background-service).
 </Note>
 
 <Tip>
@@ -28,36 +27,34 @@ The free plan groups its limits into three kinds: **monthly usage quotas** that 
 You can check your current usage against these limits [in the Usage page in the dashboard](https://dashboard.ngrok.com/usage).
 </Note>
 
-## Domain limitations on free plan
+## Domains
 
-The free plan includes one automatically assigned **dev domain** (for example, `your-assigned-name.ngrok-free.app`) that you can use for public endpoints. 
+The free plan includes one automatically assigned **dev domain** (for example, `your-assigned-name.ngrok-free.app`) tied to your account. You can point up to 3 online endpoints at it:
 
-**What you CAN do on the free plan:**
-- Use your assigned dev domain with commands like: `ngrok http 8080`
-- Create up to 3 online endpoints using your dev domain
+```bash
+ngrok http 8080
+```
 
-**What you CANNOT do on the free plan:**
-- Choose or customize your domain name (for example, `--url https://my-custom-name.ngrok.app` will not work)
-- Reserve or create custom static domains
-- Use random domain generation (for example, `--url 'https://'` will not work)
-- Use your own custom domain (for example, `app.yourdomain.com`)
-- Create wildcard domains
+The dev domain is the only domain available on the free plan. Upgrading to a [paid plan](https://ngrok.com/pricing?ref=docs-domain-limits) unlocks:
 
-To choose custom domain names, use random domain generation, or bring your own domain, you need to [upgrade to a paid plan](https://ngrok.com/pricing?ref=docs-domain-limits).
+- **Custom domain names** — for example, `--url https://my-custom-name.ngrok.app`
+- **Reserved static domains** you control
+- **Randomly generated URLs** — for example, `--url 'https://'`
+- **Your own domains** — for example, `app.yourdomain.com`
+- **Wildcard domains**
 
 ## Increasing your limits
 
-If you run into a limit, you can [upgrade to a plan with higher limits](https://ngrok.com/pricing?ref=docs).
-If you always want your endpoints online and available, select the Pay-as-you-go plan.
+If you hit a limit or run out of credit, [upgrade to a plan with higher limits](https://ngrok.com/pricing?ref=docs). Choose **Pay-as-you-go** if you want your endpoints to always stay online and available.
 
-See the [Pricing and Limits](/pricing-limits) page for more information.
+See [Pricing and Limits](/pricing-limits) for the full plan comparison.
 
 ## Removing the interstitial page
 
-To prevent bad actors from using ngrok to execute [phishing attacks](https://en.wikipedia.org/wiki/Phishing), ngrok [injects an interstitial page](https://ngrok.com/blog-post/fighting-abuse-on-the-ngrok-platform) in front of all HTML browser traffic on the free tier.
+To deter [phishing attacks](https://en.wikipedia.org/wiki/Phishing), ngrok shows an [interstitial page](https://ngrok.com/blog-post/fighting-abuse-on-the-ngrok-platform) in front of all HTML browser traffic on the free tier.
 
-- This page informs visitors that they're accessing a site served by ngrok.
-- Once the visitor selects the "Visit" button to continue to the site, a cookie is set which prevents the interstitial from appearing for that domain for 7 days.
+- It tells visitors the site is served by ngrok.
+- When the visitor clicks **Visit** to continue, a cookie suppresses the interstitial for that domain for 7 days.
 
 <Note>
 This does not impact users serving APIs or accessing ngrok endpoints programmatically.
@@ -82,7 +79,7 @@ These requests will bypass the interstitial.
         });
       ```
     </Tab>
-    <Tab title="Fetch">    
+    <Tab title="Fetch">
       ```js
       const response = await fetch(URL, {
         headers: {
@@ -100,12 +97,12 @@ These requests will bypass the interstitial.
             .then(callback);
       ```
     </Tab>
-    <Tab title="JQuery">
+    <Tab title="jQuery">
       ```js
-      request
-            .get('/endpoint')
-            .set('ngrok-skip-browser-warning', '1')
-            .then(callback);
+      $.ajax({
+        url: '/endpoint',
+        headers: { 'ngrok-skip-browser-warning': '1' },
+      }).then(callback);
       ```
     </Tab>
   </Tabs>
@@ -118,8 +115,3 @@ Change your user agent by setting [the `User-Agent` header](https://developer.mo
 You can also use a browser extension to customize your browser's user agent value.
 Here's an [example for Chrome](https://chromewebstore.google.com/detail/requestly-intercept-modif/mdnleldcmiljblolnjhpnblkcekpdkpa?hl=en-US).
 </Tip>
-
-## I hit a limit on my plan or ran out of credit. What are my options?
-
-[Upgrade to a plan with higher limits](https://ngrok.com/pricing).
-If you want to ensure your endpoints are always online, choose the Pay-as-you-go plan.

--- a/pricing-limits/free-plan-limits.mdx
+++ b/pricing-limits/free-plan-limits.mdx
@@ -37,10 +37,10 @@ ngrok http 8080
 
 The dev domain is the only domain available on the free plan. Upgrading to a [paid plan](https://ngrok.com/pricing?ref=docs-domain-limits) unlocks:
 
-- **Custom domain names** — for example, `--url https://my-custom-name.ngrok.app`
+- **Custom domain names** for example, `--url https://my-custom-name.ngrok.app`
 - **Reserved static domains** you control
-- **Randomly generated URLs** — for example, `--url 'https://'`
-- **Your own domains** — for example, `app.yourdomain.com`
+- **Randomly generated URLs** for example, `--url 'https://'`
+- **Your own domains** for example, `app.yourdomain.com`
 - **Wildcard domains**
 
 ## Increasing your limits

--- a/pricing-limits/free-plan-limits.mdx
+++ b/pricing-limits/free-plan-limits.mdx
@@ -18,23 +18,15 @@ If you'd like to run your endpoint all the time, you can do so, on the free tier
 See [Pricing and Limits](https://ngrok.com/pricing?ref=docs) to learn how to increase or remove these limits.
 </Tip>
 
-## Limits and licensing
+## Plan limits and resources
 
-| Resource          | Limit on Free |
-| ----------------- | ------------- |
-| Data Transfer Out | 1 GB          |
-| Online Endpoints  | Up to 3       |
-| Requests          | 20,000        |
-| TCP Connections   | 5,000         |
-| TLS Connections   | Not Available |
-
-<Note>
-You can check your usage [in the Usage page in the dashboard](https://dashboard.ngrok.com/usage).
-</Note>
-
-## Free plan resources
+The free plan groups its limits into three kinds: **monthly usage quotas** that reset each billing cycle, **rate limits** that cap sustained throughput at any moment, and **concurrency and account limits** that apply at all times.
 
 <FreeResources />
+
+<Note>
+You can check your current usage against these limits [in the Usage page in the dashboard](https://dashboard.ngrok.com/usage).
+</Note>
 
 ## Domain limitations on free plan
 

--- a/snippets/shared/limits/free-resources.mdx
+++ b/snippets/shared/limits/free-resources.mdx
@@ -1,4 +1,4 @@
-**Monthly usage quotas** — these reset at the start of each monthly billing cycle.
+**Monthly usage quotas:** these reset at the start of each monthly billing cycle.
 
 | Resource                            | Limit on Free      |
 | ----------------------------------- | ------------------ |
@@ -9,14 +9,14 @@
 | Webhook verifications               | 500 / month        |
 | Traffic identities (OAuth/OIDC MAU) | 3 / month          |
 
-**Rate limits** — the maximum sustained throughput at any moment, separate from the monthly quotas above.
+**Rate limits:** the maximum sustained throughput at any moment, separate from the monthly quotas above.
 
 | Resource          | Limit on Free |
 | ----------------- | ------------- |
 | HTTP request rate | 4,000 / min   |
 | TCP connection rate | 100 / min   |
 
-**Concurrency and account limits** — apply at all times, not per month.
+**Concurrency and account limits:** these apply at all times, not per month.
 
 | Resource                          | Limit on Free |
 | --------------------------------- | ------------- |

--- a/snippets/shared/limits/free-resources.mdx
+++ b/snippets/shared/limits/free-resources.mdx
@@ -1,19 +1,35 @@
-| Resource                        | Limit on Free          |
-| ------------------------------- | ---------------------- |
-| Users                           | 1                      |
-| Online Endpoints                | Up to 3                |
-| Traffic Policy Rules per Policy | 5                      |
-| Development domain              | 1                      |
-| Concurrent Agents               | 3                      |
-| Data Transfer Out               | 1 GB/month             |
-| TCP Connection Rate             | 100/min                |
-| HTTP Request Rate               | 4,000/min              |
-| Logs/Events                     | Up to 10,000 per month |
-| Traffic Identities (OAuth/OIDC MAU) | Up to 3 per month  |
-| HTTP Requests                   | Up to 20,000/month     |
-| TCP Connections                 | Up to 5,000/month      |
-| TLS Connections                 | Not available          |
-| Webhook verifications           | Up to 500/month        |
+**Monthly usage quotas** — these reset at the start of each monthly billing cycle.
+
+| Resource                            | Limit on Free      |
+| ----------------------------------- | ------------------ |
+| Data transfer out                   | 1 GB / month       |
+| HTTP requests                       | 20,000 / month     |
+| TCP connections                     | 5,000 / month      |
+| Logs & events                       | 10,000 / month     |
+| Webhook verifications               | 500 / month        |
+| Traffic identities (OAuth/OIDC MAU) | 3 / month          |
+
+**Rate limits** — the maximum sustained throughput at any moment, separate from the monthly quotas above.
+
+| Resource          | Limit on Free |
+| ----------------- | ------------- |
+| HTTP request rate | 4,000 / min   |
+| TCP connection rate | 100 / min   |
+
+**Concurrency and account limits** — apply at all times, not per month.
+
+| Resource                          | Limit on Free |
+| --------------------------------- | ------------- |
+| Online endpoints                  | Up to 3       |
+| Concurrent agents                 | 3             |
+| Users                             | 1             |
+| Development domains               | 1             |
+| Traffic policy rules (per policy) | 5             |
+| TLS endpoints                     | Not available |
+
+<Note>
+Free plans include HTTPS endpoints with automatic TLS certificates and encryption. The **TLS endpoints** row above refers to [raw TLS endpoints](/gateway/tls/) that you terminate yourself, which require a paid plan.
+</Note>
 
 Features included for free on all plans:
 


### PR DESCRIPTION
## Why

Feedback that [`/docs/pricing-limits/free-plan-limits`](https://ngrok.com/docs/pricing-limits/free-plan-limits) is confusing. This PR does a clarity + tightening pass across the whole page. Root issues:

1. **Two near-duplicate limit tables.** The page rendered its own 5-row "Limits and licensing" table *and* the shared `FreeResources` snippet's 14-row table right below it — same values, different names (`Requests / 20,000` vs `HTTP Requests / Up to 20,000/month`).
2. **The snippet's table was flat and unordered**, mixing monthly quotas, per-minute rate limits, and concurrency/account limits with no units or reset semantics.
3. **Upgrade messaging repeated three times** — a top Tip, an "Increasing your limits" section, and a bottom FAQ that duplicated it nearly verbatim.
4. **Shouty, negative framing** in the domains section ("What you CAN / CANNOT do" bullet walls).
5. **A real bug:** the "jQuery" code tab actually contained Super Agent code.

## What changed

**`pricing-limits/free-plan-limits.mdx`**
- Removed the redundant top table; the `FreeResources` snippet is now the single source of truth, under one "Plan limits and resources" heading with a one-line explanation of the three limit types.
- Rewrote the domains section from "CAN / CANNOT" bullet walls into a positive "upgrading unlocks…" list (same examples, less noise).
- Deleted the bottom "I hit a limit…" FAQ that duplicated "Increasing your limits"; consolidated into one section.
- Fixed the **jQuery tab** (was Super Agent code) and corrected the tab label `JQuery` → `jQuery`.
- De-shouted the no-timeout note, tightened the interstitial intro, dropped trailing whitespace.

**`snippets/shared/limits/free-resources.mdx`** (shared; also renders on `pricing-limits/index.mdx`)
- Split the flat 14-row table into three labeled tables — **monthly usage quotas**, **rate limits**, **concurrency and account limits** — with consistent units.
- Relabeled "TLS Connections: Not Available" → "TLS endpoints" with a note distinguishing it from the HTTPS + automatic TLS certs that *are* included on free.

**No limit values were changed** — the numbers are identical; this is reorganization, labeling, and prose.

## Please verify before merge
- **TLS row:** confirm "TLS endpoints" (raw/self-terminated TLS) is the right interpretation of the old "TLS Connections: Not Available."
- **Reset timing:** I described monthly quotas as resetting "at the start of each monthly billing cycle" — confirm billing-cycle-based, not calendar-month.
- **Dev domain persistence:** I wrote the dev domain is "tied to your account" (implying it's stable/persistent). Confirm free dev domains don't rotate.
- **jQuery snippet:** quick sanity check on the replacement `$.ajax({ headers })` example.

Generated with [Claude Code](https://claude.com/claude-code)