### PR TITLE
Correct the auto-assigned domain behavior on the domains overview

### DIFF
--- a/gateway/domains/index.mdx
+++ b/gateway/domains/index.mdx
@@ -81,17 +81,15 @@ For billing information on wildcard endpoints, including how endpoint hours and 
 Reserving subdomains of a wildcard domain within the ngrok dashboard count towards the number of reserved domains in your account. For example, if you reserve `foo.example.com` and `*.example.com`, you have reserved two domains.
 </Note>
 
-### Random domains
+### Auto-assigned domains
 
-For some applications, you may not care much about the actual domain for the endpoint. Rather than picking one yourself, you can let ngrok assign a hostname by using the value `https://` in the `url` field:
+For some applications, you may not care much about the actual domain for the endpoint. Rather than picking one yourself, you can use the value `https://` in the `url` field to have ngrok automatically assign your endpoint your account's [dev domain](#dev-domains):
 
 ```bash
 ngrok http 80 --url 'https://'
 ```
 
-<Note>
-Depending on your account, using `https://` either generates a random domain or returns your account's automatically assigned [dev domain](#dev-domains). Either way, you get a usable public hostname for your endpoint without having to reserve one yourself.
-</Note>
+The dev domain is a stable, auto-assigned hostname, so you get a usable public URL for your endpoint without reserving one yourself.
 
 ### Ownership
 
@@ -213,4 +211,4 @@ the [Pricing page](https://ngrok.com/pricing) for details.
 | Domains                | All plans. The Domain name is automatically assigned on Free; you may choose it on paid plans. |
 | Bring-your-own domains | Pay-as-you-go                                       |
 | Wildcard endpoints     | Pay-as-you-go                                                                     |
-| Auto-assigned domain (`https://`) | All plans. Returns a randomly generated domain or your account's dev domain, depending on the account. |
+| Auto-assigned domain (`https://`) | All plans. Assigns your account's dev domain to the endpoint. |

--- a/gateway/domains/index.mdx
+++ b/gateway/domains/index.mdx
@@ -83,16 +83,14 @@ Reserving subdomains of a wildcard domain within the ngrok dashboard count towar
 
 ### Random domains
 
-For some applications, you may not care much about the actual domain for the endpoint. Generating these can be a pain, so ngrok includes an easy way
-to create and use these for endpoints. Using the value `https://` in the `url` field will generate a random URL for you to use with your endpoint.
+For some applications, you may not care much about the actual domain for the endpoint. Rather than picking one yourself, you can let ngrok assign a hostname by using the value `https://` in the `url` field:
 
 ```bash
 ngrok http 80 --url 'https://'
 ```
 
 <Note>
-Random domain generation (using `--url 'https://'`) is only available on paid plans. 
-The free plan is limited to using your automatically assigned dev domain for public endpoints.
+Depending on your account, using `https://` either generates a random domain or returns your account's automatically assigned [dev domain](#dev-domains). Either way, you get a usable public hostname for your endpoint without having to reserve one yourself.
 </Note>
 
 ### Ownership
@@ -215,4 +213,4 @@ the [Pricing page](https://ngrok.com/pricing) for details.
 | Domains                | All plans. The Domain name is automatically assigned on Free; you may choose it on paid plans. |
 | Bring-your-own domains | Pay-as-you-go                                       |
 | Wildcard endpoints     | Pay-as-you-go                                                                     |
-| Random domain generation | Paid plans only                                                                |
+| Auto-assigned domain (`https://`) | All plans. Returns a randomly generated domain or your account's dev domain, depending on the account. |


### PR DESCRIPTION
The domains overview page claimed random domain generation is available on paid plans, but that does not match the behavior. Running ngrok http 80 --url 'https://' assigns your account's dev domain — a stable, auto-assigned hostname — not a random one.

This reworks the page to describe that directly:
- Renamed the Random domains section to Auto-assigned domains and stated the dev-domain behavior plainly, dropping the random-generation claim.
- Updated the domain-capabilities table row to match, so the two stay consistent.

Single file (gateway/domains/index.mdx). Interim correction for GAT-626; the section stays open to finalize the wording once the related product decision lands.

Linear: https://linear.app/ngrok/issue/GAT-626