### PR TITLE
Exclude the served agent CLI pages from Vale, not just their pre-reslug paths

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -50,13 +50,16 @@ jobs:
             --jq '.[] | select(.status != "removed") | .filename' \
             > pr_files.txt
 
-          # Keep markdown only, excluding specific directories and files
+          # Keep markdown only, excluding specific directories and files.
+          # The agent CLI pages are generated from the ngrok monorepo, so Vale has
+          # nothing actionable to say about their prose. Both path forms are matched
+          # on purpose: the generator still writes agent/cli*.mdx, while the pages
+          # actually served live at gateway/agent/cli*.mdx after the #2299 reslug.
           grep -E '\.(mdx|md)$' pr_files.txt \
             | grep -v '^snippets/' \
             | grep -v '^errors/' \
             | grep -v '^\.skills/' \
-            | grep -v '^agent/cli-api.mdx$' \
-            | grep -v '^agent/cli.mdx$' \
+            | grep -vE '^(gateway/)?agent/cli(-api)?\.mdx$' \
             | grep -v '^style-guide.mdx$' \
             > changed_files.txt || true
 


### PR DESCRIPTION
The Vale workflow skips the generated agent CLI pages by path, and those paths went stale in #2299. It excludes `agent/cli.mdx` and `agent/cli-api.mdx`, but the pages actually served now live at `gateway/agent/cli.mdx` and `gateway/agent/cli-api.mdx`, so any PR touching those gets 741 and 9,790 lines of generated CLI output linted for prose style. This matches both path forms with one pattern and says why both exist.

While tracking that down I found the reason the old paths are still live, which this PR does not fix. `agent/cli.mdx` and `agent/cli-api.mdx` are still in the tree alongside the `gateway/agent/` copies #2299 created, because #2299 added the new copies without removing the originals. The generation pipeline still targets the old paths: it updated `agent/cli.mdx` in #2319 and both files in #2308, while the served copies have not changed since #2299. Nothing serves the old paths, since `/agent/cli` and `/agent/cli-api` both redirect into `/gateway/agent/`, so those regenerations reach no reader.

Content has not actually drifted yet. The two copies of `cli.mdx` are identical and the two of `cli-api.mdx` differ by a single link that #2299 correctly rewrote from `../api` to `/api`, which is right for the new location and wrong for the old one. The CLI simply has not changed since 21 August. It will drift the next time it does.

Fixing that properly means repointing the doc generation in the monorepo at `gateway/agent/`, which is not a change this repo can make. That is now open as ngrok-private/ngrok#47386.

Deleting the duplicates here is a follow-up that has to come after that merges. The delivery script clones this repo fresh and force-pushes, so deleting them now would just let the next generation run recreate them.

