### PR TITLE
Update connect-url.mdx for connect_cas

### DIFF
--- a/agent/connect-url.mdx
+++ b/agent/connect-url.mdx
@@ -121,7 +121,7 @@ When you create a custom Connect URL, choose one of two certificate issuers:
 
 - Public CA; useful when corporate proxies or network devices cannot trust
   a private CA.
-- May require setting `root_cas: host` (or providing the Let's Encrypt root)
+- May require setting `connect_cas: host` (or providing the Let's Encrypt root)
   for some SDKs and for the SSH Reverse Tunnel agent.
 - Provisioning can take time (DNS propagation). ngrok issues a temporary
   certificate until Let's Encrypt is ready. Even if DNS checks pass in the


### PR DESCRIPTION
Updated Let's Encrypt section to use connect_cas: host instead of the older root_cas: host

https://ngrok.com/docs/agent/config/v3#connect_cas