### PR TITLE
Fix stacked pills in Traffic Policy config reference

### DIFF
--- a/snippets/ConfigTable.jsx
+++ b/snippets/ConfigTable.jsx
@@ -20,7 +20,7 @@ export const ConfigField = ({
               </a>
             </div>
             <div className="font-semibold text-primary dark:text-primary-light overflow-wrap-anywhere">{title}</div>
-            <div className="inline items-center gap-2 text-xs font-medium [&_div]:inline [&_div]:mr-2 [&_div]:leading-5 [&_a]:inline [&_a]:mr-2 [&_a]:leading-5">
+            <div className="flex items-center flex-wrap gap-2 text-xs font-medium leading-5">
               {type && (<div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
                 <span className="text-gray-600 dark:text-gray-200 !font-medium">{type}</span>
               </div>)}
@@ -92,7 +92,7 @@ export const OldConfigItem = ({
               </a>
             </div>
             <div className="font-semibold text-primary dark:text-primary-light overflow-wrap-anywhere">{title}</div>
-            <div className="inline items-center gap-2 text-xs font-medium [&_div]:inline [&_div]:mr-2 [&_div]:leading-5 [&_a]:inline [&_a]:mr-2 [&_a]:leading-5">
+            <div className="flex items-center flex-wrap gap-2 text-xs font-medium leading-5">
               {type && (<div className="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 break-all">
                 <span className="text-gray-600 dark:text-gray-200 !font-medium">{type}</span>
               </div>)}


### PR DESCRIPTION
Config reference pills (`type`, `default:`, `Required`, `Supports CEL`) rendered stacked instead of in a row.

The wrapper used `[&_div]:inline` to undo `flex` on each pill, but Mintlify leaves arbitrary variants inside `@layer utilities` while prefixing plain utilities into an unlayered sheet, so the override always lost. Made the wrapper a real flex row instead.