### PR TITLE
Fix misleading Traffic Policy expression links (DOC-616)

### DIFF
--- a/gateway/traffic-policy/examples/filter-by-ip-category.mdx
+++ b/gateway/traffic-policy/examples/filter-by-ip-category.mdx
@@ -4,7 +4,7 @@ description: Learn how to allow or block traffic from specific services, bots, c
 ---
 
 ngrok maintains up-to-date IP ranges for dozens of well-known services, cloud providers, bots, and threat categories under [IP Intelligence](/gateway/traffic-policy/variables/ip-intel).
-You can reference these in Traffic Policy [expressions](/gateway/traffic-policy/how-it-works#cel-interpolation) to allow or block traffic without maintaining lists of CIDRs by hand.
+You can reference these in Traffic Policy [expressions](/gateway/traffic-policy/how-it-works#expressions) to allow or block traffic without maintaining lists of CIDRs by hand.
 
 All category lookups use the `conn.client_ip.categories` variable.
 See the [full list of available categories](/gateway/traffic-policy/variables/ip-intel#ip-categories).

--- a/gateway/traffic-policy/how-it-works.mdx
+++ b/gateway/traffic-policy/how-it-works.mdx
@@ -87,7 +87,7 @@ on_http_request:
 ```
 
 <Tip>
-See the [Expression Examples](/gateway/traffic-policy/how-it-works#expressions) documentation to explore expressions across different use cases.
+See the [Expression Examples](/gateway/traffic-policy/concepts/expressions) documentation to explore expressions across different use cases.
 </Tip>
 
 ## Actions


### PR DESCRIPTION
Resolves [DOC-616](https://linear.app/ngrok/issue/DOC-616/address-rickys-feedback) — Ricky's design-audit feedback on the Create Traffic Policy → CEL docs flow.

## Fixed

| File | Was | Now |
|------|-----|-----|
| `gateway/traffic-policy/how-it-works.mdx` | "Expression Examples" → `how-it-works#expressions` — the same section the tip sits in | → `/gateway/traffic-policy/concepts/expressions`, whose title *is* "Expression Examples" |
| `gateway/traffic-policy/examples/filter-by-ip-category.mdx` | "expressions" → `how-it-works#cel-interpolation` | → `how-it-works#expressions` |

The second one wasn't in the report — found while sweeping for the same defect class.

Swept every `.mdx` for links pointing at their own route. The 4 others are legitimate jump links whose labels name on-page sections. `mint broken-links` is clean apart from 2 pre-existing failures in the auto-generated `snippets/k8s/_changelog.mdx`.

## Not fixed — not ours

The other two items are Safari-only and originate in the Mintlify platform, not this repo:

- **Page auto-scrolls after landing on an anchor** — hydration resetting scroll position after the anchor jump.
- **Left sidenav unclickable** — our only click-blocking CSS is the Ketch consent banner, and it's scoped under `#lanyard_root` with a deliberate `pointer-events` pass-through already in place. Nothing here reaches the sidenav.

Both need a Mintlify support ticket.