### PR TITLE
Update AI gateway model catalog

### DIFF
--- a/ai-gateway/reference/model-catalog.mdx
+++ b/ai-gateway/reference/model-catalog.mdx
@@ -55,35 +55,44 @@ Other providers do need a key. For those, add your provider key in app.ngrok.ai.
 
 | Model ID | Display Name | Context Window | Output Tokens | Modalities |
 |----------|--------------|----------------|---------------|------------|
+| `gpt-5.6-luna` | GPT-5.6 Luna | 1,050,000 | 128,000 | text, image |
+| `gpt-5.6-terra` | GPT-5.6 Terra | 1,050,000 | 128,000 | text, image |
+| `gpt-5.6-sol` | GPT-5.6 Sol | 1,050,000 | 128,000 | text, image |
+| `gpt-5.5-pro` | GPT-5.5 Pro | 1,050,000 | 128,000 | text, image |
+| `gpt-5.5` | GPT-5.5 | 1,050,000 | 128,000 | text, image |
+| `gpt-5.4-nano` | GPT-5.4 Nano | 400,000 | 128,000 | text, image |
+| `gpt-5.4-mini` | GPT-5.4 Mini | 400,000 | 128,000 | text, image |
 | `gpt-5.4-pro` | GPT-5.4 Pro | 1,050,000 | 128,000 | text, image |
 | `gpt-5.4` | GPT-5.4 | 1,050,000 | 128,000 | text, image |
 | `gpt-5.3-codex` | GPT-5.3-Codex | 400,000 | 128,000 | text, image |
 | `gpt-5.2-codex` | GPT-5.2-Codex | 400,000 | 128,000 | text, image |
-| `gpt-5.2-pro` | GPT-5.2 Pro | 400,000 | 100,000 | text, image |
+| `gpt-5.2-pro` | GPT-5.2 Pro | 400,000 | 128,000 | text, image |
+| `gpt-5.2-chat-latest` | GPT-5.2 Chat Latest | 128,000 | 16,384 | text, image |
 | `gpt-5.2` | GPT-5.2 | 400,000 | 128,000 | text, image |
-| `gpt-5.2-chat-latest` | GPT-5.2 Chat Latest | 400,000 | 128,000 | text, image |
+| `gpt-5.1-chat-latest` | GPT-5.1 Chat Latest | 128,000 | 16,384 | text, image |
 | `gpt-5.1` | GPT-5.1 | 400,000 | 128,000 | text, image |
-| `gpt-5.1-chat-latest` | GPT-5.1 Chat Latest | 256,000 | 32,768 | text, image |
-| `gpt-5` | GPT-5 | 400,000 | 128,000 | text, image |
-| `gpt-5-mini` | GPT-5 Mini | 400,000 | 128,000 | text, image |
+| `gpt-5-pro` | GPT-5 Pro | 400,000 | 272,000 | text, image |
+| `gpt-5-chat-latest` | GPT-5 Chat | 128,000 | 16,384 | text, image |
 | `gpt-5-nano` | GPT-5 Nano | 400,000 | 128,000 | text, image |
-| `gpt-5-chat-latest` | GPT-5 Chat | 400,000 | 128,000 | text, image |
-| `gpt-4.1` | GPT-4.1 | 1,000,000 | - | text, image |
-| `gpt-4.1-mini` | GPT-4.1 mini | 1,000,000 | - | text, image |
-| `gpt-4.1-nano` | GPT-4.1 nano | 1,000,000 | - | text, image |
-| `gpt-4o` | GPT-4o | 128,000 | 16,384 | text, image, audio |
-| `gpt-4o-mini` | GPT-4o Mini | 128,000 | 16,384 | text, image |
-| `o4-mini` | O4-Mini | 200,000 | 100,000 | text |
-| `o4-mini-deep-research` | O4-Mini-Deep-Research | 200,000 | 100,000 | text |
-| `o3-pro` | O3-Pro | 128,000 | 100,000 | text |
-| `o3` | O3 | 128,000 | 100,000 | text |
+| `gpt-5-mini` | GPT-5 Mini | 400,000 | 128,000 | text, image |
+| `gpt-5` | GPT-5 | 400,000 | 128,000 | text, image |
+| `o3-deep-research` | O3-Deep-Research | 200,000 | 100,000 | text, image |
+| `o4-mini-deep-research` | O4-Mini-Deep-Research | 200,000 | 100,000 | text, image |
+| `o3-pro` | O3-Pro | 200,000 | 100,000 | text, image |
+| `o3` | O3 | 200,000 | 100,000 | text, image |
+| `o4-mini` | O4-Mini | 200,000 | 100,000 | text, image |
+| `gpt-4.1-nano` | GPT-4.1 nano | 1,047,576 | 32,768 | text, image |
+| `gpt-4.1-mini` | GPT-4.1 mini | 1,047,576 | 32,768 | text, image |
+| `gpt-4.1` | GPT-4.1 | 1,047,576 | 32,768 | text, image |
+| `o1-pro` | O1-Pro | 200,000 | 100,000 | text, image |
 | `o3-mini` | O3 Mini | 200,000 | 100,000 | text |
-| `o3-deep-research` | O3-Deep-Research | 200,000 | 100,000 | text |
-| `o1-pro` | O1-Pro | 200,000 | 100,000 | text |
-| `o1` | O1 | 128,000 | 100,000 | text |
+| `o1` | O1 | 200,000 | 100,000 | text, image |
+| `gpt-4o-mini` | GPT-4o Mini | 128,000 | 16,384 | text, image |
+| `gpt-4o` | GPT-4o | 128,000 | 16,384 | text, image |
 | `gpt-4-turbo` | GPT-4 Turbo | 128,000 | 4,096 | text, image |
+| `gpt-3.5-turbo-instruct` | GPT-3.5 Turbo Instruct | 4,096 | 4,096 | text |
 | `gpt-4` | GPT-4 | 8,192 | 8,192 | text |
-| `gpt-3.5-turbo` | GPT-3.5 Turbo _(deprecated, retires September 28, 2026)_ | 16,385 | 4,096 | text |
+| `gpt-3.5-turbo` | GPT-3.5 Turbo | 16,385 | 4,096 | text |
 
 ---
 
@@ -103,15 +112,17 @@ Other providers do need a key. For those, add your provider key in app.ngrok.ai.
 
 | Model ID | Display Name | Context Window | Output Tokens | Modalities |
 |----------|--------------|----------------|---------------|------------|
-| `claude-opus-4-6` | Claude Opus 4.6 | 1,000,000 | 128,000 | text, image |
-| `claude-sonnet-4-6` | Claude Sonnet 4.6 | 1,000,000 | 64,000 | text, image |
-| `claude-haiku-4-5` | Claude Haiku 4.5 | 200,000 | 64,000 | text, image |
-| `claude-sonnet-4-5` | Claude Sonnet 4.5 | 1,000,000 | 64,000 | text, image |
-| `claude-opus-4-5` | Claude Opus 4.5 | 200,000 | 64,000 | text, image |
-| `claude-opus-4-1` | Claude Opus 4.1 | 200,000 | 32,000 | text, image |
-| `claude-sonnet-4-0` | Claude Sonnet 4 | 1,000,000 | 64,000 | text, image |
-| `claude-opus-4-0` | Claude Opus 4 | 200,000 | 32,000 | text, image |
-| `claude-3-haiku-20240307` | Claude Haiku 3 _(deprecated, retires April 20, 2026)_ | 200,000 | 4,096 | text, image |
+| `claude-opus-5` | Claude Opus 5 | 1,000,000 | 128,000 | text, image, file |
+| `claude-sonnet-5` | Claude Sonnet 5 | 1,000,000 | 128,000 | text, image, file |
+| `claude-fable-5` | Claude Fable 5 | 1,000,000 | 128,000 | text, image, file |
+| `claude-opus-4-8` | Claude Opus 4.8 | 1,000,000 | 128,000 | text, image, file |
+| `claude-opus-4-7` | Claude Opus 4.7 | 1,000,000 | 128,000 | text, image, file |
+| `claude-sonnet-4-6` | Claude Sonnet 4.6 | 1,000,000 | 128,000 | text, image, file |
+| `claude-opus-4-6` | Claude Opus 4.6 | 1,000,000 | 128,000 | text, image, file |
+| `claude-opus-4-5` | Claude Opus 4.5 | 200,000 | 64,000 | text, image, file |
+| `claude-haiku-4-5` | Claude Haiku 4.5 | 200,000 | 64,000 | text, image, file |
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 | 200,000 | 64,000 | text, image, file |
+| `claude-opus-4-1` | Claude Opus 4.1 | 200,000 | 32,000 | text, image, file |
 
 ---
 
@@ -131,12 +142,16 @@ Other providers do need a key. For those, add your provider key in app.ngrok.ai.
 
 | Model ID | Display Name | Context Window | Output Tokens | Modalities |
 |----------|--------------|----------------|---------------|------------|
-| `gemini-2.5-pro` | Gemini 2.5 Pro | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.5-flash` | Gemini 2.5 Flash | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1,048,576 | 65,535 | text, image, audio, video, file |
-| `gemini-2.0-flash` | Gemini 2.0 Flash | 1,048,576 | 8,192 | text, image, audio, video, file |
-| `gemini-2.0-flash-lite` | Gemini 2.0 Flash-Lite | 1,048,576 | 8,192 | text, image, audio, video, file |
-| `gemini-3-pro-preview` | Gemini 3 Pro Preview | 1,000,000 | 65,536 | text, image, audio, video, file |
+| `gemini-3.5-flash-lite` | Gemini 3.5 Flash-Lite | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3.6-flash` | Gemini 3.6 Flash | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3.5-flash` | Gemini 3.5 Flash | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash-Lite | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-3-flash-preview` | Gemini 3 Flash Preview | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | 1,048,576 | 65,536 | text, image, audio, video, file |
+| `gemini-2.5-pro` | Gemini 2.5 Pro | 1,048,576 | 65,536 | text, image, audio, video, file |
 
 ---
 
@@ -156,8 +171,8 @@ Other providers do need a key. For those, add your provider key in app.ngrok.ai.
 
 | Model ID | Display Name | Context Window | Output Tokens | Modalities |
 |----------|--------------|----------------|---------------|------------|
-| `deepseek-reasoner` | deepseek-reasoner | 128,000 | 64,000 | text |
-| `deepseek-chat` | deepseek-chat | 128,000 | 8,192 | text |
+| `deepseek-v4-flash` | DeepSeek V4 Flash | 1,000,000 | 384,000 | text |
+| `deepseek-v4-pro` | DeepSeek V4 Pro | 1,000,000 | 384,000 | text |
 
 ---
 
@@ -178,18 +193,73 @@ Groq provides AI inference powered by their custom LPU (Language Processing Unit
 
 | Model ID | Display Name | Context Window | Output Tokens | Modalities |
 |----------|--------------|----------------|---------------|------------|
-| `meta-llama/llama-3.1-8b-instant` | Llama 3.1 8B Instant | 131,072 | 131,072 | text |
-| `meta-llama/llama-3.3-70b-versatile` | Llama 3.3 70B Versatile | 131,072 | 32,768 | text |
-| `meta-llama/llama-prompt-guard-2-22m` | Llama Prompt Guard 2 22M | 512 | 512 | text |
+| `openai/gpt-oss-safeguard-20b` | GPT-OSS Safeguard 20B | 131,072 | 65,536 | text |
+| `openai/gpt-oss-20b` | GPT OSS 20B | 131,072 | 65,536 | text |
+| `openai/gpt-oss-120b` | GPT OSS 120B | 131,072 | 65,536 | text |
 | `meta-llama/llama-prompt-guard-2-86m` | Llama Prompt Guard 2 86M | 512 | 512 | text |
-| `meta-llama/llama-guard-4-12b` | Llama Guard 4 12B | 131,072 | 1,024 | text, image |
-| `meta-llama/llama-4-maverick-17b-128e-instruct` | Llama 4 Maverick 17B 128E Instruct | 131,072 | 8,192 | text, image |
-| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout 17B 16E Instruct | 131,072 | 8,192 | text, image |
-| `moonshotai/kimi-k2-instruct-0905` | Kimi K2 | 262,144 | 16,384 | text |
-| `openai/gpt-oss-120b` | GPT OSS 120B | 131,072 | 131,072 | text |
-| `openai/gpt-oss-20b` | GPT OSS 20B | 131,072 | 131,072 | text |
-| `openai/gpt-oss-safeguard-20b` | Safety GPT OSS 20B | 131,072 | 65,536 | text |
+| `meta-llama/llama-prompt-guard-2-22m` | Llama Prompt Guard 2 22M | 512 | 512 | text |
+| `meta-llama/llama-3.3-70b-versatile` | Llama 3.3 70B Versatile | 131,072 | 32,768 | text |
+| `meta-llama/llama-3.1-8b-instant` | Llama 3.1 8B Instant | 131,072 | 131,072 | text |
+
+{/* Groq's supported-models page no
+longer lists these models, and its deprecation notice says both were shut down on July
+17, 2026.
+
 | `qwen/qwen3-32b` | Qwen3-32B | 131,072 | 40,960 | text |
+| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout 17B 16E Instruct | 131,072 | 8,192 | text, image |
+*/}
+
+---
+
+### Moonshot AI
+
+| Field | Value |
+|-------|-------|
+| **Provider ID** | `moonshotai` |
+| **Aliases** | `Moonshot AI`, `Moonshot`, `Kimi`, `kimi.ai`, `kimi-ai` |
+| **Base URL** | `https://api.moonshot.ai/v1` |
+| **Website** | [moonshot.ai](https://www.moonshot.ai/) |
+| **Provider key required** | Yes |
+
+#### Moonshot AI models
+
+| Model ID | Display Name | Context Window | Output Tokens | Modalities |
+|----------|--------------|----------------|---------------|------------|
+| `kimi-k3` | Kimi K3 | 1,048,576 | 1,048,576 | text, image, video |
+| `kimi-k2.7-code-highspeed` | Kimi K2.7 Code HighSpeed | 262,144 | 262,144 | text, image, video |
+| `kimi-k2.7-code` | Kimi K2.7 Code | 262,144 | 262,144 | text, image, video |
+| `kimi-k2.6` | Kimi K2.6 | 262,144 | 262,144 | text, image, video |
+
+---
+
+### Z.ai
+
+| Field | Value |
+|-------|-------|
+| **Provider ID** | `z-ai` |
+| **Aliases** | `Z.ai`, `ZhipuAI`, `Zhipu AI`, `zhipu-ai` |
+| **Base URL** | `https://api.z.ai/api/paas/v4` |
+| **Website** | [z.ai](https://z.ai/model-api) |
+| **Provider key required** | Yes |
+
+#### Z.ai models
+
+| Model ID | Display Name | Context Window | Output Tokens | Modalities |
+|----------|--------------|----------------|---------------|------------|
+| `glm-5.2` | GLM-5.2 | 1,000,000 | 131,072 | text |
+| `glm-5.1` | GLM-5.1 | 200,000 | 131,072 | text |
+| `glm-5-turbo` | GLM-5-Turbo | 200,000 | 131,072 | text |
+| `glm-5` | GLM-5 | 200,000 | 131,072 | text |
+| `glm-4.7-flash` | GLM-4.7-Flash | 200,000 | 131,072 | text |
+| `glm-4.7-flashx` | GLM-4.7-FlashX | 200,000 | 131,072 | text |
+| `glm-4.7` | GLM-4.7 | 200,000 | 131,072 | text |
+| `glm-4.6` | GLM-4.6 | 200,000 | 131,072 | text |
+| `glm-4.5-flash` | GLM-4.5-Flash | 128,000 | 98,304 | text |
+| `glm-4.5-airx` | GLM-4.5-AirX | 128,000 | 98,304 | text |
+| `glm-4.5-air` | GLM-4.5-Air | 128,000 | 98,304 | text |
+| `glm-4.5-x` | GLM-4.5-X | 128,000 | 98,304 | text |
+| `glm-4.5` | GLM-4.5 | 128,000 | 98,304 | text |
+| `glm-4-32b-0414-128k` | GLM-4-32B-0414-128K | 128,000 | 16,000 | text |
 
 ---
 
@@ -305,6 +375,8 @@ The following aliases are available in addition to the primary IDs listed above.
 | `inceptionlabs` | `inception-labs`, `inception` |
 | `inference.net` | `inference-net`, `inference_net` |
 | `groq` | `groqcloud` |
+| `moonshotai` | `Moonshot AI`, `Moonshot`, `Kimi`, `kimi.ai`, `kimi-ai` |
+| `z-ai` | `Z.ai`, `ZhipuAI`, `Zhipu AI`, `zhipu-ai` |
 
 ### OpenAI model aliases
 
@@ -375,7 +447,7 @@ The following aliases are available in addition to the primary IDs listed above.
 | `llama-3.1-8b` | `llama-3.1-8b-instant` |
 | `llama-3.3-70b` | `llama-3.3-70b-versatile` |
 | `llama-4-maverick-17b-128e` | `llama-4-maverick-17b-128e-instruct` |
-| `llama-4-scout-17b-16e` | `llama-4-scout-17b-16e-instruct` |
+{/* `llama-4-scout-17b-16e` resolves to `llama-4-scout-17b-16e-instruct`; the target model is commented out above because Groq shut it down on July 17, 2026. */}
 
 ### Moonshot AI model aliases
 


### PR DESCRIPTION
  - Add Moonshot AI and Z.ai models and provider metadata
  - Update model limits, modalities, display names, aliases, and ordering
  - Sort each provider catalog newest to oldest by release date
  - Preserve but comment out shut-down Groq models
