### PR TITLE
docs: embed existing YouTube videos on 9 pages, fix the n8n workshop link

### DIFF
--- a/ai-gateway/quickstart.mdx
+++ b/ai-gateway/quickstart.mdx
@@ -4,7 +4,11 @@ icon: rocket
 description: Integrate ngrok.ai with your application in minutes.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 The onboarding should have you covered, but this short quickstart guide is here just in case.
+
+<YouTubeEmbed videoId="ly8ERfGfgA4" title="How to connect Cursor to a self-hosted LLM using an AI gateway" />
 
 ## Making your first request
 

--- a/gateway/domains/custom-domains.mdx
+++ b/gateway/domains/custom-domains.mdx
@@ -4,7 +4,11 @@ sidebarTitle: Using Custom Domains
 description: Learn how to use your own custom domain with your ngrok endpoints.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 This guide shows you how to use any domain name you already own, such as `app.your-domain.com`, with ngrok.
+
+<YouTubeEmbed videoId="TliAZiDaevM" title="Set up a custom domain on an ngrok account" />
 
 <Note>
 ngrok is not a domain registrar; you must already own a domain name to use it with ngrok.

--- a/gateway/domains/index.mdx
+++ b/gateway/domains/index.mdx
@@ -4,11 +4,15 @@ sidebarTitle: Overview
 description: Learn how to connect domains to your ngrok endpoints.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 ## Domains
 
 Domains enable you to create public endpoints with hostnames matching the
 domain. For example, after you create the domain `your-name.ngrok.app`, you may
 create the Endpoint `https://your-name.ngrok.app`
+
+<YouTubeEmbed videoId="TliAZiDaevM" title="Set up a custom domain on an ngrok account" />
 
 Domain names may be a subdomain of an [ngrok-managed
 domain](#ngrok-managed-domains) like `foo.ngrok.app` or you can [bring your own

--- a/gateway/endpoints/agent-cli-quickstart.mdx
+++ b/gateway/endpoints/agent-cli-quickstart.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Quickstart
 description: Learn how to get started with ngrok Agent CLI to create secure tunnels from your local applications to the internet.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 import AgentCliQuickstartContent from "/snippets/guides/agent-cli-quickstart-content.mdx";
 
 <Prompt description="Give this to your AI coding agent to complete the full quickstart automatically." actions={["copy", "cursor"]}>
@@ -18,5 +20,7 @@ Complete the ngrok Agent CLI quickstart on my machine:
 
 Ask me for my auth token and reserved domain before starting.
 </Prompt>
+
+<YouTubeEmbed videoId="doIbcGDPYB4" title="Set up the ngrok agent in 60 seconds" />
 
 <AgentCliQuickstartContent />

--- a/gateway/examples/n8n.mdx
+++ b/gateway/examples/n8n.mdx
@@ -240,7 +240,7 @@ This policy first verifies any incoming webhooks as before. Then, the policy app
 
 ## What's next?
 
-- Watch the livestreamed [n8n workshop](https://www.youtube.com/watch?v=U5FGr5axBnI) to see this example deployed live.
+- Watch the livestreamed [n8n workshop](https://www.youtube.com/watch?v=Og1S25RvIi8) to see this example deployed live.
 - Read more about [Traffic Policy](/traffic-policy), [core concepts](/gateway/traffic-policy/how-it-works), and [actions](/gateway/traffic-policy/actions) you might want to implement next.
 - View your Ollama traffic in [Traffic Inspector](https://dashboard.ngrok.com/traffic-inspector).
 

--- a/gateway/k8s/index.mdx
+++ b/gateway/k8s/index.mdx
@@ -4,11 +4,15 @@ sidebarTitle: Overview
 description: Learn about the ngrok Kubernetes Operator for providing secure ingress to your k8s applications.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 The ngrok Kubernetes Operator exposes your Kubernetes services securely using standard Kubernetes resources like Ingress or the Gateway API. 
 With the Operator, teams can create and manage ngrok endpoints for their apps using a shared ngrok account.
 
 Optionally, bindings let you make services running elsewhere (including your local machine or another cluster) appear inside a cluster as normal Kubernetes Services. 
 This enables private, cross-cluster connectivity without publishing publicly accessible URLs.
+
+<YouTubeEmbed videoId="VU71CY6xcuY" title="Developer Roundtable: the ngrok Kubernetes Operator" />
 
 ## Concepts
 

--- a/gateway/traffic-policy/examples/block-unwanted-requests.mdx
+++ b/gateway/traffic-policy/examples/block-unwanted-requests.mdx
@@ -3,11 +3,15 @@ title: Block Unwanted Requests
 description: Learn how to block unwanted or malicious requests using Traffic Policy including examples for blocking Tor, bots, and specific IPs.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 import BlockAIBotsByIPIntel from "/snippets/traffic-policy/gallery/BlockAIBotsIPIntel.mdx";
 
 
 
 With Traffic Policy, you can block unwanted requests to your endpoints. This page demonstrates a few example rules that do so.
+
+<YouTubeEmbed videoId="Yx7QHvs4cfg" title="How to use ngrok as your WAF (with just a dash of YAML)" />
 
 See the following Traffic Policy action docs for more information:
 

--- a/gateway/traffic-policy/index.mdx
+++ b/gateway/traffic-policy/index.mdx
@@ -4,11 +4,15 @@ sidebarTitle: Overview
 description: Learn about ngrok's Traffic Policy for authenticating requests, rate limiting traffic, rewriting URLs, and applying security controls.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 ngrok's Traffic Policy is a configuration language that offers you the flexibility to filter, match, manage, and orchestrate traffic to your endpoints.
 
 - Validate incoming traffic, block malicious traffic, rewrite URLs, and respond with custom content.
 - Forward traffic to your agents running across the globe and orchestrate traffic across your infrastructure.
 - Add Traffic Policies to any type of ngrok endpoint to scope traffic management for each of your endpoints.
+
+<YouTubeEmbed videoId="tFAQXU2DiTU" title="Route and secure multiple services with ngrok's Traffic Policy" />
 
 <Columns cols={2}>
 	<Card icon="gears" title="How It Works" href="/gateway/traffic-policy/how-it-works">

--- a/getting-started/javascript.mdx
+++ b/getting-started/javascript.mdx
@@ -4,6 +4,8 @@ sidebarTitle: JavaScript
 description: Learn how to get started with the ngrok JavaScript SDK to create secure tunnels from your Node.js applications to the internet.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 <Prompt description="Give this to your AI coding agent to complete the full quickstart automatically." actions={["copy", "cursor"]}>
 Complete the ngrok JavaScript SDK quickstart:
 
@@ -26,6 +28,8 @@ This quickstart uses the ngrok JavaScript SDK to create an Agent Endpoint that f
 If you'd prefer to skip the boilerplate setup, you can clone the complete example from the [ngrok-samples collection](https://github.com/ngrok-samples/javascript-quickstart).
 In that case, you'll just need to reserve a domain and add your auth token as described below to get started.
 </Info>
+
+<YouTubeEmbed videoId="8ZeQ4btyVls" title="Watch the developer roundtable on the ngrok JavaScript SDK" />
 
 ## What you'll need
 

--- a/integrations/event-destinations/datadog-event-destination.mdx
+++ b/integrations/event-destinations/datadog-event-destination.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Datadog
 description: Send network traffic logs from ngrok to Datadog.
 ---
 
+import { YouTubeEmbed } from "/snippets/YouTubeEmbed.jsx";
+
 This guide walks you through sending ngrok events, including network traffic logs, to Datadog.
 You may want to keep an audit log of configuration changes in your ngrok account, record all traffic to your endpoints for active monitoring and troubleshooting, or use Datadog as a SIEM for security inspections.
 
@@ -16,6 +18,8 @@ By integrating ngrok with Datadog, you can:
 
 ngrok sends logs to the Datadog Logs API and automatically compresses them with gzip.
 ngrok does not support the events or metrics APIs at this time.
+
+<YouTubeEmbed videoId="56cJmj3ulYk" title="ngrok: Datadog event destination in action" />
 
 ## What you'll need
 


### PR DESCRIPTION
## Why

The ngrok YouTube channel holds 79 uploads. Only 11 docs pages carried an embed, so several videos had an obvious home and no placement.

## What changed

| Page | Video |
| --- | --- |
| `getting-started/javascript` | Developer Roundtable: JavaScript SDK |
| `gateway/k8s` | Developer Roundtable: Kubernetes Operator |
| `gateway/traffic-policy` | Route and secure multiple services with Traffic Policy |
| `gateway/domains` | Set up a custom domain on an ngrok account |
| `gateway/domains/custom-domains` | Set up a custom domain on an ngrok account |
| `gateway/endpoints/agent-cli-quickstart` | Set up the ngrok agent in 60 seconds |
| `gateway/traffic-policy/examples/block-unwanted-requests` | How to use ngrok as your WAF |
| `ai-gateway/quickstart` | Connect Cursor to a self-hosted LLM |
| `integrations/event-destinations/datadog-event-destination` | Datadog event destination in action |

`getting-started/go` already had a video and `getting-started/javascript` did not, so this closes that gap.

## Bug fix

`gateway/examples/n8n` linked the "livestreamed n8n workshop" to `U5FGr5axBnI`, which is the Universal Gateway video. The workshop is `Og1S25RvIi8`.

## Notes

- Two pages get the same domain-setup video, the same way both load-balancing pages share `xD1hZ84uEJs` today. Drop one if that reads as duplication.
- The channel has two domain videos. This uses the newer one. The older "static domain on ANY ngrok account" video is still unplaced.
- The WAF video has no dedicated WAF page to sit on. It went to the Traffic Policy "block unwanted requests" example, because the OWASP CRS action pages already carry `HHxj5VGFTEA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
