### PR TITLE
Fix a couple typos on the Start page and update the copy

### DIFF
--- a/start.mdx
+++ b/start.mdx
@@ -6,7 +6,8 @@ mode: center
 
 import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
 
-ngrok is an all-in-one cloud networking platform that secures, transforms, and routes your traffic to services running anywhere. From sharing localhost to production API gateways, ngrok handles it all.
+ngrok is an all-in-one cloud networking platform that secures, transforms, and routes your traffic to services running anywhere. 
+From sharing localhost to production API gateways, ngrok handles it all.
 
 <YouTubeEmbed videoId="trXqyNXJa1k" title="Here’s how teams are using ngrok in ways you might not expect." />
 
@@ -51,10 +52,10 @@ ngrok is an all-in-one cloud networking platform that secures, transforms, and r
 		Explore our example gallery to learn how to use ngrok as a gateway for your API, database, webhooks, and more, all protecting your services from malicious actors.
 	</Card>
 	<Card href="/traffic-policy/examples/" icon="diamond-turn-right" title="Traffic Policy Examples">
-		Use our Taffic Policy examples to get started routing, authenticating, filtering, and modifying headers on requests to your ngrok endpoints.
+		Use our Traffic Policy examples to get started routing, authenticating, filtering, and modifying headers on requests to your ngrok endpoints.
 	</Card>
 	<Card icon="book" href="/guides/" title="Guides">
-		Follow our guides on using ngrok for site-to-site connectivity, setting up gaming servers like mincraft, managing ingress to IoT devices, and more.
+		Follow our guides on using ngrok for site-to-site connectivity, setting up gaming servers like Minecraft, managing ingress to IoT devices, and more.
 	</Card>
 </Columns>
 

--- a/start.mdx
+++ b/start.mdx
@@ -9,7 +9,7 @@ import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
 ngrok is developer infrastructure that routes and secures traffic to your apps, APIs, and AI models. 
 We give you ways to manage connectivity between all of the tools and platforms you use to put your services online, no matter where they're deployed or what network they're on. 
 
-<YouTubeEmbed videoId="trXqyNXJa1k" title="Here's how teams are using ngrok in ways you might not expect." />
+<YouTubeEmbed videoId="trXqyNXJa1k" title="Here is how teams are using ngrok in ways you might not expect." />
 
 ## Problems we solve
 

--- a/start.mdx
+++ b/start.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get Started with ngrok
+title: Get started with ngrok
 description: ngrok makes it easy to put your apps, APIs, and services online.
 mode: center
 ---

--- a/start.mdx
+++ b/start.mdx
@@ -6,10 +6,10 @@ mode: center
 
 import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
 
-ngrok is an all-in-one cloud networking platform that secures, transforms, and routes your traffic to services running anywhere. 
-From sharing localhost to production API gateways, ngrok handles it all.
+ngrok is developer infrastructure that routes and secures traffic to your apps, APIs, and AI models. 
+We give you ways to manage connectivity between all of the tools and platforms you use to put your services online, no matter where they're deployed or what network they're on. 
 
-<YouTubeEmbed videoId="trXqyNXJa1k" title="Here’s how teams are using ngrok in ways you might not expect." />
+<YouTubeEmbed videoId="trXqyNXJa1k" title="Here's how teams are using ngrok in ways you might not expect." />
 
 ## Problems we solve
 

--- a/start.mdx
+++ b/start.mdx
@@ -73,5 +73,5 @@ We give you ways to manage connectivity between all of the tools and platforms y
 ## Learn about pricing <Icon icon="dollar-sign" size={24} />
 
 <Card href="/pricing-limits/">
-	Learn how ngrok's pricing breaks down based on usage for each account plan  <Icon icon="arrow-right" size={16} />
+	See how ngrok's pricing breaks down based on usage for each account plan.  <Icon icon="arrow-right" size={16} />
 </Card>


### PR DESCRIPTION
Noticed a couple typos on the Start page so I fixed those. Also added the latest "elevator pitch" copy describing what ngrok is at the top. Controversially I changed the title to sentence case - since we don't capitalize ngrok, "Get Started with ngrok" just looks kind of strange to me.  