### PR TITLE
Fix inaccurate custom load-balancing docs for forward-internal

### DIFF
--- a/gateway/endpoints/endpoint-pooling.mdx
+++ b/gateway/endpoints/endpoint-pooling.mdx
@@ -233,7 +233,7 @@ be load balanced. Consult the documentation for [wildcard
 endpoints](/gateway/endpoints/http/#wildcard-endpoints) to understand
 the rules for matching and precedence.
 
-## Protocol, binding and type
+## Protocol, binding, and type
 
 - Endpoint pooling supports all endpoint protocols
 - Endpoint pooling supports all endpoint bindings

--- a/gateway/endpoints/endpoint-pooling.mdx
+++ b/gateway/endpoints/endpoint-pooling.mdx
@@ -19,9 +19,6 @@ systems:
 
 - Endpoints join and leave pools automatically as they are created and
   destroyed, there is no need to register your upstreams ahead of time.
-- You can define your own _dynamic_ load balancing strategies. For example, you
-  can define strategies that adjust traffic distribution based on the
-  performance of upstream services or properties of the incoming requests.
 - You can pool endpoints with different Traffic Policies. This means that not
   only can you blue-green and canary deploy your own apps, you can also do that
   with the Traffic Policies themselves. This helps you dramatically mitigate the
@@ -213,13 +210,9 @@ Then:
 
 ## Custom strategies
 
-When balancing traffic to internal endpoints you may define your own balancing
-strategy by setting the `endpoint_selectors` and `endpoint_weights` fields on
-the `forward-internal` Traffic Policy action configuration.
-
 <Info title="Coming Soon">
 
-Custom load balancing strategies are not yet generally available, but you can
+Custom balancing strategies are not yet generally available, but you can
 request Early Access in your [ngrok
 dashboard](https://dashboard.ngrok.com/early-access).
 


### PR DESCRIPTION
The endpoint_selectors and endpoint_weights fields referenced for custom balancing strategies don't exist in the forward-internal Traffic Policy action. Removed the false claims while keeping the Early Access callout for the upcoming feature.