### PR TITLE
Update agent connect url pricing

### DIFF
--- a/agent/connect-url.mdx
+++ b/agent/connect-url.mdx
@@ -29,7 +29,7 @@ Key points:
   ngrok account; connections using credentials from other accounts are rejected.
 - Custom agent connect URLs support both ngrok‑issued and Let's Encrypt certificates.
 
-### Create a custom connect URL
+### Create a custom agent connect URL
 
 1. Choose a domain you own
 

--- a/agent/connect-url.mdx
+++ b/agent/connect-url.mdx
@@ -1,7 +1,7 @@
 ---
-title: Connect URLs
-sidebarTitle: Using Connect URLs
-description: Learn how to customize the connect URL the ngrok agent uses to authenticate access to the ngrok service.
+title: Agent Connect URLs
+sidebarTitle: Using Agent Connect URLs
+description: Learn how to customize the URL the ngrok agent uses to authenticate access to the ngrok service.
 ---
 
 import CustomIngressAgentCliExample from "/snippets/examples/agent-cli/custom-agent-ingress.mdx";
@@ -12,22 +12,22 @@ import CustomIngressPythonSdkExample from "/snippets/examples/python-sdk/custom-
 import CustomIngressRustSdkExample from "/snippets/examples/rust-sdk/custom-agent-ingress.mdx";
 import CustomIngressSshExample from "/snippets/examples/ssh/custom-agent-ingress.mdx";
 
-The Connect URL is the hostname and port the ngrok agent (and agent SDKs) uses to
+The Agent Connect URL is the hostname and port the ngrok agent (and agent SDKs) uses to
 establish its control connection to the ngrok service. By default, agents use
 `connect.ngrok-agent.com:443`. You can change this per agent by setting the
 [`connect_url`](/agent/config/v3/#connect-url) field in your configuration file.
 
-## Custom connect URL 
+## Custom agent connect URL 
 
-Create a custom Connect URL to customize how your agents connect (for example
+Create a custom agent connect URL to customize how your agents connect (for example
 `connect.example.com:443`). This involves delegating a DNS subdomain and
 configuring certificates for the new address.
 
 Key points:
 
-- Agents connecting via your custom Connect URL must authenticate to your
+- Agents connecting via your custom agent connect URL must authenticate to your
   ngrok account; connections using credentials from other accounts are rejected.
-- Custom Connect URLs support both ngrok‑issued and Let's Encrypt certificates.
+- Custom agent connect URLs support both ngrok‑issued and Let's Encrypt certificates.
 
 ### Create a custom connect URL
 
@@ -36,7 +36,7 @@ Key points:
 - You will delegate a subdomain via `NS` records to ngrok so it can manage the
   required DNS (A/AAAA) and certificates.
 
-2. Create the Connect URL entry
+2. Create the agent connect URL entry
 
 - In the Dashboard: https://dashboard.ngrok.com/connect-urls
 - Or via API: [/api-reference/agentingresses/list/](/api-reference/agentingresses/list/)
@@ -51,14 +51,14 @@ Key points:
 After creation, the Dashboard prompts you to add `NS` records for the selected
 subdomain at your DNS provider.
 
-### Update Agent configuration
+### Update ngrok agent configuration
 
 Point your agents at the new address by setting
 [`connect_url`](/agent/config/v3/#connect-url). The helper command
 [`ngrok config add-connect-url`](/agent/cli/#ngrok-config-add-connect-url) can
 update your config for you.
 
-For example, if the domain of your custom Connect URL is
+For example, if the domain of your custom agent connect URL is
 `connect.example.com` then you might add the following line to the agent's
 configuration file:
 
@@ -91,24 +91,24 @@ configuration file:
 
 ## Regional scope and GSLB
 
-Custom Connect URLs are pinned to a specific region for the agent's control
+Custom agent connect URLs are pinned to a specific region for the agent's control
 connection and do not use
 [Global Server Load Balancing](/domains/global-load-balancer/) for that
 connection. End-user traffic to your endpoints is still delivered using GSLB.
 
 ## Dedicated IPs
 
-When you create a custom Connect URL, the DNS and certificates are branded to your domain, but the address still resolves to ngrok's shared IPs. 
+When you create a custom agent connect URL, the DNS and certificates are branded to your domain, but the address still resolves to ngrok's shared IPs. 
 If you need static, account-unique addresses, dedicated IPs are available. [Contact Sales](mailto:sales@ngrok.com?subject=Dedicated+Ingress+IPs) for details.
 
 ## Certificate issuer
 
-When you create a custom Connect URL, choose one of two certificate issuers:
+When you create a custom agent connect URL, choose one of two certificate issuers:
 
 - ngrok's internal CA
 - [Let's Encrypt](https://letsencrypt.org/)
 
-<img src="/img/docs/new-connect-url-dialog.png" alt="ngrok dashboard New Connect URL dialog with Domain, Description, and Certificate Issuer fields" width="946" height="632" />
+<img src="/img/docs/new-connect-url-dialog.png" alt="ngrok dashboard new agent connect URL dialog with Domain, Description, and Certificate Issuer fields" width="946" height="632" />
 
 ### ngrok internal CA
 
@@ -127,7 +127,7 @@ When you create a custom Connect URL, choose one of two certificate issuers:
   certificate until Let's Encrypt is ready. Even if DNS checks pass in the
   Dashboard, Let's Encrypt may still be propagating.
 
-If you select Let's Encrypt, the Connect URL drawer shows a status card while
+If you select Let's Encrypt, the agent connect URL drawer shows a status card while
 the certificate is provisioning:
 
 <img src="/img/docs/certificate-provisioning-delayed-banner.png" alt="ngrok dashboard certificate provisioning delayed warning banner with a link to contact support" width="590" height="162" />
@@ -137,22 +137,22 @@ Certificates issued by Let's Encrypt through ngrok are securely managed.
 Private keys are not exposed to requesters.
 </Note>
 
-## Why customize the connect URL?
+## Why customize the agent connect URL?
 
 ### Branded connectivity
 
 If you use ngrok for production connectivity (devices in the field or customer
-environments), a custom Connect URL lets you brand connectivity with your
+environments), a custom agent connect URL lets you brand connectivity with your
 domain.
 
 ### Policy enforcement
 
-For development and testing, a custom Connect URL helps enforce policy:
+For development and testing, a custom agent connect URL helps enforce policy:
 
 - Ensure developers use a shared ngrok account (not personal accounts).
-- Block default Connect URLs on corp networks while allowing your custom URL.
+- Block default agent connect URLs on corp networks while allowing your custom URL.
 
-## Connect URL pricing
+## Agent connect URL pricing
 
-Custom Connect URLs are not available on self‑serve plans.
-[Contact Sales](mailto:sales@ngrok.com?subject=Custom+Connect+URL) to discuss options.
+Custom agent connect URLs are available on the Pay-as-you-go plan, billed at $0.06
+per endpoint hour. See [pricing](https://ngrok.com/pricing) for details.

--- a/agent/connect-url.mdx
+++ b/agent/connect-url.mdx
@@ -154,5 +154,5 @@ For development and testing, a custom agent connect URL helps enforce policy:
 
 ## Agent connect URL pricing
 
-Custom agent connect URLs are available on the Pay-as-you-go plan, billed at $0.06
-per endpoint hour. See [pricing](https://ngrok.com/pricing) for details.
+Custom agent connect URLs are available on the Pay-as-you-go plan, billed by active endpoint hour. See
+[pricing](https://ngrok.com/pricing) for complete pricing details.

--- a/pricing-limits/how-ngrok-charges.mdx
+++ b/pricing-limits/how-ngrok-charges.mdx
@@ -95,7 +95,7 @@ description: Learn how ngrok applies feature and usage metrics to each payment p
 | ------------------------------------------------------------------------------------------- | ------------- | ------------- | ---------------------------------------------------- |
 | **Concurrent Agents** <br /> Number of agents that can be connected at the same time.       | 3             | 3             | Unlimited                                            |
 | **Dedicated Agent Connect IPs** <br /> A constant, dedicated IP for your account's agents.  | Not available | Not available | $900 per month per region (contact ngrok)             |
-| **Custom Agent Connect URLs** <br /> Customize the URL that the agent connects to.          | Not available | Not available | $250 per month per URL (contact ngrok)                |
+| **Custom Agent Connect URLs** <br /> Customize the URL that the agent connects to.          | Not available | Not available | $0.06 per endpoint hour                               |
 | **Remote Agent Update Operations** <br /> Run ngrok as a service; remotely stop, restart, or update agents from the Dashboard. | Stop, Restart | Stop, Restart | Stop, Restart, Update |
 
 ---

--- a/pricing-limits/how-ngrok-charges.mdx
+++ b/pricing-limits/how-ngrok-charges.mdx
@@ -95,7 +95,7 @@ description: Learn how ngrok applies feature and usage metrics to each payment p
 | ------------------------------------------------------------------------------------------- | ------------- | ------------- | ---------------------------------------------------- |
 | **Concurrent Agents** <br /> Number of agents that can be connected at the same time.       | 3             | 3             | Unlimited                                            |
 | **Dedicated Agent Connect IPs** <br /> A constant, dedicated IP for your account's agents.  | Not available | Not available | $900 per month per region (contact ngrok)             |
-| **Custom Agent Connect URLs** <br /> Customize the URL that the agent connects to.          | Not available | Not available | $0.06 per endpoint hour                               |
+| **Custom Agent Connect URLs** <br /> Customize the URL that the agent connects to.          | Not available | Not available | $0.068 per endpoint hour (volume discounts)           |
 | **Remote Agent Update Operations** <br /> Run ngrok as a service; remotely stop, restart, or update agents from the Dashboard. | Stop, Restart | Stop, Restart | Stop, Restart, Update |
 
 ---


### PR DESCRIPTION
custom agent connect url pricing is now hourly and self-serve, as opposed to fixed fee and via sales.