### PR TITLE
Rewrite relative changelog links to absolute when generating the k8s snippet

### DIFF
--- a/.github/workflows/auto-gen-k8s-changelog.yml
+++ b/.github/workflows/auto-gen-k8s-changelog.yml
@@ -27,15 +27,12 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           ref: main
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
       - name: Fetch and Update Changelog
-        run: |
-          CHANGELOG_URL="https://raw.githubusercontent.com/ngrok/ngrok-operator/refs/heads/main/CHANGELOG.md"
-          OUTPUT_PATH="snippets/k8s/_changelog.mdx"
-          
-          # Fetch and process using perl to remove the title and leading newlines exactly as the script did
-          curl -sSL --fail "$CHANGELOG_URL" | perl -0777 -pe 's/^# Changelog\n*//m' > "$OUTPUT_PATH"
-          
-          echo "Updated $OUTPUT_PATH"
+        run: node custom/scripts/fetch-k8s-changelog.js
 
       - name: Check for changes
         id: check

--- a/custom/scripts/fetch-k8s-changelog.js
+++ b/custom/scripts/fetch-k8s-changelog.js
@@ -5,7 +5,28 @@ const https = require('https');
 const path = require('path');
 
 const CHANGELOG_URL = 'https://raw.githubusercontent.com/ngrok/ngrok-operator/refs/heads/main/CHANGELOG.md';
-const OUTPUT_PATH = path.join(__dirname, '..', 'snippets', 'k8s', '_changelog.mdx');
+const OUTPUT_PATH = path.join(__dirname, '..', '..', 'snippets', 'k8s', '_changelog.mdx');
+
+// The upstream changelog sits at the root of the ngrok-operator repo, so its
+// relative links (docs/upgrading-to-0.24.md) resolve on GitHub but 404 once
+// copied into this repo. Rewrite them to absolute URLs.
+const BLOB_BASE = 'https://github.com/ngrok/ngrok-operator/blob/main';
+const RAW_BASE = 'https://raw.githubusercontent.com/ngrok/ngrok-operator/refs/heads/main';
+
+function absolutizeLinks(markdown) {
+  return markdown.replace(
+    /(!?)\[([^\]]*)\]\(\s*([^)\s]+)([^)]*)\)/g,
+    (match, image, text, target, trailer) => {
+      // Leave anything already absolute, protocol-relative, or an anchor alone.
+      if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(target)) {
+        return match;
+      }
+      const base = image ? RAW_BASE : BLOB_BASE;
+      const repoPath = target.replace(/^\.\//, '').replace(/^\//, '');
+      return `${image}[${text}](${base}/${repoPath}${trailer})`;
+    }
+  );
+}
 
 function fetchChangelog() {
   return new Promise((resolve, reject) => {
@@ -31,16 +52,18 @@ async function main() {
   try {
     console.log('Fetching K8s operator changelog...');
     const changelog = await fetchChangelog();
-    
+
     // Ensure the output directory exists
     const outputDir = path.dirname(OUTPUT_PATH);
     if (!fs.existsSync(outputDir)) {
       fs.mkdirSync(outputDir, { recursive: true });
     }
-    
+
     // Remove the "# Changelog" heading before writing
-    const processedChangelog = changelog.replace(/^# Changelog\n*/m, '');
-    
+    const processedChangelog = absolutizeLinks(
+      changelog.replace(/^# Changelog\n*/m, '')
+    );
+
     // Write the changelog to the output file
     fs.writeFileSync(OUTPUT_PATH, processedChangelog, 'utf8');
     console.log(`Successfully wrote changelog to ${OUTPUT_PATH}`);
@@ -50,4 +73,8 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { absolutizeLinks };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "fetch-k8s-changelog": "node custom/scripts/fetch-k8s-changelog.js",
     "dev": "mint dev --port 3333",
     "check-redirect-conflicts": "node custom/scripts/check-redirect-conflicts.js",
     "test-links": "mint broken-links",

--- a/snippets/k8s/_changelog.mdx
+++ b/snippets/k8s/_changelog.mdx
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/ngrok-operator-0.21.0...ngrok-operator-0.22.0
 
 Before upgrading, review the
-[Helm chart 0.23 to 0.24 upgrade guide](docs/upgrading-to-0.24.md).
+[Helm chart 0.23 to 0.24 upgrade guide](https://github.com/ngrok/ngrok-operator/blob/main/docs/upgrading-to-0.24.md).
 
 Moving `0.22.0-rc.2` to `0.22.0`. See the `0.22.0-rc.1` and `0.22.0-rc.2` notes below for changes.
 
@@ -22,7 +22,7 @@ Moving `0.22.0-rc.2` to `0.22.0`. See the `0.22.0-rc.1` and `0.22.0-rc.2` notes 
 **Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/ngrok-operator-0.21.0...ngrok-operator-0.22.0-rc.1
 
 For upgrade steps and required manifest migrations, see the
-[Helm chart 0.23 to 0.24 upgrade guide](docs/upgrading-to-0.24.md).
+[Helm chart 0.23 to 0.24 upgrade guide](https://github.com/ngrok/ngrok-operator/blob/main/docs/upgrading-to-0.24.md).
 
 ### Breaking Changes
 - Migrated ingress class handling to the new `ngrok.com` API group by @alex-bezek in [#819](https://github.com/ngrok/ngrok-operator/pull/819)


### PR DESCRIPTION
The k8s changelog snippet is copied verbatim from `ngrok-operator`'s `CHANGELOG.md`, which lives at that repo's root. Its relative links resolve on GitHub but 404 here, which is how the 0.24 upgrade guide link broke in `snippets/k8s/_changelog.mdx`.

The generator now rewrites relative link targets to absolute `ngrok-operator` URLs (`blob/main` for links, `raw.githubusercontent.com` for images), leaving absolute URLs, `mailto:`, protocol-relative, and anchor-only targets alone.

Two related fixes along the way. The workflow had its own inlined `curl | perl` copy of the fetch logic and never called `custom/scripts/fetch-k8s-changelog.js`, so the script had drifted into dead code — it now runs the script, so there is one implementation. And the script's `OUTPUT_PATH` was one directory short, resolving to `custom/snippets/k8s/_changelog.mdx`; it now writes to the real snippet path.

The regenerated snippet is included so the published link is fixed without waiting for the Monday cron. It is byte-identical to the previous file apart from the two link lines, confirming the node path reproduces the shell pipeline's output.

Upstream companion, making the links absolute at the source: ngrok/ngrok-operator#885.
