### PR TITLE
Drop "Coming soon" on string substring filter functions

### DIFF
--- a/api/api-filtering.mdx
+++ b/api/api-filtering.mdx
@@ -38,7 +38,7 @@ These core operators and helpers are supported:
 - Comparative operators: `<`, `<=`, `==`, `!=`, `>=`, `>`
 - Parentheses for grouping
 - List membership using the `in` keyword
-- [Coming soon] String substring checks: `startsWith()`, `contains()`, `endsWith()`
+- String substring checks: `startsWith()`, `contains()`, `endsWith()`
 - Length / emptiness checks: `size()`, `== ""`, `== null`
 - Date and time helpers: `timestamp(RFC-3339)`, `timestamp(time.now)`, `timestamp(time.now).subtract(<duration>)`, `timestamp(time.now).add(<duration>)`
 


### PR DESCRIPTION
The API Filtering page lists `startsWith()`, `contains()`, and `endsWith()` as "Coming soon" in the supported-operators list, but they are supported today — the page already uses them in its own usage examples (`obj.domain.startsWith(...)`, `obj.cidr.contains(...)`, `obj.description.contains(...)`) and documents their high-entropy-field restriction. This drops the stale tag so the operator list matches actual behavior.

The last gap here was substring matching on `obj.domain` for reserved domains, which was fixed in ngrok-private/ngrok#46607.