### PR TITLE
Remove billing for secrets and Traffic Policy macros

### DIFF
--- a/gateway/traffic-policy/secrets.mdx
+++ b/gateway/traffic-policy/secrets.mdx
@@ -111,12 +111,11 @@ Secrets and vaults emit the following [audit events](/obs/events/reference/#audi
 | `secret_deleted.v0` | Triggered when a secret is deleted |
 | `secret_updated.v0` | Triggered when a secret is updated |
 
-## Limits and pricing
+## Limits
 
-<Warning>
-Secrets and vaults are currently free to use.
-**This feature _will_ be billed and metered in the future, per the plan details below**.
-</Warning>
+<Note>
+Secrets and vaults are free to use. The plan limits below apply.
+</Note>
 
 | Plan     | Vault Limit      | Secret Limit               |
 | -------- | ---------------- | -------------------------- |

--- a/pricing-limits/how-ngrok-charges.mdx
+++ b/pricing-limits/how-ngrok-charges.mdx
@@ -68,7 +68,7 @@ description: Learn how ngrok applies feature and usage metrics to each payment p
 
 | Feature                                                                                                                                 | Free Plan        | Hobbyist Plan        | Pay-as-you-go Plan                                                           |
 | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------------------- | ---------------------------------------------------------------------------- |
-| **Traffic Policy Units (TPUs)** <br /> Actions and variables applied to requests (WAF, mTLS, etc.). Billed in 100k blocks. | $1 per 100k (against credit) | $1 per 100k (against credit) | $1 per 100k with volume discounts |
+| **Traffic Policy Units (TPUs)** <br /> Actions and variables applied to requests (WAF, mTLS, etc.). Billed in 100k blocks. | $0.10 per 100k (against credit) | $0.10 per 100k (against credit) | $0.10 per 100k with volume discounts |
 
 ---
 

--- a/pricing-limits/how-ngrok-charges.mdx
+++ b/pricing-limits/how-ngrok-charges.mdx
@@ -68,7 +68,7 @@ description: Learn how ngrok applies feature and usage metrics to each payment p
 
 | Feature                                                                                                                                 | Free Plan        | Hobbyist Plan        | Pay-as-you-go Plan                                                           |
 | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------------------- | ---------------------------------------------------------------------------- |
-| **Traffic Policy Units (TPUs)** <br /> Actions, macros, and variables applied to requests (WAF, mTLS, etc.). Billed in 100k blocks. | $1 per 100k (against credit) | $1 per 100k (against credit) | $1 per 100k with volume discounts |
+| **Traffic Policy Units (TPUs)** <br /> Actions and variables applied to requests (WAF, mTLS, etc.). Billed in 100k blocks. | $1 per 100k (against credit) | $1 per 100k (against credit) | $1 per 100k with volume discounts |
 
 ---
 

--- a/pricing-limits/pricing-glossary.mdx
+++ b/pricing-limits/pricing-glossary.mdx
@@ -134,7 +134,7 @@ Mutual TLS Authentication (mTLS) is a network security protocol that ensures bot
 
 ## Traffic Policy Units (TPUs)
 
-This is a combination of the actions, macros, and variables applied to a request. WAF, mTLS, and more are included in TPUs.
+This is a combination of the actions and variables applied to a request. WAF, mTLS, and more are included in TPUs.
 
 [Learn More](/pricing-limits/traffic-policy-unit-pricing/)
 

--- a/pricing-limits/traffic-policy-unit-pricing.mdx
+++ b/pricing-limits/traffic-policy-unit-pricing.mdx
@@ -6,14 +6,13 @@ description: Learn about how ngrok uses Traffic Processing Units (TPUs) to measu
 
 ## Traffic Policy Units (TPUs)
 
-Traffic Processing Units (TPUs) are ngrok's usage-based metric for measuring the work your Traffic Policies perform. Because requests can include any mix of expressions, macros, and actions—often applied only to a subset of traffic—charging a flat rate per request or connection would usually result in overcharging. Instead, ngrok calculates TPUs dynamically for each request, based only on the parts of the Traffic Policy that were actually executed.
+Traffic Processing Units (TPUs) are ngrok's usage-based metric for measuring the work your Traffic Policies perform. Because requests can include any mix of expressions and actions—often applied only to a subset of traffic—charging a flat rate per request or connection would usually result in overcharging. Instead, ngrok calculates TPUs dynamically for each request, based only on the parts of the Traffic Policy that were actually executed.
 
 TPUs are sold in bundles of 100,000 for $.10 and are charged as your policies execute.
 
 ## TPU pricing breakdown
 
 - [**Actions**](/gateway/traffic-policy/how-it-works#actions): Define what happens when a Traffic Policy rule matches (such as adding headers, denying a request, or forwarding traffic).
-- [**Macros**](/gateway/traffic-policy/macros/): Macros can be used within the Traffic Policy engine to simplify traffic management and dynamic configuration.
 - [**Variables**](/gateway/traffic-policy/variables/): Metadata about connections or requests that you can use in expressions or actions (such as the client IP or headers).
 
 ### Actions
@@ -43,89 +42,6 @@ TPUs are sold in bundles of 100,000 for $.10 and are charged as your policies ex
 | [terminate-tls](/gateway/traffic-policy/actions/terminate-tls/)           | 100 TPUs |
 | [url-rewrite](/gateway/traffic-policy/actions/url-rewrite/)               | 10 TPUs  |
 | [verify-webhook](/gateway/traffic-policy/actions/verify-webhook/)         | 1 TPU    |
-
-### Macros
-
-| Name                                                                                | TPU Cost                 |
-| ----------------------------------------------------------------------------------- | ------------------------ |
-| [b64.decode(string)](/gateway/traffic-policy/macros/#base64)                                | 3 TPUs per GB after 1 GB |
-| [b64.encode(string)](/gateway/traffic-policy/macros/#base64)                                | 3 TPUs per GB after 1 GB |
-| [basic_auth.encode(username, password)](/gateway/traffic-policy/macros/#basic-auth)         | Free                     |
-| [http.header(name)](/gateway/traffic-policy/macros/#http-requests)                          | Free                     |
-| [http.header(name, default)](/gateway/traffic-policy/macros/#http-requests)                 | Free                     |
-| [http.param(name)](/gateway/traffic-policy/macros/#http-requests)                           | Free                     |
-| [http.param(name, default)](/gateway/traffic-policy/macros/#http-requests)                  | Free                     |
-| [http.path()](/gateway/traffic-policy/macros/#http-requests)                                | Free                     |
-| [http.path_segment(index)](/gateway/traffic-policy/macros/#http-requests)                   | Free                     |
-| [http.path_segment(index, default)](/gateway/traffic-policy/macros/#http-requests)          | Free                     |
-| [http.query()](/gateway/traffic-policy/macros/#http-requests)                               | Free                     |
-| [http.query_param(name)](/gateway/traffic-policy/macros/#http-requests)                     | Free                     |
-| [http.query_param(name, default)](/gateway/traffic-policy/macros/#http-requests)            | Free                     |
-| [http.remote_addr()](/gateway/traffic-policy/macros/#http-requests)                         | Free                     |
-| [http.request_body()](/gateway/traffic-policy/macros/#http-requests)                        | Free                     |
-| [http.request_body_json()](/gateway/traffic-policy/macros/#http-requests)                   | Free                     |
-| [http.request_body_query()](/gateway/traffic-policy/macros/#http-requests)                  | Free                     |
-| [http.request_method()](/gateway/traffic-policy/macros/#http-requests)                      | Free                     |
-| [http.request_uri()](/gateway/traffic-policy/macros/#http-requests)                         | Free                     |
-| [http.response_body()](/gateway/traffic-policy/macros/#http-responses)                      | Free                     |
-| [http.response_body_json()](/gateway/traffic-policy/macros/#http-responses)                 | Free                     |
-| [http.response_body_query()](/gateway/traffic-policy/macros/#http-responses)                | Free                     |
-| [http.scheme()](/gateway/traffic-policy/macros/#http-requests)                              | Free                     |
-| [http.status()](/gateway/traffic-policy/macros/#http-responses)                             | Free                     |
-| [http.status_text()](/gateway/traffic-policy/macros/#http-responses)                        | Free                     |
-| [http.user_agent()](/gateway/traffic-policy/macros/#http-requests)                          | Free                     |
-| [inCidrRange(ip, cidr)](/gateway/traffic-policy/macros/#utility)                            | Free                     |
-| [inCidrRanges(ip, cidrs)](/gateway/traffic-policy/macros/#utility)                          | Free                     |
-| [json.decode(string)](/gateway/traffic-policy/macros/#json)                                 | 3 TPUs per GB after 1 GB |
-| [json.encode(list\| map)](/gateway/traffic-policy/macros/#json)                             | 3 TPUs per GB after 1 GB |
-| [list.encodeJson()](/gateway/traffic-policy/macros/#lists)                                  | Free                     |
-| [object.encodeJson()](/gateway/traffic-policy/macros/#maps)                                 | Free                     |
-| [object.encodeQueryString()](/gateway/traffic-policy/macros/#maps)                          | Free                     |
-| [queryString.decode(string)](/gateway/traffic-policy/macros/#query-string)                  | Free                     |
-| [queryString.encode(map)](/gateway/traffic-policy/macros/#query-string)                     | Free                     |
-| [rand.double()](/gateway/traffic-policy/macros/#random)                                     | Free                     |
-| [rand.int(min, max)](/gateway/traffic-policy/macros/#random)                                | Free                     |
-| [security.secret(string, string)](/gateway/traffic-policy/macros/#secrets)                  | Free                     |
-| [string.decodeBase64()](/gateway/traffic-policy/macros/#string)                             | Free                     |
-| [string.decodeJson()](/gateway/traffic-policy/macros/#string)                               | Free                     |
-| [string.decodeQueryString()](/gateway/traffic-policy/macros/#string)                        | Free                     |
-| [string.encodeBase64()](/gateway/traffic-policy/macros/#string)                             | Free                     |
-| [string.escapeUrl()](/gateway/traffic-policy/macros/#string)                                | Free                     |
-| [string.isJson()](/gateway/traffic-policy/macros/#string)                                   | Free                     |
-| [string.isQueryString()](/gateway/traffic-policy/macros/#string)                            | Free                     |
-| [string.isURL()](/gateway/traffic-policy/macros/#string)                                    | Free                     |
-| [string.parseUrl()](/gateway/traffic-policy/macros/#string)                                 | Free                     |
-| [string.unescapeUrl()](/gateway/traffic-policy/macros/#string)                              | Free                     |
-| [url.escape(string)](/gateway/traffic-policy/macros/#url)                                   | Free                     |
-| [url.parse(string)](/gateway/traffic-policy/macros/#url)                                    | Free                     |
-| [url.unescape(string)](/gateway/traffic-policy/macros/#url)                                 | Free                     |
-| [utility.base64_decode(string)](/gateway/traffic-policy/macros/#base64)                     | Free                     |
-| [utility.base64_encode(string)](/gateway/traffic-policy/macros/#base64)                     | Free                     |
-| [utility.basic_auth_encode(username, password)](/gateway/traffic-policy/macros/#basic-auth) | Free                     |
-| [utility.in_cidr_range(ip, cidr)](/gateway/traffic-policy/macros/#utility)                  | Free                     |
-| [utility.in_cidr_ranges(ip, cidrs)](/gateway/traffic-policy/macros/#utility)                | Free                     |
-| [utility.json_decode(string)](/gateway/traffic-policy/macros/#json)                         | Free                     |
-| [utility.json_encode(list \| map)](/gateway/traffic-policy/macros/#json)                    | Free                     |
-| [utility.list_encode_json()](/gateway/traffic-policy/macros/#lists)                         | Free                     |
-| [utility.object_encode_json()](/gateway/traffic-policy/macros/#maps)                        | Free                     |
-| [utility.object_encode_query_string()](/gateway/traffic-policy/macros/#maps)                | Free                     |
-| [utility.query_string_decode(string)](/gateway/traffic-policy/macros/#query-string)         | Free                     |
-| [utility.query_string_encode(map)](/gateway/traffic-policy/macros/#query-string)            | Free                     |
-| [utility.rand_double()](/gateway/traffic-policy/macros/#random)                             | Free                     |
-| [utility.rand_int(min, max)](/gateway/traffic-policy/macros/#random)                        | Free                     |
-| [utility.string_decode_base64()](/gateway/traffic-policy/macros/#string)                    | Free                     |
-| [utility.string_decode_json()](/gateway/traffic-policy/macros/#string)                      | Free                     |
-| [utility.string_decode_query_string()](/gateway/traffic-policy/macros/#string)              | Free                     |
-| [utility.string_encode_base64()](/gateway/traffic-policy/macros/#string)                    | Free                     |
-| [utility.string_escape_url()](/gateway/traffic-policy/macros/#string)                       | Free                     |
-| [utility.string_is_json()](/gateway/traffic-policy/macros/#string)                          | Free                     |
-| [utility.string_is_query_string()](/gateway/traffic-policy/macros/#string)                  | Free                     |
-| [utility.string_is_url()](/gateway/traffic-policy/macros/#string)                           | Free                     |
-| [utility.string_parse_url()](/gateway/traffic-policy/macros/#string)                        | Free                     |
-| [utility.string_unescape_url()](/gateway/traffic-policy/macros/#string)                     | Free                     |
-| [utility.url_escape(string)](/gateway/traffic-policy/macros/#url)                           | Free                     |
-| [utility.url_parse(string)](/gateway/traffic-policy/macros/#url)                            | Free                     |
-| [utility.url_unescape(string)](/gateway/traffic-policy/macros/#url)                         | Free                     |
 
 ### Variables
 


### PR DESCRIPTION
We decided not to bill for secrets/vaults or Traffic Policy macros. This removes those billing claims from the docs.

## Traffic Policy macros

Macros were billed as part of Traffic Policy Units (TPUs). Removed:

- **`pricing-limits/traffic-policy-unit-pricing.mdx`** — deleted the entire `### Macros` cost table (78 rows, including the four billed `b64.decode/encode` and `json.decode/encode` entries at "3 TPUs per GB after 1 GB"), the Macros bullet in the TPU breakdown, and "macros" from the intro sentence.
- **`pricing-limits/how-ngrok-charges.mdx`** — TPU row now reads "Actions and variables applied to requests".
- **`pricing-limits/pricing-glossary.mdx`** — same edit to the TPU definition.

Functional macro documentation is untouched — only the billing/cost surfaces changed. No inbound anchor links pointed at the removed section.

## Secrets

- **`gateway/traffic-policy/secrets.mdx`** — dropped the warning stating "**This feature _will_ be billed and metered in the future**", retitled "Limits and pricing" to "Limits", and replaced the warning with a plain note that secrets and vaults are free.

The per-plan vault/secret limit table is kept, since those are capacity limits rather than billing.

## Drive-by price correction

`how-ngrok-charges.mdx` listed TPUs at **$1 per 100k** — 10x the actual price. The TPU pricing page, `pricing-limits/index.mdx`, and the ngrok.com pricing page all say **$0.10 per 100k**. Corrected to $0.10 across all three plan columns.

The HTTP request ($1/100k) and TCP connection ($2/100k) rows in the same file are separate line items, verified against the pricing page, and are unchanged.

## Related

Companion pricing-page change in the frontend repo removes "macros" from the TPU explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)