### PR TITLE
Document the native Gemini API surface on gateway.ngrok.ai

### DIFF
--- a/.vale/styles/StyleRules/Headings.yml
+++ b/.vale/styles/StyleRules/Headings.yml
@@ -88,6 +88,7 @@ exceptions:
   - Firehose
   - FusionAuth
   - Gateway API
+  - Gemini
   - Groq
   - GET
   - Get Kubernetes Operator

--- a/ai-gateway/changelog.mdx
+++ b/ai-gateway/changelog.mdx
@@ -17,6 +17,9 @@ rss: true
   All three are exposed through CORS, so browser clients can read them.
   They are ngrok's own headers, so managed-key and Bring Your Own Keys callers see the same values.
   See [Response headers](/ai-gateway/how-it-works#response-headers).
+
+  The native Gemini `generateContent` and `streamGenerateContent` surface returns these headers too, where it previously returned only `Content-Type`.
+  Bodies on that surface are still forwarded byte-for-byte.
 </Update>
 
 <Update label="2026-08-20" description="Traffic Policy action retired" tags={["Breaking Change"]}>

--- a/ai-gateway/providers/google.mdx
+++ b/ai-gateway/providers/google.mdx
@@ -3,7 +3,13 @@ title: Google
 description: Use Google Gemini models through the ngrok AI Gateway's OpenAI-compatible API.
 ---
 
-[Google AI Studio](https://aistudio.google.com) provides Gemini models. The gateway reaches them through Google's OpenAI-compatible Chat Completions endpoint: send requests to `/v1/chat/completions` with an OpenAI client and change only the model name. The native Gemini `generateContent` API and the OpenAI Responses API (`/v1/responses`) do not reach Google models.
+[Google AI Studio](https://aistudio.google.com) provides Gemini models.
+The gateway reaches them two ways:
+
+- OpenAI-compatible Chat Completions: send requests to `/v1/chat/completions` with an OpenAI client and change only the model name.
+- Native Gemini: send requests to `/v1beta/models/{model}:generateContent` or `:streamGenerateContent` with a Gemini client.
+
+The OpenAI Responses API (`/v1/responses`) does not reach Google models.
 
 <Note>
 Google is a **built-in provider** with ngrok.ai inference available, so a provider key is optional. Add your own Google key to bill usage to your Google account instead of your ngrok credits.
@@ -42,6 +48,25 @@ Google is a **built-in provider** with ngrok.ai inference available, so a provid
     ```
   </Step>
 </Steps>
+
+## Native Gemini API
+
+Point a Gemini client at `https://gateway.ngrok.ai` and send your access key.
+The gateway accepts it as `Authorization: Bearer` or as `X-Goog-Api-Key`, the header Google's own SDKs set.
+
+```bash
+curl "https://gateway.ngrok.ai/v1beta/models/gemini-3.6-flash:generateContent" \
+  -H "X-Goog-Api-Key: ng-xxxxx-g1-xxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
+```
+
+Request and response bodies are forwarded byte-for-byte, so payloads match Google's own API exactly.
+Nothing is added to, removed from, or reordered inside a body.
+
+The headers are ngrok's, though.
+Alongside `Content-Type`, responses on this surface carry `Ngrok-AIG-Request-Id`, `Ngrok-AIG-Attempts`, and `Ngrok-AIG-Model`.
+See [Response headers](/ai-gateway/how-it-works#response-headers).
 
 ## Available models
 


### PR DESCRIPTION
Part of [AIG-1434](https://linear.app/ngrok/issue/AIG-1434/document-the-native-gemini-generatecontent-endpoint).