### PR TITLE
Gateway sidebar variant A: mirror AI Gateway's nav grammar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -270,6 +270,7 @@
         "tab": "Gateway",
         "pages": [
           "gateway/overview",
+          "gateway/endpoints/agent-cli-quickstart",
           "gateway/how-it-works",
           "gateway/points-of-presence",
           {
@@ -280,25 +281,14 @@
                 "group": "Agent Endpoints",
                 "pages": [
                   "gateway/endpoints/agent-endpoints",
-                  "gateway/endpoints/agent-cli-quickstart",
-                  {
-                    "group": "Protocols",
-                    "pages": [
-                      "gateway/endpoints/protocols",
-                      "gateway/endpoints/http",
-                      "gateway/endpoints/tls",
-                      "gateway/endpoints/tcp"
-                    ]
-                  },
-                  {
-                    "group": "Bindings",
-                    "pages": [
-                      "gateway/endpoints/bindings",
-                      "gateway/endpoints/public-endpoints",
-                      "gateway/endpoints/internal-endpoints",
-                      "gateway/endpoints/kubernetes-endpoints"
-                    ]
-                  }
+                  "gateway/endpoints/protocols",
+                  "gateway/endpoints/http",
+                  "gateway/endpoints/tls",
+                  "gateway/endpoints/tcp",
+                  "gateway/endpoints/bindings",
+                  "gateway/endpoints/public-endpoints",
+                  "gateway/endpoints/internal-endpoints",
+                  "gateway/endpoints/kubernetes-endpoints"
                 ]
               },
               {
@@ -306,41 +296,21 @@
                 "pages": [
                   "gateway/endpoints/cloud-endpoints/index",
                   "getting-started/cloud-endpoints-quickstart",
-                  {
-                    "group": "Protocols",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/protocols",
-                      "gateway/endpoints/cloud-endpoints/http",
-                      "gateway/endpoints/cloud-endpoints/tls",
-                      "gateway/endpoints/cloud-endpoints/tcp"
-                    ]
-                  },
-                  {
-                    "group": "Bindings",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/bindings",
-                      "gateway/endpoints/cloud-endpoints/public-endpoints",
-                      "gateway/endpoints/cloud-endpoints/internal-endpoints",
-                      "gateway/endpoints/cloud-endpoints/kubernetes-endpoints"
-                    ]
-                  },
-                  {
-                    "group": "Guides",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
-                      {
-                        "group": "Forwarding Traffic",
-                        "pages": [
-                          "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
-                          "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
-                        ]
-                      }
-                    ]
-                  }
+                  "gateway/endpoints/cloud-endpoints/protocols",
+                  "gateway/endpoints/cloud-endpoints/http",
+                  "gateway/endpoints/cloud-endpoints/tls",
+                  "gateway/endpoints/cloud-endpoints/tcp",
+                  "gateway/endpoints/cloud-endpoints/bindings",
+                  "gateway/endpoints/cloud-endpoints/public-endpoints",
+                  "gateway/endpoints/cloud-endpoints/internal-endpoints",
+                  "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
+                  "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
+                  "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
+                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
                 ]
               },
               {
-                "group": "Pooling & load balancing",
+                "group": "Pooling & Load Balancing",
                 "pages": [
                   "gateway/endpoints/endpoint-pooling",
                   "gateway/endpoints/load-balancing-multiple-clouds"
@@ -354,9 +324,20 @@
               "gateway/traffic-policy/index",
               "gateway/traffic-policy/how-it-works",
               {
+                "group": "Concepts",
+                "pages": [
+                  "gateway/traffic-policy/concepts/expressions",
+                  "gateway/traffic-policy/concepts/actions",
+                  "gateway/traffic-policy/concepts/ip-policies",
+                  "gateway/traffic-policy/secrets",
+                  "gateway/traffic-policy/identities"
+                ]
+              },
+              {
                 "group": "Quickstarts",
                 "pages": [
                   "gateway/traffic-policy/getting-started/agent-endpoints",
+                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
                   "gateway/traffic-policy/getting-started/cloud-endpoints"
                 ]
               },
@@ -414,31 +395,17 @@
                 ]
               },
               {
-                "group": "References",
+                "group": "Reference",
                 "pages": [
-                  "/gateway/traffic-policy/concepts/expressions",
                   "gateway/traffic-policy/macros/index",
-                  {
-                    "group": "Variables",
-                    "pages": [
-                      "gateway/traffic-policy/variables/index",
-                      "gateway/traffic-policy/variables/action",
-                      "gateway/traffic-policy/variables/connection",
-                      "gateway/traffic-policy/variables/endpoint",
-                      "gateway/traffic-policy/variables/ip-intel",
-                      "gateway/traffic-policy/variables/req",
-                      "gateway/traffic-policy/variables/res",
-                      "gateway/traffic-policy/variables/time"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Traffic Policy Features",
-                "pages": [
-                  "gateway/traffic-policy/secrets",
-                  "gateway/traffic-policy/identities",
-                  "gateway/traffic-policy/concepts/ip-policies"
+                  "gateway/traffic-policy/variables/index",
+                  "gateway/traffic-policy/variables/action",
+                  "gateway/traffic-policy/variables/connection",
+                  "gateway/traffic-policy/variables/endpoint",
+                  "gateway/traffic-policy/variables/ip-intel",
+                  "gateway/traffic-policy/variables/req",
+                  "gateway/traffic-policy/variables/res",
+                  "gateway/traffic-policy/variables/time"
                 ]
               }
             ]
@@ -446,14 +413,9 @@
           {
             "group": "Domains & TLS",
             "pages": [
-              {
-                "group": "Domains",
-                "pages": [
-                  "gateway/domains/index",
-                  "gateway/domains/custom-domains",
-                  "gateway/domains/region-pinning"
-                ]
-              },
+              "gateway/domains/index",
+              "gateway/domains/custom-domains",
+              "gateway/domains/region-pinning",
               "gateway/domains/ip-addresses",
               "gateway/domains/dedicated-ips",
               "gateway/domains/tcp-addresses",
@@ -502,36 +464,21 @@
           {
             "group": "ngrok Agent",
             "pages": [
-              "gateway/agent/overview",
               "gateway/agent/index",
+              "gateway/agent/overview",
               "gateway/agent/upgrade-v2-v3",
               "gateway/agent/version-support-policy",
               "gateway/agent/deprecation-notices",
-              {
-                "group": "Observing Agent Traffic",
-                "pages": [
-                  "gateway/agent/web-inspection-interface"
-                ]
-              },
+              "gateway/agent/web-inspection-interface",
+              "gateway/agent/agent-tls-termination",
               {
                 "group": "Guides",
                 "pages": [
                   "gateway/agent/ssh-reverse-tunnel-agent",
                   "gateway/agent/connect-url",
-                  {
-                    "group": "Docker",
-                    "pages": [
-                      "using-ngrok-with/docker/index",
-                      "using-ngrok-with/docker/compose",
-                      "using-ngrok-with/docker/desktop"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Agent TLS Termination",
-                "pages": [
-                  "gateway/agent/agent-tls-termination"
+                  "using-ngrok-with/docker/index",
+                  "using-ngrok-with/docker/compose",
+                  "using-ngrok-with/docker/desktop"
                 ]
               }
             ]
@@ -542,7 +489,6 @@
               "gateway/k8s/index",
               "gateway/k8s/how-it-works",
               "gateway/k8s/installation/architecture",
-              "gateway/k8s/guides/local-cluster",
               "gateway/k8s/releasing",
               {
                 "group": "Quickstarts",
@@ -554,7 +500,7 @@
                 ]
               },
               {
-                "group": "Manage",
+                "group": "Installation",
                 "pages": [
                   "gateway/k8s/installation/network-egress",
                   "gateway/k8s/installation/update",
@@ -565,16 +511,9 @@
                 ]
               },
               {
-                "group": "Load Balancing",
+                "group": "Guides",
                 "pages": [
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
-                  "gateway/k8s/guides/using-loadbalancers"
-                ]
-              },
-              {
-                "group": "Usage Guides",
-                "pages": [
+                  "gateway/k8s/guides/local-cluster",
                   "gateway/k8s/guides/using-crds",
                   "gateway/k8s/guides/endpoint-types",
                   "gateway/k8s/guides/bindings",
@@ -588,6 +527,20 @@
                   "gateway/k8s/guides/managed-resources",
                   "gateway/k8s/guides/finalizers",
                   "gateway/k8s/guides/troubleshooting",
+                  "gateway/k8s/guides/expose-kubernetes-api"
+                ]
+              },
+              {
+                "group": "Load Balancing",
+                "pages": [
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
+                  "gateway/k8s/guides/using-loadbalancers"
+                ]
+              },
+              {
+                "group": "How-to",
+                "pages": [
                   "gateway/k8s/guides/how-to/request-routing",
                   "gateway/k8s/guides/how-to/tls-routing",
                   "gateway/k8s/guides/how-to/tcp-routing",
@@ -625,110 +578,116 @@
             ]
           },
           {
-            "group": "API Gateway",
+            "group": "Use Cases",
             "pages": [
-              "gateway/api-gateway/get-started",
-              "gateway/api-gateway/multicloud",
-              "gateway/api-gateway/monitor-ngrok"
-            ]
-          },
-          {
-            "group": "Device Gateway",
-            "pages": [
-              "gateway/device-gateway/overview",
-              "gateway/device-gateway/quickstart",
-              "gateway/device-gateway/faq",
               {
-                "group": "Use cases",
+                "group": "API Gateway",
                 "pages": [
-                  "gateway/device-gateway/cloud-to-device",
-                  "gateway/device-gateway/remote-access",
-                  "gateway/device-gateway/private-connectivity",
-                  "gateway/device-gateway/fleet-management",
-                  "gateway/device-gateway/sdk"
+                  "gateway/api-gateway/get-started",
+                  "gateway/api-gateway/multicloud",
+                  "gateway/api-gateway/monitor-ngrok"
                 ]
               },
               {
-                "group": "The ngrok platform",
+                "group": "Device Gateway",
                 "pages": [
-                  "gateway/device-gateway/security",
-                  "gateway/device-gateway/tunnels",
-                  "gateway/device-gateway/traffic-policy"
+                  "gateway/device-gateway/overview",
+                  "gateway/device-gateway/quickstart",
+                  "gateway/device-gateway/faq",
+                  "gateway/device-gateway/agent",
+                  {
+                    "group": "Guides",
+                    "pages": [
+                      "gateway/device-gateway/cloud-to-device",
+                      "gateway/device-gateway/remote-access",
+                      "gateway/device-gateway/private-connectivity",
+                      "gateway/device-gateway/fleet-management",
+                      "gateway/device-gateway/sdk"
+                    ]
+                  },
+                  {
+                    "group": "Concepts",
+                    "pages": [
+                      "gateway/device-gateway/security",
+                      "gateway/device-gateway/tunnels",
+                      "gateway/device-gateway/traffic-policy"
+                    ]
+                  },
+                  {
+                    "group": "Installation Guides",
+                    "pages": [
+                      "gateway/device-gateway/linux",
+                      "gateway/device-gateway/arm64",
+                      "gateway/device-gateway/raspberry-pi",
+                      "gateway/device-gateway/raspbian",
+                      "gateway/device-gateway/windows"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Installation Guides",
+                "group": "Site-to-Site Connectivity",
                 "pages": [
-                  "gateway/device-gateway/linux",
-                  "gateway/device-gateway/arm64",
-                  "gateway/device-gateway/raspberry-pi",
-                  "gateway/device-gateway/raspbian",
-                  "gateway/device-gateway/windows"
+                  "gateway/site-to-site-connectivity/overview",
+                  "gateway/site-to-site-connectivity/quickstart",
+                  "gateway/site-to-site-connectivity/index",
+                  "gateway/site-to-site-connectivity/faq",
+                  "gateway/site-to-site-connectivity/end-customers",
+                  {
+                    "group": "Security",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/agent-tls-termination",
+                      "gateway/site-to-site-connectivity/region-ip-resolution",
+                      "gateway/site-to-site-connectivity/authtoken-acls"
+                    ]
+                  },
+                  {
+                    "group": "Reliability",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/background-service",
+                      "gateway/site-to-site-connectivity/redundant-agents",
+                      "gateway/site-to-site-connectivity/traffic-events",
+                      "gateway/site-to-site-connectivity/multi-region-failover"
+                    ]
+                  },
+                  {
+                    "group": "Private Addressability",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/customer-networks",
+                      "gateway/site-to-site-connectivity/non-k8s-environment"
+                    ]
+                  },
+                  {
+                    "group": "Production Ready",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/custom-connect-url",
+                      "gateway/site-to-site-connectivity/agent-cli",
+                      "gateway/site-to-site-connectivity/agent-sdks",
+                      "gateway/site-to-site-connectivity/apis-terraform",
+                      "gateway/site-to-site-connectivity/agent-packaging"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Webhooks to On-Prem",
+                "pages": [
+                  "gateway/webhooks-to-on-prem/overview",
+                  "gateway/webhooks-to-on-prem/quickstart",
+                  "gateway/webhooks-to-on-prem/tutorial"
+                ]
+              },
+              {
+                "group": "Security Best Practices",
+                "pages": [
+                  "gateway/security-dev-productivity/index",
+                  "gateway/security-dev-productivity/securing-your-tunnels",
+                  "gateway/security-dev-productivity/hipaa-compliance",
+                  "gateway/identity-aware-proxy/securing-with-oauth",
+                  "gateway/ssh-rdp/index",
+                  "gateway/running-behind-firewalls"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Site-to-Site Connectivity",
-            "pages": [
-              "gateway/site-to-site-connectivity/overview",
-              "gateway/site-to-site-connectivity/quickstart",
-              "gateway/site-to-site-connectivity/index",
-              "gateway/site-to-site-connectivity/faq",
-              "gateway/site-to-site-connectivity/end-customers",
-              {
-                "group": "Security",
-                "pages": [
-                  "gateway/site-to-site-connectivity/agent-tls-termination",
-                  "gateway/site-to-site-connectivity/region-ip-resolution",
-                  "gateway/site-to-site-connectivity/authtoken-acls"
-                ]
-              },
-              {
-                "group": "Reliability",
-                "pages": [
-                  "gateway/site-to-site-connectivity/background-service",
-                  "gateway/site-to-site-connectivity/redundant-agents",
-                  "gateway/site-to-site-connectivity/traffic-events",
-                  "gateway/site-to-site-connectivity/multi-region-failover"
-                ]
-              },
-              {
-                "group": "Private addressability",
-                "pages": [
-                  "gateway/site-to-site-connectivity/customer-networks",
-                  "gateway/site-to-site-connectivity/non-k8s-environment"
-                ]
-              },
-              {
-                "group": "Production ready",
-                "pages": [
-                  "gateway/site-to-site-connectivity/custom-connect-url",
-                  "gateway/site-to-site-connectivity/agent-cli",
-                  "gateway/site-to-site-connectivity/agent-sdks",
-                  "gateway/site-to-site-connectivity/apis-terraform",
-                  "gateway/site-to-site-connectivity/agent-packaging"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Webhooks to On-Prem",
-            "pages": [
-              "gateway/webhooks-to-on-prem/overview",
-              "gateway/webhooks-to-on-prem/quickstart",
-              "gateway/webhooks-to-on-prem/tutorial"
-            ]
-          },
-          {
-            "group": "Security Best Practices",
-            "pages": [
-              "gateway/security-dev-productivity/index",
-              "gateway/security-dev-productivity/securing-your-tunnels",
-              "gateway/security-dev-productivity/hipaa-compliance",
-              "gateway/identity-aware-proxy/securing-with-oauth",
-              "gateway/ssh-rdp/index",
-              "gateway/running-behind-firewalls"
             ]
           },
           {
@@ -750,9 +709,10 @@
               "gateway/examples/lock-admin-dashboards",
               "gateway/examples/maintenance-mode",
               "gateway/examples/minecraft",
-              "gateway/examples/n8n-redirect",
+              "gateway/examples/n8n",
               "gateway/examples/offload-analytics",
-              "/gateway/examples/ollama-redirect",
+              "gateway/examples/odoo",
+              "gateway/examples/ollama",
               "gateway/examples/pre-tier-requests",
               "gateway/examples/rewrite-headers-redirects",
               "gateway/examples/route-api-app-traffic-user-agent",

--- a/docs.json
+++ b/docs.json
@@ -528,56 +528,82 @@
           {
             "group": "Examples",
             "pages": [
+              "gateway/examples",
+              "gateway/traffic-policy/examples/index",
               {
-                "group": "Gateway",
+                "group": "Secure and Control Access",
+                "expanded": false,
                 "pages": [
-                  "gateway/examples",
-                  "gateway/examples/front-door-pattern",
-                  "gateway/examples/multiplex",
-                  "gateway/examples/custom-error-pages",
-                  "gateway/examples/paas-alternative-gateway",
-                  "gateway/examples/agent-assisted-gateway",
-                  "gateway/examples/microservices-gateway",
-                  "gateway/examples/webhook-gateway",
-                  "gateway/examples/database-gateway",
-                  "gateway/examples/ephemeral-workloads",
-                  "gateway/examples/blue-green-deployments",
-                  "gateway/examples/canary-deployments",
                   "gateway/examples/ip-restrictions-basic-auth",
                   "gateway/examples/lock-admin-dashboards",
-                  "gateway/examples/maintenance-mode",
-                  "gateway/examples/minecraft",
-                  "gateway/examples/n8n",
-                  "gateway/examples/offload-analytics",
-                  "gateway/examples/odoo",
-                  "gateway/examples/ollama",
-                  "gateway/examples/pre-tier-requests",
-                  "gateway/examples/rewrite-headers-redirects",
-                  "gateway/examples/route-api-app-traffic-user-agent",
-                  "gateway/examples/route-by-geography",
-                  "gateway/examples/route-by-oidc",
-                  "gateway/examples/secure-developer-environments",
                   "gateway/examples/validate-requests-identity",
-                  "gateway/examples/wordpress"
+                  "gateway/examples/secure-developer-environments",
+                  "gateway/traffic-policy/examples/add-authentication",
+                  "gateway/traffic-policy/examples/oauth-protection",
+                  "gateway/traffic-policy/examples/block-unwanted-requests",
+                  "gateway/traffic-policy/examples/filter-by-ip-category",
+                  "gateway/traffic-policy/examples/user-agent-filtering",
+                  "gateway/traffic-policy/examples/enforce-tls"
                 ]
               },
               {
-                "group": "Traffic Policy",
+                "group": "Route and Shape Traffic",
+                "expanded": false,
                 "pages": [
-                  "gateway/traffic-policy/examples/index",
-                  "gateway/traffic-policy/examples/a-b-tests",
-                  "gateway/traffic-policy/examples/add-and-remove-headers",
-                  "gateway/traffic-policy/examples/add-authentication",
-                  "gateway/traffic-policy/examples/block-unwanted-requests",
-                  "gateway/traffic-policy/examples/filter-by-ip-category",
-                  "gateway/traffic-policy/examples/compress-json-responses",
-                  "gateway/traffic-policy/examples/enforce-tls",
-                  "gateway/traffic-policy/examples/event-logging",
-                  "gateway/traffic-policy/examples/oauth-protection",
-                  "gateway/traffic-policy/examples/rate-limit-requests",
+                  "gateway/examples/front-door-pattern",
+                  "gateway/examples/multiplex",
+                  "gateway/examples/microservices-gateway",
+                  "gateway/examples/route-api-app-traffic-user-agent",
+                  "gateway/examples/route-by-geography",
+                  "gateway/examples/route-by-oidc",
+                  "gateway/examples/rewrite-headers-redirects",
+                  "gateway/examples/custom-error-pages",
                   "gateway/traffic-policy/examples/route-requests",
                   "gateway/traffic-policy/examples/url-rewrites",
-                  "gateway/traffic-policy/examples/user-agent-filtering"
+                  "gateway/traffic-policy/examples/add-and-remove-headers",
+                  "gateway/traffic-policy/examples/compress-json-responses"
+                ]
+              },
+              {
+                "group": "Ship Changes Safely",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/blue-green-deployments",
+                  "gateway/examples/canary-deployments",
+                  "gateway/examples/ephemeral-workloads",
+                  "gateway/examples/maintenance-mode",
+                  "gateway/traffic-policy/examples/a-b-tests"
+                ]
+              },
+              {
+                "group": "Protect and Observe",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/pre-tier-requests",
+                  "gateway/examples/offload-analytics",
+                  "gateway/traffic-policy/examples/rate-limit-requests",
+                  "gateway/traffic-policy/examples/event-logging"
+                ]
+              },
+              {
+                "group": "Connect Services",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/database-gateway",
+                  "gateway/examples/webhook-gateway",
+                  "gateway/examples/paas-alternative-gateway",
+                  "gateway/examples/agent-assisted-gateway"
+                ]
+              },
+              {
+                "group": "Expose Self-Hosted Apps",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/minecraft",
+                  "gateway/examples/n8n",
+                  "gateway/examples/odoo",
+                  "gateway/examples/ollama",
+                  "gateway/examples/wordpress"
                 ]
               }
             ]

--- a/docs.json
+++ b/docs.json
@@ -277,12 +277,6 @@
             "group": "Concepts",
             "pages": [
               "gateway/endpoints/index",
-              "gateway/endpoints/agent-endpoints",
-              "gateway/endpoints/protocols",
-              "gateway/endpoints/bindings",
-              "gateway/endpoints/cloud-endpoints/index",
-              "gateway/endpoints/cloud-endpoints/protocols",
-              "gateway/endpoints/cloud-endpoints/bindings",
               "gateway/endpoints/endpoint-pooling",
               "gateway/traffic-policy/index",
               "gateway/traffic-policy/how-it-works",
@@ -292,11 +286,8 @@
               "gateway/traffic-policy/secrets",
               "gateway/traffic-policy/identities",
               "gateway/domains/index",
-              "iam/index",
               "gateway/agent/index",
-              "gateway/agent/overview",
-              "gateway/k8s/how-it-works",
-              "gateway/k8s/installation/architecture"
+              "gateway/agent/overview"
             ]
           },
           {
@@ -321,24 +312,35 @@
             "group": "Guides",
             "pages": [
               {
-                "group": "Endpoints",
+                "group": "Agent Endpoints",
                 "pages": [
+                  "gateway/endpoints/agent-endpoints",
+                  "gateway/endpoints/protocols",
                   "gateway/endpoints/http",
                   "gateway/endpoints/tls",
                   "gateway/endpoints/tcp",
+                  "gateway/endpoints/bindings",
                   "gateway/endpoints/public-endpoints",
                   "gateway/endpoints/internal-endpoints",
                   "gateway/endpoints/kubernetes-endpoints",
+                  "gateway/endpoints/load-balancing-multiple-clouds"
+                ]
+              },
+              {
+                "group": "Cloud Endpoints",
+                "pages": [
+                  "gateway/endpoints/cloud-endpoints/index",
+                  "gateway/endpoints/cloud-endpoints/protocols",
                   "gateway/endpoints/cloud-endpoints/http",
                   "gateway/endpoints/cloud-endpoints/tls",
                   "gateway/endpoints/cloud-endpoints/tcp",
+                  "gateway/endpoints/cloud-endpoints/bindings",
                   "gateway/endpoints/cloud-endpoints/public-endpoints",
                   "gateway/endpoints/cloud-endpoints/internal-endpoints",
                   "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
                   "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
                   "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
-                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization",
-                  "gateway/endpoints/load-balancing-multiple-clouds"
+                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
                 ]
               },
               {
@@ -359,6 +361,7 @@
               {
                 "group": "Identity & Access",
                 "pages": [
+                  "iam/index",
                   "iam/users",
                   "iam/service-users",
                   "iam/sso",
@@ -381,6 +384,8 @@
               {
                 "group": "Kubernetes Operator",
                 "pages": [
+                  "gateway/k8s/how-it-works",
+                  "gateway/k8s/installation/architecture",
                   "gateway/k8s/releasing",
                   "gateway/k8s/installation/network-egress",
                   "gateway/k8s/installation/update",
@@ -511,8 +516,13 @@
             "pages": [
               "obs/index",
               "obs/traffic-inspection",
-              "obs/events/index",
-              "obs/events/reference"
+              {
+                "group": "Events",
+                "pages": [
+                  "obs/events/index",
+                  "obs/events/reference"
+                ]
+              }
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -274,73 +274,308 @@
           "gateway/how-it-works",
           "gateway/points-of-presence",
           {
-            "group": "Endpoints",
+            "group": "Concepts",
             "pages": [
               "gateway/endpoints/index",
+              "gateway/endpoints/agent-endpoints",
+              "gateway/endpoints/protocols",
+              "gateway/endpoints/bindings",
+              "gateway/endpoints/cloud-endpoints/index",
+              "gateway/endpoints/cloud-endpoints/protocols",
+              "gateway/endpoints/cloud-endpoints/bindings",
+              "gateway/endpoints/endpoint-pooling",
+              "gateway/traffic-policy/index",
+              "gateway/traffic-policy/how-it-works",
+              "gateway/traffic-policy/concepts/expressions",
+              "gateway/traffic-policy/concepts/actions",
+              "gateway/traffic-policy/concepts/ip-policies",
+              "gateway/traffic-policy/secrets",
+              "gateway/traffic-policy/identities",
+              "gateway/domains/index",
+              "iam/index",
+              "gateway/agent/index",
+              "gateway/agent/overview",
+              "gateway/k8s/how-it-works",
+              "gateway/k8s/installation/architecture"
+            ]
+          },
+          {
+            "group": "Getting Started With",
+            "pages": [
+              "getting-started/cloud-endpoints-quickstart",
+              "gateway/traffic-policy/getting-started/agent-endpoints",
+              "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
+              "gateway/traffic-policy/getting-started/cloud-endpoints",
+              "using-ngrok-with/docker/index",
+              "using-ngrok-with/docker/compose",
+              "using-ngrok-with/docker/desktop",
+              "gateway/k8s/index",
+              "getting-started/kubernetes/ingress",
+              "getting-started/kubernetes/crds",
+              "getting-started/kubernetes/gateway-api",
+              "getting-started/kubernetes/endpoints",
+              "gateway/k8s/guides/local-cluster"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
               {
-                "group": "Agent Endpoints",
+                "group": "Endpoints",
                 "pages": [
-                  "gateway/endpoints/agent-endpoints",
-                  "gateway/endpoints/protocols",
                   "gateway/endpoints/http",
                   "gateway/endpoints/tls",
                   "gateway/endpoints/tcp",
-                  "gateway/endpoints/bindings",
                   "gateway/endpoints/public-endpoints",
                   "gateway/endpoints/internal-endpoints",
-                  "gateway/endpoints/kubernetes-endpoints"
-                ]
-              },
-              {
-                "group": "Cloud Endpoints",
-                "pages": [
-                  "gateway/endpoints/cloud-endpoints/index",
-                  "getting-started/cloud-endpoints-quickstart",
-                  "gateway/endpoints/cloud-endpoints/protocols",
+                  "gateway/endpoints/kubernetes-endpoints",
                   "gateway/endpoints/cloud-endpoints/http",
                   "gateway/endpoints/cloud-endpoints/tls",
                   "gateway/endpoints/cloud-endpoints/tcp",
-                  "gateway/endpoints/cloud-endpoints/bindings",
                   "gateway/endpoints/cloud-endpoints/public-endpoints",
                   "gateway/endpoints/cloud-endpoints/internal-endpoints",
                   "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
                   "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
                   "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
-                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
+                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization",
+                  "gateway/endpoints/load-balancing-multiple-clouds"
                 ]
               },
               {
-                "group": "Pooling & Load Balancing",
+                "group": "Domains & TLS",
                 "pages": [
-                  "gateway/endpoints/endpoint-pooling",
-                  "gateway/endpoints/load-balancing-multiple-clouds"
+                  "gateway/domains/custom-domains",
+                  "gateway/domains/region-pinning",
+                  "gateway/domains/ip-addresses",
+                  "gateway/domains/dedicated-ips",
+                  "gateway/domains/tcp-addresses",
+                  "gateway/domains/tls-certificates",
+                  "gateway/domains/tls-termination",
+                  "gateway/domains/mtls-termination",
+                  "gateway/domains/ddos-protection",
+                  "gateway/domains/global-load-balancer"
+                ]
+              },
+              {
+                "group": "Identity & Access",
+                "pages": [
+                  "iam/users",
+                  "iam/service-users",
+                  "iam/sso",
+                  "iam/rbac",
+                  "iam/domain-controls"
+                ]
+              },
+              {
+                "group": "ngrok Agent",
+                "pages": [
+                  "gateway/agent/upgrade-v2-v3",
+                  "gateway/agent/version-support-policy",
+                  "gateway/agent/deprecation-notices",
+                  "gateway/agent/web-inspection-interface",
+                  "gateway/agent/agent-tls-termination",
+                  "gateway/agent/ssh-reverse-tunnel-agent",
+                  "gateway/agent/connect-url"
+                ]
+              },
+              {
+                "group": "Kubernetes Operator",
+                "pages": [
+                  "gateway/k8s/releasing",
+                  "gateway/k8s/installation/network-egress",
+                  "gateway/k8s/installation/update",
+                  "gateway/k8s/installation/helm",
+                  "gateway/k8s/installation/observability",
+                  "gateway/k8s/installation/uninstall",
+                  "gateway/k8s/guides/multiple-installs",
+                  "gateway/k8s/guides/using-crds",
+                  "gateway/k8s/guides/endpoint-types",
+                  "gateway/k8s/guides/bindings",
+                  "gateway/k8s/guides/pooling",
+                  "gateway/k8s/guides/custom-domain",
+                  "gateway/k8s/guides/customer-networks",
+                  "gateway/k8s/guides/local-projection",
+                  "gateway/k8s/guides/using-gwapi",
+                  "gateway/k8s/guides/using-ingresses",
+                  "gateway/k8s/guides/annotations",
+                  "gateway/k8s/guides/managed-resources",
+                  "gateway/k8s/guides/finalizers",
+                  "gateway/k8s/guides/troubleshooting",
+                  "gateway/k8s/guides/expose-kubernetes-api",
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
+                  "gateway/k8s/guides/using-loadbalancers",
+                  "gateway/k8s/guides/how-to/request-routing",
+                  "gateway/k8s/guides/how-to/tls-routing",
+                  "gateway/k8s/guides/how-to/tcp-routing",
+                  "gateway/k8s/guides/how-to/manipulate-headers",
+                  "gateway/k8s/guides/how-to/redirects",
+                  "gateway/k8s/guides/how-to/rewrite-url",
+                  "gateway/k8s/guides/how-to/static-response",
+                  "gateway/k8s/guides/how-to/terminate-tls",
+                  "gateway/k8s/guides/how-to/upstream-tls",
+                  "gateway/k8s/guides/how-to/rate-limiting",
+                  "gateway/k8s/guides/how-to/deny-requests",
+                  "gateway/k8s/guides/how-to/basic-auth",
+                  "gateway/k8s/guides/how-to/oauth",
+                  "gateway/k8s/guides/how-to/oidc",
+                  "gateway/k8s/guides/how-to/jwt-validation",
+                  "gateway/k8s/guides/how-to/restrict-ips",
+                  "gateway/k8s/guides/how-to/pod-identity",
+                  "gateway/k8s/guides/how-to/circuit-breaking",
+                  "gateway/k8s/guides/how-to/compress-response"
                 ]
               }
             ]
           },
           {
-            "group": "Traffic Policy",
+            "group": "Use Cases",
             "pages": [
-              "gateway/traffic-policy/index",
-              "gateway/traffic-policy/how-it-works",
               {
-                "group": "Concepts",
+                "group": "API Gateway",
                 "pages": [
-                  "gateway/traffic-policy/concepts/expressions",
-                  "gateway/traffic-policy/concepts/actions",
-                  "gateway/traffic-policy/concepts/ip-policies",
-                  "gateway/traffic-policy/secrets",
-                  "gateway/traffic-policy/identities"
+                  "gateway/api-gateway/get-started",
+                  "gateway/api-gateway/multicloud",
+                  "gateway/api-gateway/monitor-ngrok"
                 ]
               },
               {
-                "group": "Quickstarts",
+                "group": "Device Gateway",
                 "pages": [
-                  "gateway/traffic-policy/getting-started/agent-endpoints",
-                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
-                  "gateway/traffic-policy/getting-started/cloud-endpoints"
+                  "gateway/device-gateway/overview",
+                  "gateway/device-gateway/quickstart",
+                  "gateway/device-gateway/faq",
+                  "gateway/device-gateway/agent",
+                  "gateway/device-gateway/cloud-to-device",
+                  "gateway/device-gateway/remote-access",
+                  "gateway/device-gateway/private-connectivity",
+                  "gateway/device-gateway/fleet-management",
+                  "gateway/device-gateway/sdk",
+                  "gateway/device-gateway/security",
+                  "gateway/device-gateway/tunnels",
+                  "gateway/device-gateway/traffic-policy",
+                  "gateway/device-gateway/linux",
+                  "gateway/device-gateway/arm64",
+                  "gateway/device-gateway/raspberry-pi",
+                  "gateway/device-gateway/raspbian",
+                  "gateway/device-gateway/windows"
                 ]
               },
+              {
+                "group": "Site-to-Site Connectivity",
+                "pages": [
+                  "gateway/site-to-site-connectivity/overview",
+                  "gateway/site-to-site-connectivity/quickstart",
+                  "gateway/site-to-site-connectivity/index",
+                  "gateway/site-to-site-connectivity/faq",
+                  "gateway/site-to-site-connectivity/end-customers",
+                  "gateway/site-to-site-connectivity/agent-tls-termination",
+                  "gateway/site-to-site-connectivity/region-ip-resolution",
+                  "gateway/site-to-site-connectivity/authtoken-acls",
+                  "gateway/site-to-site-connectivity/background-service",
+                  "gateway/site-to-site-connectivity/redundant-agents",
+                  "gateway/site-to-site-connectivity/traffic-events",
+                  "gateway/site-to-site-connectivity/multi-region-failover",
+                  "gateway/site-to-site-connectivity/customer-networks",
+                  "gateway/site-to-site-connectivity/non-k8s-environment",
+                  "gateway/site-to-site-connectivity/custom-connect-url",
+                  "gateway/site-to-site-connectivity/agent-cli",
+                  "gateway/site-to-site-connectivity/agent-sdks",
+                  "gateway/site-to-site-connectivity/apis-terraform",
+                  "gateway/site-to-site-connectivity/agent-packaging"
+                ]
+              },
+              {
+                "group": "Webhooks to On-Prem",
+                "pages": [
+                  "gateway/webhooks-to-on-prem/overview",
+                  "gateway/webhooks-to-on-prem/quickstart",
+                  "gateway/webhooks-to-on-prem/tutorial"
+                ]
+              },
+              {
+                "group": "Security Best Practices",
+                "pages": [
+                  "gateway/security-dev-productivity/index",
+                  "gateway/security-dev-productivity/securing-your-tunnels",
+                  "gateway/security-dev-productivity/hipaa-compliance",
+                  "gateway/identity-aware-proxy/securing-with-oauth",
+                  "gateway/ssh-rdp/index",
+                  "gateway/running-behind-firewalls"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Observability",
+            "pages": [
+              "obs/index",
+              "obs/traffic-inspection",
+              "obs/events/index",
+              "obs/events/reference"
+            ]
+          },
+          {
+            "group": "Examples",
+            "pages": [
+              {
+                "group": "Gateway",
+                "pages": [
+                  "gateway/examples",
+                  "gateway/examples/front-door-pattern",
+                  "gateway/examples/multiplex",
+                  "gateway/examples/custom-error-pages",
+                  "gateway/examples/paas-alternative-gateway",
+                  "gateway/examples/agent-assisted-gateway",
+                  "gateway/examples/microservices-gateway",
+                  "gateway/examples/webhook-gateway",
+                  "gateway/examples/database-gateway",
+                  "gateway/examples/ephemeral-workloads",
+                  "gateway/examples/blue-green-deployments",
+                  "gateway/examples/canary-deployments",
+                  "gateway/examples/ip-restrictions-basic-auth",
+                  "gateway/examples/lock-admin-dashboards",
+                  "gateway/examples/maintenance-mode",
+                  "gateway/examples/minecraft",
+                  "gateway/examples/n8n",
+                  "gateway/examples/offload-analytics",
+                  "gateway/examples/odoo",
+                  "gateway/examples/ollama",
+                  "gateway/examples/pre-tier-requests",
+                  "gateway/examples/rewrite-headers-redirects",
+                  "gateway/examples/route-api-app-traffic-user-agent",
+                  "gateway/examples/route-by-geography",
+                  "gateway/examples/route-by-oidc",
+                  "gateway/examples/secure-developer-environments",
+                  "gateway/examples/validate-requests-identity",
+                  "gateway/examples/wordpress"
+                ]
+              },
+              {
+                "group": "Traffic Policy",
+                "pages": [
+                  "gateway/traffic-policy/examples/index",
+                  "gateway/traffic-policy/examples/a-b-tests",
+                  "gateway/traffic-policy/examples/add-and-remove-headers",
+                  "gateway/traffic-policy/examples/add-authentication",
+                  "gateway/traffic-policy/examples/block-unwanted-requests",
+                  "gateway/traffic-policy/examples/filter-by-ip-category",
+                  "gateway/traffic-policy/examples/compress-json-responses",
+                  "gateway/traffic-policy/examples/enforce-tls",
+                  "gateway/traffic-policy/examples/event-logging",
+                  "gateway/traffic-policy/examples/oauth-protection",
+                  "gateway/traffic-policy/examples/rate-limit-requests",
+                  "gateway/traffic-policy/examples/route-requests",
+                  "gateway/traffic-policy/examples/url-rewrites",
+                  "gateway/traffic-policy/examples/user-agent-filtering"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "gateway/traffic-policy/macros/index",
               {
                 "group": "Actions",
                 "pages": [
@@ -376,28 +611,8 @@
                 ]
               },
               {
-                "group": "Examples",
+                "group": "Variables",
                 "pages": [
-                  "gateway/traffic-policy/examples/index",
-                  "gateway/traffic-policy/examples/a-b-tests",
-                  "gateway/traffic-policy/examples/add-and-remove-headers",
-                  "gateway/traffic-policy/examples/add-authentication",
-                  "gateway/traffic-policy/examples/block-unwanted-requests",
-                  "gateway/traffic-policy/examples/filter-by-ip-category",
-                  "gateway/traffic-policy/examples/compress-json-responses",
-                  "gateway/traffic-policy/examples/enforce-tls",
-                  "gateway/traffic-policy/examples/event-logging",
-                  "gateway/traffic-policy/examples/oauth-protection",
-                  "gateway/traffic-policy/examples/rate-limit-requests",
-                  "gateway/traffic-policy/examples/route-requests",
-                  "gateway/traffic-policy/examples/url-rewrites",
-                  "gateway/traffic-policy/examples/user-agent-filtering"
-                ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "gateway/traffic-policy/macros/index",
                   "gateway/traffic-policy/variables/index",
                   "gateway/traffic-policy/variables/action",
                   "gateway/traffic-policy/variables/connection",
@@ -407,163 +622,9 @@
                   "gateway/traffic-policy/variables/res",
                   "gateway/traffic-policy/variables/time"
                 ]
-              }
-            ]
-          },
-          {
-            "group": "Domains & TLS",
-            "pages": [
-              "gateway/domains/index",
-              "gateway/domains/custom-domains",
-              "gateway/domains/region-pinning",
-              "gateway/domains/ip-addresses",
-              "gateway/domains/dedicated-ips",
-              "gateway/domains/tcp-addresses",
-              "gateway/domains/tls-certificates",
-              "gateway/domains/tls-termination",
-              "gateway/domains/mtls-termination",
-              "gateway/domains/ddos-protection",
-              "gateway/domains/global-load-balancer"
-            ]
-          },
-          {
-            "group": "Identity & Access",
-            "pages": [
-              "iam/index",
-              {
-                "group": "Principals",
-                "pages": [
-                  "iam/users",
-                  "iam/service-users"
-                ]
               },
               {
-                "group": "Account Governance",
-                "pages": [
-                  "iam/sso",
-                  "iam/rbac",
-                  "iam/domain-controls"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Observability",
-            "pages": [
-              "obs/index",
-              "obs/traffic-inspection",
-              {
-                "group": "Events",
-                "pages": [
-                  "obs/events/index",
-                  "obs/events/reference"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "ngrok Agent",
-            "pages": [
-              "gateway/agent/index",
-              "gateway/agent/overview",
-              "gateway/agent/upgrade-v2-v3",
-              "gateway/agent/version-support-policy",
-              "gateway/agent/deprecation-notices",
-              "gateway/agent/web-inspection-interface",
-              "gateway/agent/agent-tls-termination",
-              {
-                "group": "Guides",
-                "pages": [
-                  "gateway/agent/ssh-reverse-tunnel-agent",
-                  "gateway/agent/connect-url",
-                  "using-ngrok-with/docker/index",
-                  "using-ngrok-with/docker/compose",
-                  "using-ngrok-with/docker/desktop"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Kubernetes Operator",
-            "pages": [
-              "gateway/k8s/index",
-              "gateway/k8s/how-it-works",
-              "gateway/k8s/installation/architecture",
-              "gateway/k8s/releasing",
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "getting-started/kubernetes/ingress",
-                  "getting-started/kubernetes/crds",
-                  "getting-started/kubernetes/gateway-api",
-                  "getting-started/kubernetes/endpoints"
-                ]
-              },
-              {
-                "group": "Installation",
-                "pages": [
-                  "gateway/k8s/installation/network-egress",
-                  "gateway/k8s/installation/update",
-                  "gateway/k8s/installation/helm",
-                  "gateway/k8s/installation/observability",
-                  "gateway/k8s/installation/uninstall",
-                  "gateway/k8s/guides/multiple-installs"
-                ]
-              },
-              {
-                "group": "Guides",
-                "pages": [
-                  "gateway/k8s/guides/local-cluster",
-                  "gateway/k8s/guides/using-crds",
-                  "gateway/k8s/guides/endpoint-types",
-                  "gateway/k8s/guides/bindings",
-                  "gateway/k8s/guides/pooling",
-                  "gateway/k8s/guides/custom-domain",
-                  "gateway/k8s/guides/customer-networks",
-                  "gateway/k8s/guides/local-projection",
-                  "gateway/k8s/guides/using-gwapi",
-                  "gateway/k8s/guides/using-ingresses",
-                  "gateway/k8s/guides/annotations",
-                  "gateway/k8s/guides/managed-resources",
-                  "gateway/k8s/guides/finalizers",
-                  "gateway/k8s/guides/troubleshooting",
-                  "gateway/k8s/guides/expose-kubernetes-api"
-                ]
-              },
-              {
-                "group": "Load Balancing",
-                "pages": [
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
-                  "gateway/k8s/guides/using-loadbalancers"
-                ]
-              },
-              {
-                "group": "How-to",
-                "pages": [
-                  "gateway/k8s/guides/how-to/request-routing",
-                  "gateway/k8s/guides/how-to/tls-routing",
-                  "gateway/k8s/guides/how-to/tcp-routing",
-                  "gateway/k8s/guides/how-to/manipulate-headers",
-                  "gateway/k8s/guides/how-to/redirects",
-                  "gateway/k8s/guides/how-to/rewrite-url",
-                  "gateway/k8s/guides/how-to/static-response",
-                  "gateway/k8s/guides/how-to/terminate-tls",
-                  "gateway/k8s/guides/how-to/upstream-tls",
-                  "gateway/k8s/guides/how-to/rate-limiting",
-                  "gateway/k8s/guides/how-to/deny-requests",
-                  "gateway/k8s/guides/how-to/basic-auth",
-                  "gateway/k8s/guides/how-to/oauth",
-                  "gateway/k8s/guides/how-to/oidc",
-                  "gateway/k8s/guides/how-to/jwt-validation",
-                  "gateway/k8s/guides/how-to/restrict-ips",
-                  "gateway/k8s/guides/how-to/pod-identity",
-                  "gateway/k8s/guides/how-to/circuit-breaking",
-                  "gateway/k8s/guides/how-to/compress-response"
-                ]
-              },
-              {
-                "group": "Custom Resources",
+                "group": "Kubernetes Custom Resources",
                 "pages": [
                   "gateway/k8s/crds/index",
                   "gateway/k8s/crds/agentendpoint",
@@ -575,152 +636,6 @@
                   "gateway/k8s/crds/ippolicy"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Use Cases",
-            "pages": [
-              {
-                "group": "API Gateway",
-                "pages": [
-                  "gateway/api-gateway/get-started",
-                  "gateway/api-gateway/multicloud",
-                  "gateway/api-gateway/monitor-ngrok"
-                ]
-              },
-              {
-                "group": "Device Gateway",
-                "pages": [
-                  "gateway/device-gateway/overview",
-                  "gateway/device-gateway/quickstart",
-                  "gateway/device-gateway/faq",
-                  "gateway/device-gateway/agent",
-                  {
-                    "group": "Guides",
-                    "pages": [
-                      "gateway/device-gateway/cloud-to-device",
-                      "gateway/device-gateway/remote-access",
-                      "gateway/device-gateway/private-connectivity",
-                      "gateway/device-gateway/fleet-management",
-                      "gateway/device-gateway/sdk"
-                    ]
-                  },
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "gateway/device-gateway/security",
-                      "gateway/device-gateway/tunnels",
-                      "gateway/device-gateway/traffic-policy"
-                    ]
-                  },
-                  {
-                    "group": "Installation Guides",
-                    "pages": [
-                      "gateway/device-gateway/linux",
-                      "gateway/device-gateway/arm64",
-                      "gateway/device-gateway/raspberry-pi",
-                      "gateway/device-gateway/raspbian",
-                      "gateway/device-gateway/windows"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Site-to-Site Connectivity",
-                "pages": [
-                  "gateway/site-to-site-connectivity/overview",
-                  "gateway/site-to-site-connectivity/quickstart",
-                  "gateway/site-to-site-connectivity/index",
-                  "gateway/site-to-site-connectivity/faq",
-                  "gateway/site-to-site-connectivity/end-customers",
-                  {
-                    "group": "Security",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/agent-tls-termination",
-                      "gateway/site-to-site-connectivity/region-ip-resolution",
-                      "gateway/site-to-site-connectivity/authtoken-acls"
-                    ]
-                  },
-                  {
-                    "group": "Reliability",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/background-service",
-                      "gateway/site-to-site-connectivity/redundant-agents",
-                      "gateway/site-to-site-connectivity/traffic-events",
-                      "gateway/site-to-site-connectivity/multi-region-failover"
-                    ]
-                  },
-                  {
-                    "group": "Private Addressability",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/customer-networks",
-                      "gateway/site-to-site-connectivity/non-k8s-environment"
-                    ]
-                  },
-                  {
-                    "group": "Production Ready",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/custom-connect-url",
-                      "gateway/site-to-site-connectivity/agent-cli",
-                      "gateway/site-to-site-connectivity/agent-sdks",
-                      "gateway/site-to-site-connectivity/apis-terraform",
-                      "gateway/site-to-site-connectivity/agent-packaging"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Webhooks to On-Prem",
-                "pages": [
-                  "gateway/webhooks-to-on-prem/overview",
-                  "gateway/webhooks-to-on-prem/quickstart",
-                  "gateway/webhooks-to-on-prem/tutorial"
-                ]
-              },
-              {
-                "group": "Security Best Practices",
-                "pages": [
-                  "gateway/security-dev-productivity/index",
-                  "gateway/security-dev-productivity/securing-your-tunnels",
-                  "gateway/security-dev-productivity/hipaa-compliance",
-                  "gateway/identity-aware-proxy/securing-with-oauth",
-                  "gateway/ssh-rdp/index",
-                  "gateway/running-behind-firewalls"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Examples",
-            "pages": [
-              "gateway/examples",
-              "gateway/examples/front-door-pattern",
-              "gateway/examples/multiplex",
-              "gateway/examples/custom-error-pages",
-              "gateway/examples/paas-alternative-gateway",
-              "gateway/examples/agent-assisted-gateway",
-              "gateway/examples/microservices-gateway",
-              "gateway/examples/webhook-gateway",
-              "gateway/examples/database-gateway",
-              "gateway/examples/ephemeral-workloads",
-              "gateway/examples/blue-green-deployments",
-              "gateway/examples/canary-deployments",
-              "gateway/examples/ip-restrictions-basic-auth",
-              "gateway/examples/lock-admin-dashboards",
-              "gateway/examples/maintenance-mode",
-              "gateway/examples/minecraft",
-              "gateway/examples/n8n",
-              "gateway/examples/offload-analytics",
-              "gateway/examples/odoo",
-              "gateway/examples/ollama",
-              "gateway/examples/pre-tier-requests",
-              "gateway/examples/rewrite-headers-redirects",
-              "gateway/examples/route-api-app-traffic-user-agent",
-              "gateway/examples/route-by-geography",
-              "gateway/examples/route-by-oidc",
-              "gateway/examples/secure-developer-environments",
-              "gateway/examples/validate-requests-identity",
-              "gateway/examples/wordpress"
             ]
           }
         ]

--- a/gateway/agent/overview.mdx
+++ b/gateway/agent/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Secure Tunnels Overview
-sidebarTitle: Overview
+sidebarTitle: Secure Tunnels
 description: Learn about ngrok's secure tunnel agent for exposing local services, connecting devices, and creating secure remote access.
 ---
 

--- a/gateway/domains/index.mdx
+++ b/gateway/domains/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Domains
-sidebarTitle: Overview
+sidebarTitle: Domains
 description: Learn how to connect domains to your ngrok endpoints.
 ---
 

--- a/gateway/endpoints/agent-cli-quickstart.mdx
+++ b/gateway/endpoints/agent-cli-quickstart.mdx
@@ -1,6 +1,7 @@
 ---
 title: Agent CLI Quickstart
 sidebarTitle: Quickstart
+icon: rocket
 description: Learn how to get started with ngrok Agent CLI to create secure tunnels from your local applications to the internet.
 ---
 

--- a/gateway/endpoints/bindings.mdx
+++ b/gateway/endpoints/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Bindings
-sidebarTitle: Overview
+sidebarTitle: Bindings
 description: Learn about ngrok's public, internal, and kubernetes endpoint bindings.
 ---
 

--- a/gateway/endpoints/cloud-endpoints/bindings.mdx
+++ b/gateway/endpoints/cloud-endpoints/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Bindings
-sidebarTitle: Overview
+sidebarTitle: Bindings
 description: Learn about ngrok's public, internal, and kubernetes endpoint bindings.
 noindex: true
 ---

--- a/gateway/endpoints/cloud-endpoints/protocols.mdx
+++ b/gateway/endpoints/cloud-endpoints/protocols.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cloud Endpoint Protocols
-sidebarTitle: Overview
+sidebarTitle: Protocols
 description: "Learn about the four endpoint protocols supported by ngrok: HTTP/S, TCP, and TLS, and how they determine traffic processing."
 noindex: true
 ---

--- a/gateway/endpoints/endpoint-pooling.mdx
+++ b/gateway/endpoints/endpoint-pooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Pooling
-sidebarTitle: Overview
+sidebarTitle: Endpoint Pooling
 description: Learn how ngrok enables you to load balance traffic to endpoints with endpoint pooling.
 ---
 

--- a/gateway/endpoints/index.mdx
+++ b/gateway/endpoints/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoints Overview
-sidebarTitle: Overview
+sidebarTitle: Endpoints
 description: Create and manage ngrok Endpoints to deliver and manage traffic to your services.
 ---
 

--- a/gateway/endpoints/protocols.mdx
+++ b/gateway/endpoints/protocols.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Endpoint Protocols
-sidebarTitle: Overview
+sidebarTitle: Protocols
 description: "Learn about the four endpoint protocols supported by ngrok: HTTP/S, TCP, and TLS, and how they determine traffic processing."
 ---
 

--- a/gateway/examples/n8n-redirect.mdx
+++ b/gateway/examples/n8n-redirect.mdx
@@ -1,6 +1,0 @@
----
-title: Securely Put Your Self-Hosted n8n Workflows Online
-sidebarTitle: Grant Access to Your n8n Workflows
-description: This page exists to redirect to the n8n guide
-noindex: true
----

--- a/gateway/examples/ollama-redirect.mdx
+++ b/gateway/examples/ollama-redirect.mdx
@@ -1,6 +1,0 @@
----
-title: Expose and Secure Your Self-Hosted Ollama API
-sidebarTitle: Expose Ollama API
-description: This page exists to redirect to the Ollama API guide
-noindex: true
----

--- a/gateway/how-it-works.mdx
+++ b/gateway/how-it-works.mdx
@@ -1,6 +1,7 @@
 ---
 title: How does ngrok's Gateway work?
 sidebarTitle: How it works
+icon: gears
 description: Learn how ngrok's global cloud service and agent software work together to provide secure ingress to your applications.
 ---
 

--- a/gateway/overview.mdx
+++ b/gateway/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Gateway Overview
 sidebarTitle: Overview
+icon: house
 description: Learn about ngrok's building blocks for creating API and device gateways, identity-aware proxies, site-to-site connectivity, and more.
 ---
 

--- a/gateway/points-of-presence.mdx
+++ b/gateway/points-of-presence.mdx
@@ -1,5 +1,6 @@
 ---
 title: Points of Presence
+icon: globe
 description: Learn about ngrok's globally distributed points of presence for low-latency traffic routing to your applications worldwide.
 ---
 

--- a/gateway/traffic-policy/examples/index.mdx
+++ b/gateway/traffic-policy/examples/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Traffic Policy Examples
-sidebarTitle: Overview
+sidebarTitle: Traffic Policy Examples
 description: Example Traffic Policies to help you get started.
 mode: wide
 ---

--- a/gateway/traffic-policy/index.mdx
+++ b/gateway/traffic-policy/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Traffic Policy Overview
-sidebarTitle: Overview
+sidebarTitle: Traffic Policy
 description: Learn about ngrok's Traffic Policy for authenticating requests, rate limiting traffic, rewriting URLs, and applying security controls.
 ---
 


### PR DESCRIPTION
Alternative Gateway sidebar structure - **variant A of three**, mirroring the AI Gateway tab's navigation grammar. Alongside #2314 (mirrors the dashboard) and #2315 (primitives lead, dashboard vocabulary). Pick one of the three. Navigation plus `sidebarTitle` frontmatter only — no file moves, no new redirects, no body prose changes.

| Change | Detail |
|---|---|
| Group vocabulary | Adopts AI Gateway's functional groups: Concepts, Getting Started With, Guides, Use Cases, Observability, Examples, Reference |
| Shape | 4 flat entry pages + 7 top-level groups, max nesting depth 2 — matches AI Gateway (6 + 8, depth 2) |
| Was | 3 flat pages + 13 top-level groups, max depth 4 |
| Primitives | Endpoints, Traffic Policy, Domains & TLS are distributed across Concepts / Guides / Reference rather than being top-level groups |
| Also: orphans wired | 7 pages reachable only via redirect are now in the nav, incl. `k8s/guides/expose-kubernetes-api` (380 lines) and `device-gateway/agent` (280 lines) |
| Also: stub bug fixed | `examples/n8n-redirect` and `examples/ollama-redirect` were empty `noindex` stubs wired into the sidebar purely to satisfy nav validation, redirecting to the real pages, which were themselves absent from nav. Real pages wired, stubs deleted, redirects kept |
| Page count | 254 → 259, all resolving to files |
| Checks | `mint broken-links` 2 failures, identical to `main` (pre-existing, `snippets/k8s/_changelog.mdx`); `check-redirect-conflicts` clean |


