### PR TITLE
Gateway sidebar variant B: mirror the product dashboard's nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -270,6 +270,7 @@
         "tab": "Gateway",
         "pages": [
           "gateway/overview",
+          "gateway/endpoints/agent-cli-quickstart",
           "gateway/how-it-works",
           "gateway/points-of-presence",
           {
@@ -280,25 +281,14 @@
                 "group": "Agent Endpoints",
                 "pages": [
                   "gateway/endpoints/agent-endpoints",
-                  "gateway/endpoints/agent-cli-quickstart",
-                  {
-                    "group": "Protocols",
-                    "pages": [
-                      "gateway/endpoints/protocols",
-                      "gateway/endpoints/http",
-                      "gateway/endpoints/tls",
-                      "gateway/endpoints/tcp"
-                    ]
-                  },
-                  {
-                    "group": "Bindings",
-                    "pages": [
-                      "gateway/endpoints/bindings",
-                      "gateway/endpoints/public-endpoints",
-                      "gateway/endpoints/internal-endpoints",
-                      "gateway/endpoints/kubernetes-endpoints"
-                    ]
-                  }
+                  "gateway/endpoints/protocols",
+                  "gateway/endpoints/http",
+                  "gateway/endpoints/tls",
+                  "gateway/endpoints/tcp",
+                  "gateway/endpoints/bindings",
+                  "gateway/endpoints/public-endpoints",
+                  "gateway/endpoints/internal-endpoints",
+                  "gateway/endpoints/kubernetes-endpoints"
                 ]
               },
               {
@@ -306,41 +296,21 @@
                 "pages": [
                   "gateway/endpoints/cloud-endpoints/index",
                   "getting-started/cloud-endpoints-quickstart",
-                  {
-                    "group": "Protocols",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/protocols",
-                      "gateway/endpoints/cloud-endpoints/http",
-                      "gateway/endpoints/cloud-endpoints/tls",
-                      "gateway/endpoints/cloud-endpoints/tcp"
-                    ]
-                  },
-                  {
-                    "group": "Bindings",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/bindings",
-                      "gateway/endpoints/cloud-endpoints/public-endpoints",
-                      "gateway/endpoints/cloud-endpoints/internal-endpoints",
-                      "gateway/endpoints/cloud-endpoints/kubernetes-endpoints"
-                    ]
-                  },
-                  {
-                    "group": "Guides",
-                    "pages": [
-                      "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
-                      {
-                        "group": "Forwarding Traffic",
-                        "pages": [
-                          "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
-                          "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
-                        ]
-                      }
-                    ]
-                  }
+                  "gateway/endpoints/cloud-endpoints/protocols",
+                  "gateway/endpoints/cloud-endpoints/http",
+                  "gateway/endpoints/cloud-endpoints/tls",
+                  "gateway/endpoints/cloud-endpoints/tcp",
+                  "gateway/endpoints/cloud-endpoints/bindings",
+                  "gateway/endpoints/cloud-endpoints/public-endpoints",
+                  "gateway/endpoints/cloud-endpoints/internal-endpoints",
+                  "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
+                  "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
+                  "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
+                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
                 ]
               },
               {
-                "group": "Pooling & load balancing",
+                "group": "Pooling & Load Balancing",
                 "pages": [
                   "gateway/endpoints/endpoint-pooling",
                   "gateway/endpoints/load-balancing-multiple-clouds"
@@ -354,9 +324,20 @@
               "gateway/traffic-policy/index",
               "gateway/traffic-policy/how-it-works",
               {
+                "group": "Concepts",
+                "pages": [
+                  "gateway/traffic-policy/concepts/expressions",
+                  "gateway/traffic-policy/concepts/actions",
+                  "gateway/traffic-policy/concepts/ip-policies",
+                  "gateway/traffic-policy/secrets",
+                  "gateway/traffic-policy/identities"
+                ]
+              },
+              {
                 "group": "Quickstarts",
                 "pages": [
                   "gateway/traffic-policy/getting-started/agent-endpoints",
+                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
                   "gateway/traffic-policy/getting-started/cloud-endpoints"
                 ]
               },
@@ -414,31 +395,17 @@
                 ]
               },
               {
-                "group": "References",
+                "group": "Reference",
                 "pages": [
-                  "/gateway/traffic-policy/concepts/expressions",
                   "gateway/traffic-policy/macros/index",
-                  {
-                    "group": "Variables",
-                    "pages": [
-                      "gateway/traffic-policy/variables/index",
-                      "gateway/traffic-policy/variables/action",
-                      "gateway/traffic-policy/variables/connection",
-                      "gateway/traffic-policy/variables/endpoint",
-                      "gateway/traffic-policy/variables/ip-intel",
-                      "gateway/traffic-policy/variables/req",
-                      "gateway/traffic-policy/variables/res",
-                      "gateway/traffic-policy/variables/time"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Traffic Policy Features",
-                "pages": [
-                  "gateway/traffic-policy/secrets",
-                  "gateway/traffic-policy/identities",
-                  "gateway/traffic-policy/concepts/ip-policies"
+                  "gateway/traffic-policy/variables/index",
+                  "gateway/traffic-policy/variables/action",
+                  "gateway/traffic-policy/variables/connection",
+                  "gateway/traffic-policy/variables/endpoint",
+                  "gateway/traffic-policy/variables/ip-intel",
+                  "gateway/traffic-policy/variables/req",
+                  "gateway/traffic-policy/variables/res",
+                  "gateway/traffic-policy/variables/time"
                 ]
               }
             ]
@@ -446,14 +413,9 @@
           {
             "group": "Domains & TLS",
             "pages": [
-              {
-                "group": "Domains",
-                "pages": [
-                  "gateway/domains/index",
-                  "gateway/domains/custom-domains",
-                  "gateway/domains/region-pinning"
-                ]
-              },
+              "gateway/domains/index",
+              "gateway/domains/custom-domains",
+              "gateway/domains/region-pinning",
               "gateway/domains/ip-addresses",
               "gateway/domains/dedicated-ips",
               "gateway/domains/tcp-addresses",
@@ -502,36 +464,21 @@
           {
             "group": "ngrok Agent",
             "pages": [
-              "gateway/agent/overview",
               "gateway/agent/index",
+              "gateway/agent/overview",
               "gateway/agent/upgrade-v2-v3",
               "gateway/agent/version-support-policy",
               "gateway/agent/deprecation-notices",
-              {
-                "group": "Observing Agent Traffic",
-                "pages": [
-                  "gateway/agent/web-inspection-interface"
-                ]
-              },
+              "gateway/agent/web-inspection-interface",
+              "gateway/agent/agent-tls-termination",
               {
                 "group": "Guides",
                 "pages": [
                   "gateway/agent/ssh-reverse-tunnel-agent",
                   "gateway/agent/connect-url",
-                  {
-                    "group": "Docker",
-                    "pages": [
-                      "using-ngrok-with/docker/index",
-                      "using-ngrok-with/docker/compose",
-                      "using-ngrok-with/docker/desktop"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Agent TLS Termination",
-                "pages": [
-                  "gateway/agent/agent-tls-termination"
+                  "using-ngrok-with/docker/index",
+                  "using-ngrok-with/docker/compose",
+                  "using-ngrok-with/docker/desktop"
                 ]
               }
             ]
@@ -542,7 +489,6 @@
               "gateway/k8s/index",
               "gateway/k8s/how-it-works",
               "gateway/k8s/installation/architecture",
-              "gateway/k8s/guides/local-cluster",
               "gateway/k8s/releasing",
               {
                 "group": "Quickstarts",
@@ -554,7 +500,7 @@
                 ]
               },
               {
-                "group": "Manage",
+                "group": "Installation",
                 "pages": [
                   "gateway/k8s/installation/network-egress",
                   "gateway/k8s/installation/update",
@@ -565,16 +511,9 @@
                 ]
               },
               {
-                "group": "Load Balancing",
+                "group": "Guides",
                 "pages": [
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
-                  "gateway/k8s/guides/using-loadbalancers"
-                ]
-              },
-              {
-                "group": "Usage Guides",
-                "pages": [
+                  "gateway/k8s/guides/local-cluster",
                   "gateway/k8s/guides/using-crds",
                   "gateway/k8s/guides/endpoint-types",
                   "gateway/k8s/guides/bindings",
@@ -588,6 +527,20 @@
                   "gateway/k8s/guides/managed-resources",
                   "gateway/k8s/guides/finalizers",
                   "gateway/k8s/guides/troubleshooting",
+                  "gateway/k8s/guides/expose-kubernetes-api"
+                ]
+              },
+              {
+                "group": "Load Balancing",
+                "pages": [
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
+                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
+                  "gateway/k8s/guides/using-loadbalancers"
+                ]
+              },
+              {
+                "group": "How-to",
+                "pages": [
                   "gateway/k8s/guides/how-to/request-routing",
                   "gateway/k8s/guides/how-to/tls-routing",
                   "gateway/k8s/guides/how-to/tcp-routing",
@@ -625,110 +578,116 @@
             ]
           },
           {
-            "group": "API Gateway",
+            "group": "Use Cases",
             "pages": [
-              "gateway/api-gateway/get-started",
-              "gateway/api-gateway/multicloud",
-              "gateway/api-gateway/monitor-ngrok"
-            ]
-          },
-          {
-            "group": "Device Gateway",
-            "pages": [
-              "gateway/device-gateway/overview",
-              "gateway/device-gateway/quickstart",
-              "gateway/device-gateway/faq",
               {
-                "group": "Use cases",
+                "group": "API Gateway",
                 "pages": [
-                  "gateway/device-gateway/cloud-to-device",
-                  "gateway/device-gateway/remote-access",
-                  "gateway/device-gateway/private-connectivity",
-                  "gateway/device-gateway/fleet-management",
-                  "gateway/device-gateway/sdk"
+                  "gateway/api-gateway/get-started",
+                  "gateway/api-gateway/multicloud",
+                  "gateway/api-gateway/monitor-ngrok"
                 ]
               },
               {
-                "group": "The ngrok platform",
+                "group": "Device Gateway",
                 "pages": [
-                  "gateway/device-gateway/security",
-                  "gateway/device-gateway/tunnels",
-                  "gateway/device-gateway/traffic-policy"
+                  "gateway/device-gateway/overview",
+                  "gateway/device-gateway/quickstart",
+                  "gateway/device-gateway/faq",
+                  "gateway/device-gateway/agent",
+                  {
+                    "group": "Guides",
+                    "pages": [
+                      "gateway/device-gateway/cloud-to-device",
+                      "gateway/device-gateway/remote-access",
+                      "gateway/device-gateway/private-connectivity",
+                      "gateway/device-gateway/fleet-management",
+                      "gateway/device-gateway/sdk"
+                    ]
+                  },
+                  {
+                    "group": "Concepts",
+                    "pages": [
+                      "gateway/device-gateway/security",
+                      "gateway/device-gateway/tunnels",
+                      "gateway/device-gateway/traffic-policy"
+                    ]
+                  },
+                  {
+                    "group": "Installation Guides",
+                    "pages": [
+                      "gateway/device-gateway/linux",
+                      "gateway/device-gateway/arm64",
+                      "gateway/device-gateway/raspberry-pi",
+                      "gateway/device-gateway/raspbian",
+                      "gateway/device-gateway/windows"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Installation Guides",
+                "group": "Site-to-Site Connectivity",
                 "pages": [
-                  "gateway/device-gateway/linux",
-                  "gateway/device-gateway/arm64",
-                  "gateway/device-gateway/raspberry-pi",
-                  "gateway/device-gateway/raspbian",
-                  "gateway/device-gateway/windows"
+                  "gateway/site-to-site-connectivity/overview",
+                  "gateway/site-to-site-connectivity/quickstart",
+                  "gateway/site-to-site-connectivity/index",
+                  "gateway/site-to-site-connectivity/faq",
+                  "gateway/site-to-site-connectivity/end-customers",
+                  {
+                    "group": "Security",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/agent-tls-termination",
+                      "gateway/site-to-site-connectivity/region-ip-resolution",
+                      "gateway/site-to-site-connectivity/authtoken-acls"
+                    ]
+                  },
+                  {
+                    "group": "Reliability",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/background-service",
+                      "gateway/site-to-site-connectivity/redundant-agents",
+                      "gateway/site-to-site-connectivity/traffic-events",
+                      "gateway/site-to-site-connectivity/multi-region-failover"
+                    ]
+                  },
+                  {
+                    "group": "Private Addressability",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/customer-networks",
+                      "gateway/site-to-site-connectivity/non-k8s-environment"
+                    ]
+                  },
+                  {
+                    "group": "Production Ready",
+                    "pages": [
+                      "gateway/site-to-site-connectivity/custom-connect-url",
+                      "gateway/site-to-site-connectivity/agent-cli",
+                      "gateway/site-to-site-connectivity/agent-sdks",
+                      "gateway/site-to-site-connectivity/apis-terraform",
+                      "gateway/site-to-site-connectivity/agent-packaging"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Webhooks to On-Prem",
+                "pages": [
+                  "gateway/webhooks-to-on-prem/overview",
+                  "gateway/webhooks-to-on-prem/quickstart",
+                  "gateway/webhooks-to-on-prem/tutorial"
+                ]
+              },
+              {
+                "group": "Security Best Practices",
+                "pages": [
+                  "gateway/security-dev-productivity/index",
+                  "gateway/security-dev-productivity/securing-your-tunnels",
+                  "gateway/security-dev-productivity/hipaa-compliance",
+                  "gateway/identity-aware-proxy/securing-with-oauth",
+                  "gateway/ssh-rdp/index",
+                  "gateway/running-behind-firewalls"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Site-to-Site Connectivity",
-            "pages": [
-              "gateway/site-to-site-connectivity/overview",
-              "gateway/site-to-site-connectivity/quickstart",
-              "gateway/site-to-site-connectivity/index",
-              "gateway/site-to-site-connectivity/faq",
-              "gateway/site-to-site-connectivity/end-customers",
-              {
-                "group": "Security",
-                "pages": [
-                  "gateway/site-to-site-connectivity/agent-tls-termination",
-                  "gateway/site-to-site-connectivity/region-ip-resolution",
-                  "gateway/site-to-site-connectivity/authtoken-acls"
-                ]
-              },
-              {
-                "group": "Reliability",
-                "pages": [
-                  "gateway/site-to-site-connectivity/background-service",
-                  "gateway/site-to-site-connectivity/redundant-agents",
-                  "gateway/site-to-site-connectivity/traffic-events",
-                  "gateway/site-to-site-connectivity/multi-region-failover"
-                ]
-              },
-              {
-                "group": "Private addressability",
-                "pages": [
-                  "gateway/site-to-site-connectivity/customer-networks",
-                  "gateway/site-to-site-connectivity/non-k8s-environment"
-                ]
-              },
-              {
-                "group": "Production ready",
-                "pages": [
-                  "gateway/site-to-site-connectivity/custom-connect-url",
-                  "gateway/site-to-site-connectivity/agent-cli",
-                  "gateway/site-to-site-connectivity/agent-sdks",
-                  "gateway/site-to-site-connectivity/apis-terraform",
-                  "gateway/site-to-site-connectivity/agent-packaging"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Webhooks to On-Prem",
-            "pages": [
-              "gateway/webhooks-to-on-prem/overview",
-              "gateway/webhooks-to-on-prem/quickstart",
-              "gateway/webhooks-to-on-prem/tutorial"
-            ]
-          },
-          {
-            "group": "Security Best Practices",
-            "pages": [
-              "gateway/security-dev-productivity/index",
-              "gateway/security-dev-productivity/securing-your-tunnels",
-              "gateway/security-dev-productivity/hipaa-compliance",
-              "gateway/identity-aware-proxy/securing-with-oauth",
-              "gateway/ssh-rdp/index",
-              "gateway/running-behind-firewalls"
             ]
           },
           {
@@ -750,9 +709,10 @@
               "gateway/examples/lock-admin-dashboards",
               "gateway/examples/maintenance-mode",
               "gateway/examples/minecraft",
-              "gateway/examples/n8n-redirect",
+              "gateway/examples/n8n",
               "gateway/examples/offload-analytics",
-              "/gateway/examples/ollama-redirect",
+              "gateway/examples/odoo",
+              "gateway/examples/ollama",
               "gateway/examples/pre-tier-requests",
               "gateway/examples/rewrite-headers-redirects",
               "gateway/examples/route-api-app-traffic-user-agent",

--- a/docs.json
+++ b/docs.json
@@ -269,191 +269,272 @@
       {
         "tab": "Gateway",
         "pages": [
-          "gateway/overview",
-          "gateway/endpoints/agent-cli-quickstart",
-          "gateway/how-it-works",
-          "gateway/points-of-presence",
           {
-            "group": "Endpoints",
+            "group": "Getting Started",
             "pages": [
-              "gateway/endpoints/index",
+              "gateway/overview",
+              "gateway/endpoints/agent-cli-quickstart",
+              "gateway/how-it-works",
+              "gateway/points-of-presence"
+            ]
+          },
+          {
+            "group": "Connectivity",
+            "pages": [
               {
-                "group": "Agent Endpoints",
+                "group": "Endpoints",
                 "pages": [
-                  "gateway/endpoints/agent-endpoints",
-                  "gateway/endpoints/protocols",
-                  "gateway/endpoints/http",
-                  "gateway/endpoints/tls",
-                  "gateway/endpoints/tcp",
-                  "gateway/endpoints/bindings",
-                  "gateway/endpoints/public-endpoints",
-                  "gateway/endpoints/internal-endpoints",
-                  "gateway/endpoints/kubernetes-endpoints"
+                  "gateway/endpoints/index",
+                  {
+                    "group": "Agent Endpoints",
+                    "pages": [
+                      "gateway/endpoints/agent-endpoints",
+                      "gateway/endpoints/protocols",
+                      "gateway/endpoints/http",
+                      "gateway/endpoints/tls",
+                      "gateway/endpoints/tcp",
+                      "gateway/endpoints/bindings",
+                      "gateway/endpoints/public-endpoints",
+                      "gateway/endpoints/internal-endpoints",
+                      "gateway/endpoints/kubernetes-endpoints"
+                    ]
+                  },
+                  {
+                    "group": "Cloud Endpoints",
+                    "pages": [
+                      "gateway/endpoints/cloud-endpoints/index",
+                      "getting-started/cloud-endpoints-quickstart",
+                      "gateway/endpoints/cloud-endpoints/protocols",
+                      "gateway/endpoints/cloud-endpoints/http",
+                      "gateway/endpoints/cloud-endpoints/tls",
+                      "gateway/endpoints/cloud-endpoints/tcp",
+                      "gateway/endpoints/cloud-endpoints/bindings",
+                      "gateway/endpoints/cloud-endpoints/public-endpoints",
+                      "gateway/endpoints/cloud-endpoints/internal-endpoints",
+                      "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
+                      "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
+                      "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
+                      "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
+                    ]
+                  },
+                  {
+                    "group": "Pooling & Load Balancing",
+                    "pages": [
+                      "gateway/endpoints/endpoint-pooling",
+                      "gateway/endpoints/load-balancing-multiple-clouds"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Cloud Endpoints",
+                "group": "Agents",
                 "pages": [
-                  "gateway/endpoints/cloud-endpoints/index",
-                  "getting-started/cloud-endpoints-quickstart",
-                  "gateway/endpoints/cloud-endpoints/protocols",
-                  "gateway/endpoints/cloud-endpoints/http",
-                  "gateway/endpoints/cloud-endpoints/tls",
-                  "gateway/endpoints/cloud-endpoints/tcp",
-                  "gateway/endpoints/cloud-endpoints/bindings",
-                  "gateway/endpoints/cloud-endpoints/public-endpoints",
-                  "gateway/endpoints/cloud-endpoints/internal-endpoints",
-                  "gateway/endpoints/cloud-endpoints/kubernetes-endpoints",
-                  "gateway/endpoints/cloud-endpoints/change-domain-endpoint",
-                  "gateway/endpoints/cloud-endpoints/forwarding-and-load-balancing",
-                  "gateway/endpoints/cloud-endpoints/routing-and-policy-decentralization"
+                  "gateway/agent/index",
+                  "gateway/agent/overview",
+                  "gateway/agent/upgrade-v2-v3",
+                  "gateway/agent/version-support-policy",
+                  "gateway/agent/deprecation-notices",
+                  "gateway/agent/web-inspection-interface",
+                  "gateway/agent/agent-tls-termination",
+                  "gateway/agent/ssh-reverse-tunnel-agent",
+                  "using-ngrok-with/docker/index",
+                  "using-ngrok-with/docker/compose",
+                  "using-ngrok-with/docker/desktop"
                 ]
               },
               {
-                "group": "Pooling & Load Balancing",
+                "group": "Kubernetes Operators",
                 "pages": [
-                  "gateway/endpoints/endpoint-pooling",
-                  "gateway/endpoints/load-balancing-multiple-clouds"
+                  "gateway/k8s/index",
+                  "gateway/k8s/how-it-works",
+                  "gateway/k8s/installation/architecture",
+                  "gateway/k8s/releasing",
+                  {
+                    "group": "Quickstarts",
+                    "pages": [
+                      "getting-started/kubernetes/ingress",
+                      "getting-started/kubernetes/crds",
+                      "getting-started/kubernetes/gateway-api",
+                      "getting-started/kubernetes/endpoints"
+                    ]
+                  },
+                  {
+                    "group": "Installation",
+                    "pages": [
+                      "gateway/k8s/installation/network-egress",
+                      "gateway/k8s/installation/update",
+                      "gateway/k8s/installation/helm",
+                      "gateway/k8s/installation/observability",
+                      "gateway/k8s/installation/uninstall"
+                    ]
+                  },
+                  {
+                    "group": "Load Balancing",
+                    "pages": [
+                      "gateway/k8s/load-balancing/load-balancing-kubernetes",
+                      "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters"
+                    ]
+                  },
+                  {
+                    "group": "How-to",
+                    "pages": [
+                      "gateway/k8s/guides/how-to/request-routing",
+                      "gateway/k8s/guides/how-to/tls-routing",
+                      "gateway/k8s/guides/how-to/tcp-routing",
+                      "gateway/k8s/guides/how-to/manipulate-headers",
+                      "gateway/k8s/guides/how-to/redirects",
+                      "gateway/k8s/guides/how-to/rewrite-url",
+                      "gateway/k8s/guides/how-to/static-response",
+                      "gateway/k8s/guides/how-to/terminate-tls",
+                      "gateway/k8s/guides/how-to/upstream-tls",
+                      "gateway/k8s/guides/how-to/rate-limiting",
+                      "gateway/k8s/guides/how-to/deny-requests",
+                      "gateway/k8s/guides/how-to/basic-auth",
+                      "gateway/k8s/guides/how-to/oauth",
+                      "gateway/k8s/guides/how-to/oidc",
+                      "gateway/k8s/guides/how-to/jwt-validation",
+                      "gateway/k8s/guides/how-to/restrict-ips",
+                      "gateway/k8s/guides/how-to/pod-identity",
+                      "gateway/k8s/guides/how-to/circuit-breaking",
+                      "gateway/k8s/guides/how-to/compress-response"
+                    ]
+                  },
+                  {
+                    "group": "Custom Resources",
+                    "pages": [
+                      "gateway/k8s/crds/index",
+                      "gateway/k8s/crds/agentendpoint",
+                      "gateway/k8s/crds/cloudendpoint",
+                      "gateway/k8s/crds/ngroktrafficpolicy",
+                      "gateway/k8s/crds/boundendpoint",
+                      "gateway/k8s/crds/domain",
+                      "gateway/k8s/crds/kubernetesoperator",
+                      "gateway/k8s/crds/ippolicy"
+                    ]
+                  },
+                  {
+                    "group": "Guides",
+                    "pages": [
+                      "gateway/k8s/guides/multiple-installs",
+                      "gateway/k8s/guides/local-cluster",
+                      "gateway/k8s/guides/using-crds",
+                      "gateway/k8s/guides/endpoint-types",
+                      "gateway/k8s/guides/bindings",
+                      "gateway/k8s/guides/pooling",
+                      "gateway/k8s/guides/custom-domain",
+                      "gateway/k8s/guides/customer-networks",
+                      "gateway/k8s/guides/local-projection",
+                      "gateway/k8s/guides/using-gwapi",
+                      "gateway/k8s/guides/using-ingresses",
+                      "gateway/k8s/guides/annotations",
+                      "gateway/k8s/guides/managed-resources",
+                      "gateway/k8s/guides/finalizers",
+                      "gateway/k8s/guides/troubleshooting",
+                      "gateway/k8s/guides/expose-kubernetes-api",
+                      "gateway/k8s/guides/using-loadbalancers"
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
-            "group": "Traffic Policy",
+            "group": "Traffic",
             "pages": [
-              "gateway/traffic-policy/index",
-              "gateway/traffic-policy/how-it-works",
               {
-                "group": "Concepts",
+                "group": "Traffic Policy",
                 "pages": [
+                  "gateway/traffic-policy/index",
+                  "gateway/traffic-policy/how-it-works",
                   "gateway/traffic-policy/concepts/expressions",
                   "gateway/traffic-policy/concepts/actions",
-                  "gateway/traffic-policy/concepts/ip-policies",
-                  "gateway/traffic-policy/secrets",
-                  "gateway/traffic-policy/identities"
+                  "gateway/traffic-policy/identities",
+                  {
+                    "group": "Quickstarts",
+                    "pages": [
+                      "gateway/traffic-policy/getting-started/agent-endpoints",
+                      "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
+                      "gateway/traffic-policy/getting-started/cloud-endpoints"
+                    ]
+                  },
+                  {
+                    "group": "Actions",
+                    "pages": [
+                      "gateway/traffic-policy/actions/index",
+                      "gateway/traffic-policy/actions/add-headers",
+                      "gateway/traffic-policy/actions/ai-gateway",
+                      "gateway/traffic-policy/actions/basic-auth",
+                      "gateway/traffic-policy/actions/circuit-breaker",
+                      "gateway/traffic-policy/actions/close-connection",
+                      "gateway/traffic-policy/actions/compress-response",
+                      "gateway/traffic-policy/actions/custom-response",
+                      "gateway/traffic-policy/actions/deny",
+                      "gateway/traffic-policy/actions/forward-internal",
+                      "gateway/traffic-policy/actions/http-request",
+                      "gateway/traffic-policy/actions/jwt-validation",
+                      "gateway/traffic-policy/actions/log",
+                      "gateway/traffic-policy/actions/oauth",
+                      "gateway/traffic-policy/actions/oidc",
+                      "gateway/traffic-policy/actions/owasp-crs-request",
+                      "gateway/traffic-policy/actions/owasp-crs-response",
+                      "gateway/traffic-policy/actions/rate-limit",
+                      "gateway/traffic-policy/actions/redirect",
+                      "gateway/traffic-policy/actions/remove-headers",
+                      "gateway/traffic-policy/actions/request-body-find-replace",
+                      "gateway/traffic-policy/actions/response-body-find-replace",
+                      "gateway/traffic-policy/actions/restrict-ips",
+                      "gateway/traffic-policy/actions/saml",
+                      "gateway/traffic-policy/actions/set-vars",
+                      "gateway/traffic-policy/actions/sse-find-replace",
+                      "gateway/traffic-policy/actions/terminate-tls",
+                      "gateway/traffic-policy/actions/url-rewrite",
+                      "gateway/traffic-policy/actions/verify-webhook"
+                    ]
+                  },
+                  {
+                    "group": "Examples",
+                    "pages": [
+                      "gateway/traffic-policy/examples/index",
+                      "gateway/traffic-policy/examples/a-b-tests",
+                      "gateway/traffic-policy/examples/add-and-remove-headers",
+                      "gateway/traffic-policy/examples/add-authentication",
+                      "gateway/traffic-policy/examples/block-unwanted-requests",
+                      "gateway/traffic-policy/examples/filter-by-ip-category",
+                      "gateway/traffic-policy/examples/compress-json-responses",
+                      "gateway/traffic-policy/examples/enforce-tls",
+                      "gateway/traffic-policy/examples/event-logging",
+                      "gateway/traffic-policy/examples/oauth-protection",
+                      "gateway/traffic-policy/examples/rate-limit-requests",
+                      "gateway/traffic-policy/examples/route-requests",
+                      "gateway/traffic-policy/examples/url-rewrites",
+                      "gateway/traffic-policy/examples/user-agent-filtering"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "pages": [
+                      "gateway/traffic-policy/macros/index",
+                      "gateway/traffic-policy/variables/index",
+                      "gateway/traffic-policy/variables/action",
+                      "gateway/traffic-policy/variables/connection",
+                      "gateway/traffic-policy/variables/endpoint",
+                      "gateway/traffic-policy/variables/ip-intel",
+                      "gateway/traffic-policy/variables/req",
+                      "gateway/traffic-policy/variables/res",
+                      "gateway/traffic-policy/variables/time"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Quickstarts",
+                "group": "Traffic Inspector",
                 "pages": [
-                  "gateway/traffic-policy/getting-started/agent-endpoints",
-                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
-                  "gateway/traffic-policy/getting-started/cloud-endpoints"
+                  "obs/index",
+                  "obs/traffic-inspection"
                 ]
               },
               {
-                "group": "Actions",
-                "pages": [
-                  "gateway/traffic-policy/actions/index",
-                  "gateway/traffic-policy/actions/add-headers",
-                  "gateway/traffic-policy/actions/ai-gateway",
-                  "gateway/traffic-policy/actions/basic-auth",
-                  "gateway/traffic-policy/actions/circuit-breaker",
-                  "gateway/traffic-policy/actions/close-connection",
-                  "gateway/traffic-policy/actions/compress-response",
-                  "gateway/traffic-policy/actions/custom-response",
-                  "gateway/traffic-policy/actions/deny",
-                  "gateway/traffic-policy/actions/forward-internal",
-                  "gateway/traffic-policy/actions/http-request",
-                  "gateway/traffic-policy/actions/jwt-validation",
-                  "gateway/traffic-policy/actions/log",
-                  "gateway/traffic-policy/actions/oauth",
-                  "gateway/traffic-policy/actions/oidc",
-                  "gateway/traffic-policy/actions/owasp-crs-request",
-                  "gateway/traffic-policy/actions/owasp-crs-response",
-                  "gateway/traffic-policy/actions/rate-limit",
-                  "gateway/traffic-policy/actions/redirect",
-                  "gateway/traffic-policy/actions/remove-headers",
-                  "gateway/traffic-policy/actions/request-body-find-replace",
-                  "gateway/traffic-policy/actions/response-body-find-replace",
-                  "gateway/traffic-policy/actions/restrict-ips",
-                  "gateway/traffic-policy/actions/saml",
-                  "gateway/traffic-policy/actions/set-vars",
-                  "gateway/traffic-policy/actions/sse-find-replace",
-                  "gateway/traffic-policy/actions/terminate-tls",
-                  "gateway/traffic-policy/actions/url-rewrite",
-                  "gateway/traffic-policy/actions/verify-webhook"
-                ]
-              },
-              {
-                "group": "Examples",
-                "pages": [
-                  "gateway/traffic-policy/examples/index",
-                  "gateway/traffic-policy/examples/a-b-tests",
-                  "gateway/traffic-policy/examples/add-and-remove-headers",
-                  "gateway/traffic-policy/examples/add-authentication",
-                  "gateway/traffic-policy/examples/block-unwanted-requests",
-                  "gateway/traffic-policy/examples/filter-by-ip-category",
-                  "gateway/traffic-policy/examples/compress-json-responses",
-                  "gateway/traffic-policy/examples/enforce-tls",
-                  "gateway/traffic-policy/examples/event-logging",
-                  "gateway/traffic-policy/examples/oauth-protection",
-                  "gateway/traffic-policy/examples/rate-limit-requests",
-                  "gateway/traffic-policy/examples/route-requests",
-                  "gateway/traffic-policy/examples/url-rewrites",
-                  "gateway/traffic-policy/examples/user-agent-filtering"
-                ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "gateway/traffic-policy/macros/index",
-                  "gateway/traffic-policy/variables/index",
-                  "gateway/traffic-policy/variables/action",
-                  "gateway/traffic-policy/variables/connection",
-                  "gateway/traffic-policy/variables/endpoint",
-                  "gateway/traffic-policy/variables/ip-intel",
-                  "gateway/traffic-policy/variables/req",
-                  "gateway/traffic-policy/variables/res",
-                  "gateway/traffic-policy/variables/time"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Domains & TLS",
-            "pages": [
-              "gateway/domains/index",
-              "gateway/domains/custom-domains",
-              "gateway/domains/region-pinning",
-              "gateway/domains/ip-addresses",
-              "gateway/domains/dedicated-ips",
-              "gateway/domains/tcp-addresses",
-              "gateway/domains/tls-certificates",
-              "gateway/domains/tls-termination",
-              "gateway/domains/mtls-termination",
-              "gateway/domains/ddos-protection",
-              "gateway/domains/global-load-balancer"
-            ]
-          },
-          {
-            "group": "Identity & Access",
-            "pages": [
-              "iam/index",
-              {
-                "group": "Principals",
-                "pages": [
-                  "iam/users",
-                  "iam/service-users"
-                ]
-              },
-              {
-                "group": "Account Governance",
-                "pages": [
-                  "iam/sso",
-                  "iam/rbac",
-                  "iam/domain-controls"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Observability",
-            "pages": [
-              "obs/index",
-              "obs/traffic-inspection",
-              {
-                "group": "Events",
+                "group": "Log Exporting",
                 "pages": [
                   "obs/events/index",
                   "obs/events/reference"
@@ -462,119 +543,48 @@
             ]
           },
           {
-            "group": "ngrok Agent",
+            "group": "Network",
             "pages": [
-              "gateway/agent/index",
-              "gateway/agent/overview",
-              "gateway/agent/upgrade-v2-v3",
-              "gateway/agent/version-support-policy",
-              "gateway/agent/deprecation-notices",
-              "gateway/agent/web-inspection-interface",
-              "gateway/agent/agent-tls-termination",
               {
-                "group": "Guides",
+                "group": "Domains",
                 "pages": [
-                  "gateway/agent/ssh-reverse-tunnel-agent",
-                  "gateway/agent/connect-url",
-                  "using-ngrok-with/docker/index",
-                  "using-ngrok-with/docker/compose",
-                  "using-ngrok-with/docker/desktop"
+                  "gateway/domains/index",
+                  "gateway/domains/custom-domains",
+                  "gateway/domains/region-pinning",
+                  "gateway/domains/tls-termination",
+                  "gateway/domains/mtls-termination",
+                  "gateway/domains/ddos-protection",
+                  "gateway/domains/global-load-balancer"
+                ]
+              },
+              {
+                "group": "TCP Addresses",
+                "pages": [
+                  "gateway/domains/ip-addresses",
+                  "gateway/domains/dedicated-ips",
+                  "gateway/domains/tcp-addresses"
                 ]
               }
             ]
           },
           {
-            "group": "Kubernetes Operator",
+            "group": "Resources",
             "pages": [
-              "gateway/k8s/index",
-              "gateway/k8s/how-it-works",
-              "gateway/k8s/installation/architecture",
-              "gateway/k8s/releasing",
-              {
-                "group": "Quickstarts",
-                "pages": [
-                  "getting-started/kubernetes/ingress",
-                  "getting-started/kubernetes/crds",
-                  "getting-started/kubernetes/gateway-api",
-                  "getting-started/kubernetes/endpoints"
-                ]
-              },
-              {
-                "group": "Installation",
-                "pages": [
-                  "gateway/k8s/installation/network-egress",
-                  "gateway/k8s/installation/update",
-                  "gateway/k8s/installation/helm",
-                  "gateway/k8s/installation/observability",
-                  "gateway/k8s/installation/uninstall",
-                  "gateway/k8s/guides/multiple-installs"
-                ]
-              },
-              {
-                "group": "Guides",
-                "pages": [
-                  "gateway/k8s/guides/local-cluster",
-                  "gateway/k8s/guides/using-crds",
-                  "gateway/k8s/guides/endpoint-types",
-                  "gateway/k8s/guides/bindings",
-                  "gateway/k8s/guides/pooling",
-                  "gateway/k8s/guides/custom-domain",
-                  "gateway/k8s/guides/customer-networks",
-                  "gateway/k8s/guides/local-projection",
-                  "gateway/k8s/guides/using-gwapi",
-                  "gateway/k8s/guides/using-ingresses",
-                  "gateway/k8s/guides/annotations",
-                  "gateway/k8s/guides/managed-resources",
-                  "gateway/k8s/guides/finalizers",
-                  "gateway/k8s/guides/troubleshooting",
-                  "gateway/k8s/guides/expose-kubernetes-api"
-                ]
-              },
-              {
-                "group": "Load Balancing",
-                "pages": [
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes",
-                  "gateway/k8s/load-balancing/load-balancing-kubernetes-clusters",
-                  "gateway/k8s/guides/using-loadbalancers"
-                ]
-              },
-              {
-                "group": "How-to",
-                "pages": [
-                  "gateway/k8s/guides/how-to/request-routing",
-                  "gateway/k8s/guides/how-to/tls-routing",
-                  "gateway/k8s/guides/how-to/tcp-routing",
-                  "gateway/k8s/guides/how-to/manipulate-headers",
-                  "gateway/k8s/guides/how-to/redirects",
-                  "gateway/k8s/guides/how-to/rewrite-url",
-                  "gateway/k8s/guides/how-to/static-response",
-                  "gateway/k8s/guides/how-to/terminate-tls",
-                  "gateway/k8s/guides/how-to/upstream-tls",
-                  "gateway/k8s/guides/how-to/rate-limiting",
-                  "gateway/k8s/guides/how-to/deny-requests",
-                  "gateway/k8s/guides/how-to/basic-auth",
-                  "gateway/k8s/guides/how-to/oauth",
-                  "gateway/k8s/guides/how-to/oidc",
-                  "gateway/k8s/guides/how-to/jwt-validation",
-                  "gateway/k8s/guides/how-to/restrict-ips",
-                  "gateway/k8s/guides/how-to/pod-identity",
-                  "gateway/k8s/guides/how-to/circuit-breaking",
-                  "gateway/k8s/guides/how-to/compress-response"
-                ]
-              },
-              {
-                "group": "Custom Resources",
-                "pages": [
-                  "gateway/k8s/crds/index",
-                  "gateway/k8s/crds/agentendpoint",
-                  "gateway/k8s/crds/cloudendpoint",
-                  "gateway/k8s/crds/ngroktrafficpolicy",
-                  "gateway/k8s/crds/boundendpoint",
-                  "gateway/k8s/crds/domain",
-                  "gateway/k8s/crds/kubernetesoperator",
-                  "gateway/k8s/crds/ippolicy"
-                ]
-              }
+              "gateway/traffic-policy/concepts/ip-policies",
+              "gateway/traffic-policy/secrets",
+              "gateway/domains/tls-certificates",
+              "gateway/agent/connect-url"
+            ]
+          },
+          {
+            "group": "Identity & Access",
+            "pages": [
+              "iam/index",
+              "iam/users",
+              "iam/service-users",
+              "iam/sso",
+              "iam/rbac",
+              "iam/domain-controls"
             ]
           },
           {
@@ -595,34 +605,19 @@
                   "gateway/device-gateway/quickstart",
                   "gateway/device-gateway/faq",
                   "gateway/device-gateway/agent",
-                  {
-                    "group": "Guides",
-                    "pages": [
-                      "gateway/device-gateway/cloud-to-device",
-                      "gateway/device-gateway/remote-access",
-                      "gateway/device-gateway/private-connectivity",
-                      "gateway/device-gateway/fleet-management",
-                      "gateway/device-gateway/sdk"
-                    ]
-                  },
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "gateway/device-gateway/security",
-                      "gateway/device-gateway/tunnels",
-                      "gateway/device-gateway/traffic-policy"
-                    ]
-                  },
-                  {
-                    "group": "Installation Guides",
-                    "pages": [
-                      "gateway/device-gateway/linux",
-                      "gateway/device-gateway/arm64",
-                      "gateway/device-gateway/raspberry-pi",
-                      "gateway/device-gateway/raspbian",
-                      "gateway/device-gateway/windows"
-                    ]
-                  }
+                  "gateway/device-gateway/cloud-to-device",
+                  "gateway/device-gateway/remote-access",
+                  "gateway/device-gateway/private-connectivity",
+                  "gateway/device-gateway/fleet-management",
+                  "gateway/device-gateway/sdk",
+                  "gateway/device-gateway/security",
+                  "gateway/device-gateway/tunnels",
+                  "gateway/device-gateway/traffic-policy",
+                  "gateway/device-gateway/linux",
+                  "gateway/device-gateway/arm64",
+                  "gateway/device-gateway/raspberry-pi",
+                  "gateway/device-gateway/raspbian",
+                  "gateway/device-gateway/windows"
                 ]
               },
               {
@@ -633,40 +628,20 @@
                   "gateway/site-to-site-connectivity/index",
                   "gateway/site-to-site-connectivity/faq",
                   "gateway/site-to-site-connectivity/end-customers",
-                  {
-                    "group": "Security",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/agent-tls-termination",
-                      "gateway/site-to-site-connectivity/region-ip-resolution",
-                      "gateway/site-to-site-connectivity/authtoken-acls"
-                    ]
-                  },
-                  {
-                    "group": "Reliability",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/background-service",
-                      "gateway/site-to-site-connectivity/redundant-agents",
-                      "gateway/site-to-site-connectivity/traffic-events",
-                      "gateway/site-to-site-connectivity/multi-region-failover"
-                    ]
-                  },
-                  {
-                    "group": "Private Addressability",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/customer-networks",
-                      "gateway/site-to-site-connectivity/non-k8s-environment"
-                    ]
-                  },
-                  {
-                    "group": "Production Ready",
-                    "pages": [
-                      "gateway/site-to-site-connectivity/custom-connect-url",
-                      "gateway/site-to-site-connectivity/agent-cli",
-                      "gateway/site-to-site-connectivity/agent-sdks",
-                      "gateway/site-to-site-connectivity/apis-terraform",
-                      "gateway/site-to-site-connectivity/agent-packaging"
-                    ]
-                  }
+                  "gateway/site-to-site-connectivity/agent-tls-termination",
+                  "gateway/site-to-site-connectivity/region-ip-resolution",
+                  "gateway/site-to-site-connectivity/authtoken-acls",
+                  "gateway/site-to-site-connectivity/background-service",
+                  "gateway/site-to-site-connectivity/redundant-agents",
+                  "gateway/site-to-site-connectivity/traffic-events",
+                  "gateway/site-to-site-connectivity/multi-region-failover",
+                  "gateway/site-to-site-connectivity/customer-networks",
+                  "gateway/site-to-site-connectivity/non-k8s-environment",
+                  "gateway/site-to-site-connectivity/custom-connect-url",
+                  "gateway/site-to-site-connectivity/agent-cli",
+                  "gateway/site-to-site-connectivity/agent-sdks",
+                  "gateway/site-to-site-connectivity/apis-terraform",
+                  "gateway/site-to-site-connectivity/agent-packaging"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -669,33 +669,69 @@
             "group": "Examples",
             "pages": [
               "gateway/examples",
-              "gateway/examples/front-door-pattern",
-              "gateway/examples/multiplex",
-              "gateway/examples/custom-error-pages",
-              "gateway/examples/paas-alternative-gateway",
-              "gateway/examples/agent-assisted-gateway",
-              "gateway/examples/microservices-gateway",
-              "gateway/examples/webhook-gateway",
-              "gateway/examples/database-gateway",
-              "gateway/examples/ephemeral-workloads",
-              "gateway/examples/blue-green-deployments",
-              "gateway/examples/canary-deployments",
-              "gateway/examples/ip-restrictions-basic-auth",
-              "gateway/examples/lock-admin-dashboards",
-              "gateway/examples/maintenance-mode",
-              "gateway/examples/minecraft",
-              "gateway/examples/n8n",
-              "gateway/examples/offload-analytics",
-              "gateway/examples/odoo",
-              "gateway/examples/ollama",
-              "gateway/examples/pre-tier-requests",
-              "gateway/examples/rewrite-headers-redirects",
-              "gateway/examples/route-api-app-traffic-user-agent",
-              "gateway/examples/route-by-geography",
-              "gateway/examples/route-by-oidc",
-              "gateway/examples/secure-developer-environments",
-              "gateway/examples/validate-requests-identity",
-              "gateway/examples/wordpress"
+              {
+                "group": "Secure and Control Access",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/ip-restrictions-basic-auth",
+                  "gateway/examples/lock-admin-dashboards",
+                  "gateway/examples/validate-requests-identity",
+                  "gateway/examples/secure-developer-environments"
+                ]
+              },
+              {
+                "group": "Route and Shape Traffic",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/front-door-pattern",
+                  "gateway/examples/multiplex",
+                  "gateway/examples/microservices-gateway",
+                  "gateway/examples/route-api-app-traffic-user-agent",
+                  "gateway/examples/route-by-geography",
+                  "gateway/examples/route-by-oidc",
+                  "gateway/examples/rewrite-headers-redirects",
+                  "gateway/examples/custom-error-pages"
+                ]
+              },
+              {
+                "group": "Ship Changes Safely",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/blue-green-deployments",
+                  "gateway/examples/canary-deployments",
+                  "gateway/examples/ephemeral-workloads",
+                  "gateway/examples/maintenance-mode"
+                ]
+              },
+              {
+                "group": "Protect and Observe",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/pre-tier-requests",
+                  "gateway/examples/offload-analytics"
+                ]
+              },
+              {
+                "group": "Connect Services",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/database-gateway",
+                  "gateway/examples/webhook-gateway",
+                  "gateway/examples/paas-alternative-gateway",
+                  "gateway/examples/agent-assisted-gateway"
+                ]
+              },
+              {
+                "group": "Expose Self-Hosted Apps",
+                "expanded": false,
+                "pages": [
+                  "gateway/examples/minecraft",
+                  "gateway/examples/n8n",
+                  "gateway/examples/odoo",
+                  "gateway/examples/ollama",
+                  "gateway/examples/wordpress"
+                ]
+              }
             ]
           }
         ]

--- a/gateway/device-gateway/faq.mdx
+++ b/gateway/device-gateway/faq.mdx
@@ -1,7 +1,6 @@
 ---
 title: Device Gateway FAQ
 sidebarTitle: FAQ
-icon: circle-question
 description: Answers to common questions about using ngrok as a device gateway.
 ---
 

--- a/gateway/device-gateway/overview.mdx
+++ b/gateway/device-gateway/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Device Gateway Overview
 sidebarTitle: Overview
-icon: house
 description: Use ngrok to securely connect to devices deployed in remote networks without firewall changes, VPNs, or open ports.
 ---
 

--- a/gateway/device-gateway/quickstart.mdx
+++ b/gateway/device-gateway/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: Device Gateway Quickstart
 sidebarTitle: Quickstart
-icon: rocket
 description: Get a device securely reachable from the internet in minutes using the ngrok agent.
 ---
 

--- a/gateway/endpoints/agent-cli-quickstart.mdx
+++ b/gateway/endpoints/agent-cli-quickstart.mdx
@@ -1,6 +1,7 @@
 ---
 title: Agent CLI Quickstart
 sidebarTitle: Quickstart
+icon: rocket
 description: Learn how to get started with ngrok Agent CLI to create secure tunnels from your local applications to the internet.
 ---
 

--- a/gateway/endpoints/bindings.mdx
+++ b/gateway/endpoints/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Bindings
-sidebarTitle: Overview
+sidebarTitle: Bindings
 description: Learn about ngrok's public, internal, and kubernetes endpoint bindings.
 ---
 

--- a/gateway/endpoints/cloud-endpoints/bindings.mdx
+++ b/gateway/endpoints/cloud-endpoints/bindings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Bindings
-sidebarTitle: Overview
+sidebarTitle: Bindings
 description: Learn about ngrok's public, internal, and kubernetes endpoint bindings.
 noindex: true
 ---

--- a/gateway/endpoints/cloud-endpoints/protocols.mdx
+++ b/gateway/endpoints/cloud-endpoints/protocols.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cloud Endpoint Protocols
-sidebarTitle: Overview
+sidebarTitle: Protocols
 description: "Learn about the four endpoint protocols supported by ngrok: HTTP/S, TCP, and TLS, and how they determine traffic processing."
 noindex: true
 ---

--- a/gateway/endpoints/protocols.mdx
+++ b/gateway/endpoints/protocols.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Endpoint Protocols
-sidebarTitle: Overview
+sidebarTitle: Protocols
 description: "Learn about the four endpoint protocols supported by ngrok: HTTP/S, TCP, and TLS, and how they determine traffic processing."
 ---
 

--- a/gateway/examples/n8n-redirect.mdx
+++ b/gateway/examples/n8n-redirect.mdx
@@ -1,6 +1,0 @@
----
-title: Securely Put Your Self-Hosted n8n Workflows Online
-sidebarTitle: Grant Access to Your n8n Workflows
-description: This page exists to redirect to the n8n guide
-noindex: true
----

--- a/gateway/examples/ollama-redirect.mdx
+++ b/gateway/examples/ollama-redirect.mdx
@@ -1,6 +1,0 @@
----
-title: Expose and Secure Your Self-Hosted Ollama API
-sidebarTitle: Expose Ollama API
-description: This page exists to redirect to the Ollama API guide
-noindex: true
----

--- a/gateway/how-it-works.mdx
+++ b/gateway/how-it-works.mdx
@@ -1,6 +1,7 @@
 ---
 title: How does ngrok's Gateway work?
 sidebarTitle: How it works
+icon: gears
 description: Learn how ngrok's global cloud service and agent software work together to provide secure ingress to your applications.
 ---
 

--- a/gateway/overview.mdx
+++ b/gateway/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Gateway Overview
 sidebarTitle: Overview
+icon: house
 description: Learn about ngrok's building blocks for creating API and device gateways, identity-aware proxies, site-to-site connectivity, and more.
 ---
 

--- a/gateway/points-of-presence.mdx
+++ b/gateway/points-of-presence.mdx
@@ -1,5 +1,6 @@
 ---
 title: Points of Presence
+icon: globe
 description: Learn about ngrok's globally distributed points of presence for low-latency traffic routing to your applications worldwide.
 ---
 

--- a/gateway/site-to-site-connectivity/end-customers.mdx
+++ b/gateway/site-to-site-connectivity/end-customers.mdx
@@ -1,7 +1,6 @@
 ---
 title: Why Your Vendor Uses ngrok
 sidebarTitle: Why Your Vendor Uses ngrok
-icon: comments
 description: Why your vendor has requested you install ngrok for site-to-site connectivity, how it works, and why it's secure.
 ---
 

--- a/gateway/site-to-site-connectivity/faq.mdx
+++ b/gateway/site-to-site-connectivity/faq.mdx
@@ -1,7 +1,6 @@
 ---
 title: Site-to-Site Connectivity FAQ
 sidebarTitle: FAQ
-icon: circle-question
 description: Answers to common questions about setting up and managing site-to-site connectivity with ngrok.
 ---
 

--- a/gateway/site-to-site-connectivity/index.mdx
+++ b/gateway/site-to-site-connectivity/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Connect to Your Customer's Network"
 sidebarTitle: "Tutorial"
-icon: book
 description: Follow an in-depth tutorial to learn how to use ngrok to remotely access APIs and DBs in your customer's network, connecting remotely without a VPN.
 ---
 

--- a/gateway/site-to-site-connectivity/overview.mdx
+++ b/gateway/site-to-site-connectivity/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Site-to-Site Connectivity Overview
 sidebarTitle: Overview
-icon: house
 description: Use ngrok to securely connect to APIs, databases, and services in remote private networks without a VPN.
 ---
 

--- a/gateway/site-to-site-connectivity/quickstart.mdx
+++ b/gateway/site-to-site-connectivity/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: Site-to-Site Connectivity Quickstart
 sidebarTitle: Quickstart
-icon: rocket
 description: Get a basic site-to-site connection working in minutes by forwarding traffic from a Cloud Endpoint to a service in a remote network.
 ---
 

--- a/gateway/webhooks-to-on-prem/overview.mdx
+++ b/gateway/webhooks-to-on-prem/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Webhooks to On-Prem
 sidebarTitle: Overview
-icon: house
 description: Use ngrok to grant controlled, compliant access by trusted third-party webhook providers to services inside your network.
 ---
 

--- a/gateway/webhooks-to-on-prem/quickstart.mdx
+++ b/gateway/webhooks-to-on-prem/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Webhooks to On-Prem Quickstart"
 sidebarTitle: Quickstart
-icon: rocket
 description: Verify webhooks and route them to a private service.
 ---
 

--- a/gateway/webhooks-to-on-prem/tutorial.mdx
+++ b/gateway/webhooks-to-on-prem/tutorial.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Webhooks to On-Prem Full Tutorial"
 sidebarTitle: "Tutorial"
-icon: book
 description: Follow an in-depth tutorial to set up webhook verification and routing to your internal services, all managed by a single Traffic Policy.
 ---
 


### PR DESCRIPTION
Alternative Gateway sidebar structure - **variant B of three**, mirroring the product dashboard's navigation. Alongside #2313 (mirrors AI Gateway) and #2315 (primitives lead, dashboard vocabulary). Pick one of the three. Navigation plus `sidebarTitle` frontmatter only — no file moves, no new redirects, no body prose changes.

| Change | Detail |
|---|---|
| Group vocabulary | Adopts the dashboard's groups: Getting Started, Connectivity, Traffic, Network, Resources — plus docs-only Use Cases and Examples |
| Shape | 0 flat entry pages + 8 top-level groups, max nesting depth 3. Nothing sits ungrouped, matching the dashboard |
| Was | 3 flat pages + 13 top-level groups, max depth 4 |
| Connectivity | Endpoints, Agents, Kubernetes Operators grouped together as they are in the dashboard |
| Resources | New group gathering the dashboard's reusable config objects, pulled out of their feature sections: Vaults & Secrets, IP Policies, TLS Certificates, Connect URLs |
| Traffic Policy | Placed under Traffic. The dashboard has no Traffic Policy item at all — it is configured on endpoints there — yet it is the largest section in Gateway docs at 60 pages |
| Traffic Identities | The dashboard's standalone item maps to a single docs page, so it sits inside Traffic Policy rather than as a one-page group |
| Also: orphans wired | 7 pages reachable only via redirect are now in the nav, incl. `k8s/guides/expose-kubernetes-api` (380 lines) and `device-gateway/agent` (280 lines) |
| Also: stub bug fixed | `examples/n8n-redirect` and `examples/ollama-redirect` were empty `noindex` stubs wired into the sidebar purely to satisfy nav validation, redirecting to the real pages, which were themselves absent from nav. Real pages wired, stubs deleted, redirects kept |
| Page count | 254 → 259, all resolving to files |
| Checks | `mint broken-links` 2 failures, identical to `main` (pre-existing, `snippets/k8s/_changelog.mdx`); `check-redirect-conflicts` clean |


