### PR TITLE
ci(vale): report via Checks API so large PRs don't fail the check

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -73,14 +73,22 @@ jobs:
         uses: vale-cli/vale-action@2.1.2
         with:
           files: ${{ steps.changed-files.outputs.files }}
-          reporter: github-pr-review
-          # Report all issues in changed files, not only newly added lines.
-          # Vale line numbers can differ from diff positions after MDX parsing.
-          # Must be `file`, not `nofilter`: the review API cannot comment on files
-          # outside the PR diff, so reviewdog silently downgrades those findings to
-          # GitHub Actions log annotations, which are capped at 10 per step and error
-          # the run past that -- a red check with no review comments.
-          filter_mode: file
+          # Reports via the Checks API rather than the PR review API. The review
+          # reporter fetches the PR's unified diff to anchor its comments, and
+          # GitHub answers 406 "diff exceeded the maximum number of lines (20000)"
+          # on large PRs -- reviewdog treats that as fatal and exits non-zero, so
+          # the check went red on PR size alone with no findings to show for it.
+          # Note reviewdog calls Diff() unconditionally in Run(), so filter_mode
+          # cannot avoid that fetch; only the doghouse reporters (github-check,
+          # github-pr-check) take a path that skips it.
+          reporter: github-check
+          # Report all issues in the changed files, not only newly added lines:
+          # Vale's line numbers can drift from diff positions after MDX parsing.
+          # The "Get changed files" step above already scopes Vale to the PR's own
+          # files, so diff-based filtering here would be redundant as well as
+          # size-dependent. Findings on lines inside the diff still surface inline
+          # on Files changed; the rest land in the check run summary.
+          filter_mode: nofilter
           fail_on_error: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Vale check has been going red on PR size rather than on findings:

```
reviewdog: fail to get diff: GET .../pulls/2270: 406 Sorry, the diff exceeded the maximum number of lines (20000)
Error: Vale and reviewdog exited with status code: 1
```

## Cause

`reporter: github-pr-review` fetches the PR's unified diff to anchor review comments. GitHub refuses to serve a diff over 20,000 lines, reviewdog treats the 406 as fatal, and the step exits non-zero.

`fail_on_error: false` doesn't cover it — this isn't a lint finding. Vale itself completed fine and reported 11 issues on the run above.

Note the limit counts raw diff lines, not content lines, so a PR can trip it while looking like it shouldn't: #2270 is 19,578 content lines but 24,052 raw.

## Why not just `filter_mode: nofilter`

That was my first instinct and it's wrong. reviewdog calls `Diff()` unconditionally in `Run()`:

```go
d, err := w.d.Diff(ctx)
if err != nil {
    return fmt.Errorf("fail to get diff: %w", err)
}
```

The `EmptyDiff` short-circuit exists only for the `local` reporter, so no `filter_mode` value avoids the fetch. Only the doghouse reporters — `github-check`, `github-pr-check` — take a path that skips it. (Checked against `reviewdog/reviewdog@v0.17.0`, the version this action pins.)

## Change

- `reporter: github-pr-review` → `github-check`
- `filter_mode: file` → `nofilter`

Dropping diff-based filtering is safe here: the **Get changed files** step already scopes Vale to the PR's own files, so filtering was redundant as well as size-dependent.

`checks: write` is already in the job's `permissions`. `pull-requests: write` is now unused but left in place — happy to drop it if you'd rather tighten it.

## Trade-off

Findings move from PR review comments to check run annotations. Ones on lines inside the diff still render inline on **Files changed**; the rest go to the check run summary instead of being silently discarded, which is what `filter_mode: file` was doing to them.