### PR TITLE
docs(k8s): cover 1.0.0 private connectivity in egress requirements (parked until 1.0.0)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -554,6 +554,7 @@
               {
                 "group": "Manage",
                 "pages": [
+                  "k8s/installation/network-egress",
                   "k8s/installation/update",
                   "k8s/installation/helm",
                   "k8s/installation/observability",

--- a/gateway/running-behind-firewalls.mdx
+++ b/gateway/running-behind-firewalls.mdx
@@ -8,6 +8,10 @@ When you need to deploy ngrok behind a corporate firewall, there may be addition
 
 As background, this is usually not an issue. Firewalls usually allow outbound connections, which is what an ngrok Agent makes to establish a session with the ngrok service and subsequently your tunnel.
 
+<Note>
+Running the ngrok Kubernetes Operator instead of the agent? Its egress requirements differ. See [network egress requirements](/k8s/installation/network-egress) for the hosts and ports to allow.
+</Note>
+
 However, certain corporate firewalls have more restrictions around outbound connections. For example, ngrok may be blocked on Fortinet firewalls.
 
 If you're having trouble using the ngrok agent to start a tunnel, the first step is to run [`ngrok diagnose`](/agent/diagnose) which will produce a report that will help you identify connection issues.

--- a/k8s/guides/troubleshooting.mdx
+++ b/k8s/guides/troubleshooting.mdx
@@ -152,6 +152,10 @@ If you've added several resources such as domains and endpoints, you may encount
 If you are on the pay-as-you-go plan, then you will not encounter this issue and you will be able to create resources freely and only be billed for the resources you create.
 Check with the [pricing and limits page](/pricing-limits/) for information about each plan and any limits associated with it.
 
+## Operator can't reach ngrok
+
+If the Operator logs show connection or session errors, its outbound traffic may be blocked. Clusters with a default-deny egress policy need the ngrok hostnames allowlisted. See [network egress requirements](/k8s/installation/network-egress) for the hosts and ports to allow, and for a `Job` you can run to test connectivity from inside the cluster.
+
 ## Still need help?
 
 If you aren't able to identify and resolve your issue, head over to the [support page](https://ngrok.com/support) to reach out to ngrok support.

--- a/k8s/installation/network-egress.mdx
+++ b/k8s/installation/network-egress.mdx
@@ -1,0 +1,99 @@
+---
+title: ngrok Kubernetes Operator Network Egress Requirements
+sidebarTitle: Network Egress
+description: Learn which outbound hostnames and ports the ngrok Kubernetes Operator needs so you can allowlist it through a default-deny egress firewall.
+---
+
+import EgressFqdns from "/snippets/k8s/_egress-fqdns.mdx";
+
+The ngrok Kubernetes Operator reaches ngrok over a small number of outbound connections. In most clusters this works without any extra configuration, since outbound connections on port `443` are usually allowed by default.
+
+Some environments are more restrictive. If your cluster runs under a default-deny egress policy (common on private EKS clusters and other locked-down networks), outbound traffic is blocked unless you explicitly allow it. This page lists the hostnames and ports you'll need to allow so the Operator can start, sync your resources, and serve traffic. Every connection the Operator makes to ngrok is outbound over TLS on port `443`, so your firewall only needs egress rules, not inbound ones.
+
+<Note>
+ngrok's cloud service uses a dynamic, rotating set of IP addresses that can change without notice, so you can't allowlist it by IP. Allow traffic by hostname (FQDN) instead. This means a standard Kubernetes `NetworkPolicy`, which matches on IP/CIDR, isn't enough on its own. You'll need an egress firewall or proxy that supports FQDN-based rules, or a CNI that adds FQDN matching (such as Cilium's `toFQDNs`). See [ngrok IP addresses](/domains/ip-addresses) for more detail.
+</Note>
+
+## Required egress
+
+Every Operator installation needs to reach these hosts:
+
+<EgressFqdns />
+
+If you only expose inbound services (for example, running the Operator as a webhook gateway), these two hosts plus the image registry below are all you need. The section on endpoint bindings applies only if you turn that feature on.
+
+## Installation and upgrades
+
+You install and upgrade the Operator with Helm, which pulls two container images from Docker Hub:
+
+- `docker.io/ngrok/ngrok-operator`, the image for the Operator's deployments: the API manager, the agent, and, when endpoint bindings are enabled, the bindings forwarder.
+- `docker.io/bitnami/kubectl`, used only by the pre-delete cleanup job when you uninstall.
+
+To pull these, allow Docker Hub's registry and content-delivery hosts on TCP port `443`:
+
+- `registry-1.docker.io`
+- `auth.docker.io`
+- `production.cloudflare.docker.com`
+
+If your policy is to avoid Docker Hub entirely, mirror both images to a private registry (such as Amazon ECR) and point the `image.registry` and `cleanupHook.image.repository` Helm values at your mirror. In that case you allow your own registry instead of the hosts above.
+
+<Note>
+Bitnami changed how it distributes images on Docker Hub in 2025. If you run in an air-gapped or mirrored environment, plan to mirror `bitnami/kubectl` (or set `cleanupHook.image.repository` to a `kubectl` image you control) rather than relying on it being pulled at uninstall time.
+</Note>
+
+## Endpoint bindings
+
+[Endpoint bindings](/k8s/guides/bindings) are disabled by default (`bindings.enabled: false`), so skip this section unless you turn them on. When enabled, the bindings forwarder opens an additional connection to carry that traffic. Allow this host on TCP port `443`:
+
+- `kubernetes-binding-ingress.ngrok.io`
+
+The forwarder connects to the bound endpoint host your ngrok account returns, which defaults to `kubernetes-binding-ingress.ngrok.io`. If your account uses a different host, allow that one instead.
+
+## Verify connectivity from the cluster
+
+To check connectivity from where your pods actually run, you can run [`ngrok diagnose`](/agent/diagnose) as a `Job`, using the [pre-built agent image](https://hub.docker.com/r/ngrok/ngrok). This checks name resolution, TCP, and TLS to `connect.ngrok-agent.com`.
+
+<Note>
+`ngrok diagnose` only exercises the agent connect host, not `api.ngrok.com` or the bindings host. To check those, run a shell in the cluster and test them directly, for example `curl -sv https://api.ngrok.com`. The standalone agent image also checks a certificate revocation list on port `80` that the Operator itself doesn't use, so ignore a CRL failure when you're diagnosing the Operator.
+</Note>
+
+Create a manifest file (for example, `ngrok-diagnose.yaml`):
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ngrok-diagnose
+spec:
+  template:
+    spec:
+      containers:
+        - name: ngrok-diagnose
+          image: ngrok/ngrok:latest
+          command: ["/bin/sh", "-c"]
+          args: ["ngrok diagnose"]
+      restartPolicy: Never
+```
+
+Apply it to your cluster:
+
+```bash
+kubectl apply -f ngrok-diagnose.yaml
+```
+
+Then check the logs:
+
+```bash
+kubectl logs -l "job-name=ngrok-diagnose"
+```
+
+```bash
+ngrok Connectivity - Region: Auto (lowest latency)
+  Name Resolution                           [ OK ]
+  TCP                                       [ OK ]
+  TLS                                       [ OK ]
+  Tunnel Protocol                           [ OK ]
+Successfully established ngrok connection! (region: 'auto', latency: 54.895145ms)
+```
+
+If any check fails, the host for that check isn't reachable from the cluster. Revisit the egress rules above with your network team.

--- a/k8s/installation/network-egress.mdx
+++ b/k8s/installation/network-egress.mdx
@@ -20,7 +20,7 @@ Every Operator installation needs to reach these hosts:
 
 <EgressFqdns />
 
-If you only expose inbound services (for example, running the Operator as a webhook gateway), these two hosts plus the image registry below are all you need. The section on endpoint bindings applies only if you turn that feature on.
+If you only expose inbound services (for example, running the Operator as a webhook gateway), these two hosts plus the image registry below are all you need. The section on private connectivity applies only if you turn that feature on.
 
 ## Installation and upgrades
 
@@ -41,20 +41,31 @@ If your policy is to avoid Docker Hub entirely, mirror both images to a private 
 Bitnami changed how it distributes images on Docker Hub in 2025. If you run in an air-gapped or mirrored environment, plan to mirror `bitnami/kubectl` (or set `cleanupHook.image.repository` to a `kubectl` image you control) rather than relying on it being pulled at uninstall time.
 </Note>
 
-## Endpoint bindings
+## Private connectivity
 
-[Endpoint bindings](/k8s/guides/bindings) are disabled by default (`bindings.enabled: false`), so skip this section unless you turn them on. When enabled, the bindings forwarder opens an additional connection to carry that traffic. Allow this host on TCP port `443`:
+To reach endpoints that aren't publicly exposed, the Operator uses private connectivity. In Operator `1.0.0` this replaces the [Kubernetes bound endpoints](/k8s/guides/bindings) used by earlier versions. It's off by default, so skip this section unless you turn it on. The hosts to allow depend on your Operator version.
 
-- `kubernetes-binding-ingress.ngrok.io`
+Operator `1.0.0` and later uses private connectivity. Allow:
 
-The forwarder connects to the bound endpoint host your ngrok account returns, which defaults to `kubernetes-binding-ingress.ngrok.io`. If your account uses a different host, allow that one instead.
+- `h2.connect-endpoint.ngrok.com` on TCP port `443`
+- `quic.connect-endpoint.ngrok.com` on UDP port `443`
+
+Operator versions before `1.0.0` use Kubernetes bound endpoints. Allow:
+
+- `kubernetes-binding-ingress.ngrok.io` on TCP port `443`
+
+<Note>
+On `1.0.0` and later, private connectivity prefers QUIC over UDP port `443` and falls back to HTTP/2 over TCP port `443` when UDP is blocked, so a TCP-only firewall still works. Allow `quic.connect-endpoint.ngrok.com` on UDP port `443` for the better-performing path.
+</Note>
+
+Before `1.0.0`, the Operator connects to the bound endpoint host your ngrok account returns, which defaults to `kubernetes-binding-ingress.ngrok.io`. If your account uses a different host, allow that one instead.
 
 ## Verify connectivity from the cluster
 
 To check connectivity from where your pods actually run, you can run [`ngrok diagnose`](/agent/diagnose) as a `Job`, using the [pre-built agent image](https://hub.docker.com/r/ngrok/ngrok). This checks name resolution, TCP, and TLS to `connect.ngrok-agent.com`.
 
 <Note>
-`ngrok diagnose` only exercises the agent connect host, not `api.ngrok.com` or the bindings host. To check those, run a shell in the cluster and test them directly, for example `curl -sv https://api.ngrok.com`. The standalone agent image also checks a certificate revocation list on port `80` that the Operator itself doesn't use, so ignore a CRL failure when you're diagnosing the Operator.
+`ngrok diagnose` only exercises the agent connect host, not `api.ngrok.com`, the bindings host, or the private connectivity hosts. To check those, run a shell in the cluster and test them directly, for example `curl -sv https://api.ngrok.com`. The standalone agent image also checks a certificate revocation list on port `80` that the Operator itself doesn't use, so ignore a CRL failure when you're diagnosing the Operator.
 </Note>
 
 Create a manifest file (for example, `ngrok-diagnose.yaml`):

--- a/snippets/k8s/_egress-fqdns.mdx
+++ b/snippets/k8s/_egress-fqdns.mdx
@@ -1,0 +1,2 @@
+- `api.ngrok.com` on TCP port `443`, so that the Operator can reconcile your Kubernetes resources with the ngrok API.
+- `connect.ngrok-agent.com` on TCP port `443`, so that the Operator can establish its agent session and serve traffic. ngrok uses latency-based DNS and may route you to a regional connect host, so allow the whole `*.ngrok-agent.com` family rather than pinning a single address.


### PR DESCRIPTION
**Do not merge until ngrok Operator 1.0.0 ships.** This PR is parked on purpose.

## What

Builds on #2300 to update the Network Egress page for Operator 1.0.0, which moves from Kubernetes bound endpoints to private connectivity. The bindings hosts are version-gated so the published page serves both worlds once 1.0.0 is in market:

- Operator 1.0.0 and later: `h2.connect-endpoint.ngrok.com` (TCP 443) and `quic.connect-endpoint.ngrok.com` (UDP 443).
- Before 1.0.0: `kubernetes-binding-ingress.ngrok.io` (TCP 443).

## Why parked

#2300 documents the accurate pre-1.0.0 state and merges near-term. This PR stages the 1.0.0 update so it's ready to merge the day 1.0.0 goes live, at which point the live doc covers both versions.

It's stacked on #2300 (base branch), so the diff shows only the 1.0.0 delta. GitHub retargets it to `main` automatically once #2300 merges.

Refs K8SOP-291, K8SOP-292