### PR TITLE
Add Okta OIDC dashboard SSO guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1002,6 +1002,7 @@
             "group": "Dashboard SSO",
             "pages": [
               "integrations/dashboard-sso/auth0-dashboard-sso-saml",
+              "integrations/dashboard-sso/okta-dashboard-sso-oidc",
               "integrations/dashboard-sso/okta-dashboard-sso-saml",
               "integrations/dashboard-sso/okta-dashboard-sso-scim",
               "integrations/dashboard-sso/salesforce-dashboard-sso-oidc"
@@ -1869,10 +1870,6 @@
     ]
   },
   "redirects": [
-    {
-      "source": "/integrations/dashboard-sso/okta-dashboard-sso-oidc",
-      "destination": "/integrations/dashboard-sso/okta-dashboard-sso-saml"
-    },
     {
       "source": "/getting-started",
       "destination": "/start"

--- a/integrations/dashboard-sso/okta-dashboard-sso-oidc.mdx
+++ b/integrations/dashboard-sso/okta-dashboard-sso-oidc.mdx
@@ -1,0 +1,37 @@
+---
+title: Configure Okta Single Sign-On (SSO) Using OpenID Connect (OIDC)
+sidebarTitle: Okta (OpenID Connect)
+description: Configure Okta single sign-on (SSO) with OpenID Connect (OIDC) to sign in to the ngrok dashboard.
+---
+
+This guide explains how to use Okta as an identity provider for single sign-on (SSO) into the ngrok dashboard, using OpenID Connect (OIDC). If you want to use SAML instead, see [Configure Okta Single Sign-On (SSO)](./okta-dashboard-sso-saml). It does not cover configuring an ngrok endpoint so that your [application users can log in using Okta](../endpoint-sso/okta-sso-oidc).
+
+## What you'll need
+
+- Admin access to create new applications in Okta.
+- Admin access to edit your ngrok account settings.
+- An [ngrok Pay-as-you-go account](https://ngrok.com/pricing), with the [SSO/RBAC add-on](https://ngrok.com/pricing#identity-and-acces)
+
+## 1. Create a new OIDC app integration in Okta
+
+- From the **Applications** menu, click **Create App Integration**.
+- Select **OIDC - OpenID Connect**, then click **Next**.
+- Select **Web Application**, then click **Next**.
+- Give your app a name, then click **Next**.
+- Under **Sign-in redirect URIs**, enter `https://idp.ngrok.com/oauth2/callback`.
+- Click **Save**.
+- On the **Assignments** tab, assign the users or groups that need dashboard access.
+- On the **General** tab, copy the **Client ID** and **Client Secret**. You'll need these values for the ngrok side.
+
+## 2. Configure SSO for your ngrok account
+
+- Log into your ngrok dashboard and go to **Settings > Account**.
+- Click **+ New Identity Provider**, then select **New OpenID Connect Provider**.
+- Set **Issuer URL** to your Okta org URL, for example `https://{yourOktaDomain}.okta.com`.
+- Enter the **Client ID** and **Client Secret** from Okta.
+- In the **Scopes** field, add the required `email` scope. You can optionally add the `profile` scope too to show a user's name instead of their email address.
+- Click **Save**.
+
+You can now log in to your ngrok account by authenticating with Okta.
+
+By default, your ngrok account allows users to log in with their existing credentials and through Okta ("Mixed Mode"). After you confirm the integration works, turn on **SSO Enforced** in the ngrok dashboard to require all new users to log in with Okta SSO.


### PR DESCRIPTION
## Summary
- Adds the missing Okta OIDC guide for Dashboard SSO (`integrations/dashboard-sso/okta-dashboard-sso-oidc.mdx`), covering the Okta app setup and ngrok Identity Provider config, including the required `email` OAuth scope.
- Removes the `docs.json` redirect that previously sent this URL to the Okta SAML guide, and adds the new page to the Dashboard SSO nav group.

Prompted by a support ticket where a customer's OIDC login failed because the `email` scope wasn't requested, and where the docs link for Okta OIDC redirected to the SAML setup instead of real OIDC steps.

## Test plan
- [x] Preview the new page renders correctly in Mintlify
- [x] Confirm `/integrations/dashboard-sso/okta-dashboard-sso-oidc` no longer redirects and shows the new content
- [x] Confirm the page appears in the Dashboard SSO sidebar group