### PR TITLE
Update BYO TLS Certificate Billing Information

### DIFF
--- a/gateway/tls-certificates.mdx
+++ b/gateway/tls-certificates.mdx
@@ -192,3 +192,13 @@ TLS certificates are managed programmatically via:
 
 TLS certificates are available on all plans. Bringing your own certificates is
 available on the Pay-as-you-go plan.
+
+Bring your own certificates are billed at a flat rate of $0.27/hour for any
+clock hour in which at least one endpoint using that certificate is active.
+
+<Note>
+Wildcard domains are not charged extra per matching subdomain. For example, if
+you upload a certificate for `*.acme.com`, endpoints on both `foo.acme.com`
+and `bar.acme.com` are covered by the same certificate and billed together
+as a single $0.27/hour charge, not billed separately per domain.
+</Note>

--- a/pricing-limits/how-ngrok-charges.mdx
+++ b/pricing-limits/how-ngrok-charges.mdx
@@ -58,7 +58,7 @@ description: Learn how ngrok applies feature and usage metrics to each payment p
 
 | Feature                                                                                                                           | Free Plan     | Hobbyist Plan | Pay-as-you-go Plan                                                                                                              |
 | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **Bring your own certificates** <br /> Upload your own TLS certificates instead of ngrok-provisioned certs. | Not available | Not available | $200 per cert/month |
+| **Bring your own certificates** <br /> Upload your own TLS certificates instead of ngrok-provisioned certs. Wildcard domains covered by the same certificate are not charged separately. See [TLS certificates pricing](/gateway/tls-certificates/#tls-certificates-pricing). | Not available | Not available | $0.27 per active hour |
 | **End-to-End TLS** <br /> Terminate TLS at your upstream or at the agent for end-to-end encryption. | Not available | Not available | Contact ngrok |
 | **Mutual TLS (mTLS)** <br /> Client and server authenticate each other using certificates. See [Traffic Policy](/traffic-policy/). | Not available | Not available | Available (see Traffic Policy) |
 

--- a/pricing-limits/index.mdx
+++ b/pricing-limits/index.mdx
@@ -40,12 +40,20 @@ These features are available as add-ons on the Pay-as-you-go plan:
 | ----------------------------- | ---------------------------- |
 | **SSO & RBAC**                | $10 per user/month           |
 | **Identity Governance Suite** | $15 per user/month           |
-| **Custom TLS Certificates**   | $200 per certificate/month   |
+| **Custom TLS Certificates**   | $0.27 per active hour   |
 | **Dedicated Agent IPs**       | $900 per month per region    |
 | **Custom Agent URLs**         | $250 per month per URL       |
 | **Log Exporting**             | $0.25 per 2,000 events       |
 | **Slack/Teams Support**       | $200 per month               |
 | **Dedicated On-Call Support** | Contact sales                |
+
+<Note>
+Custom TLS certificates are billed once per certificate for any hour in which
+at least one endpoint using that certificate is active. Wildcard domains
+covered by the same certificate (for example `foo.acme.com` and
+`bar.acme.com` under a `*.acme.com` certificate) are not charged
+separately — see [TLS certificates pricing](/gateway/tls-certificates/#tls-certificates-pricing).
+</Note>
 
 <Note>
 You can check your usage [in the ngrok dashboard](https://dashboard.ngrok.com/billing).


### PR DESCRIPTION
Resolves CDATA-996

### Why

The BYO TLS certificates page had no billing details, and two pricing tables elsewhere in the docs advertised a $200/certificate/month rate. Our pricing has instead been updated to only charge customers ($0.27/hour) whenever they have activity on their endpoint, so they are only billed when actually using the certification. This also adds clarification around how wildcard domains are billed, confirming that additional charges will not be incurred for using a wildcard.

See:
<img width="753" height="340" alt="image" src="https://github.com/user-attachments/assets/403c26a9-1c55-47c1-a5f5-467fafa9b1b2" />
