### PR TITLE
Subgroup the Gateway Agents sidebar and wire its reference pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -499,8 +499,8 @@
               {
                 "group": "Agents",
                 "pages": [
-                  "gateway/agent/index",
                   "gateway/agent/overview",
+                  "gateway/agent/index",
                   {
                     "group": "Guides",
                     "pages": [
@@ -543,7 +543,8 @@
                       "gateway/agent/deprecation-notices"
                     ]
                   }
-                ]
+                ],
+                "root": "gateway/agent/index"
               },
               {
                 "group": "Kubernetes Operators",

--- a/docs.json
+++ b/docs.json
@@ -510,14 +510,6 @@
                     ]
                   },
                   {
-                    "group": "Docker",
-                    "pages": [
-                      "using-ngrok-with/docker/index",
-                      "using-ngrok-with/docker/compose",
-                      "using-ngrok-with/docker/desktop"
-                    ]
-                  },
-                  {
                     "group": "Configuration File",
                     "pages": [
                       "gateway/agent/config/index",
@@ -1031,6 +1023,14 @@
               "integrations/guides/mqtt",
               "using-ngrok-with/cgnat",
               "using-ngrok-with/using-mcp",
+              {
+                "group": "Docker",
+                "pages": [
+                  "using-ngrok-with/docker/index",
+                  "using-ngrok-with/docker/compose",
+                  "using-ngrok-with/docker/desktop"
+                ]
+              },
               "using-ngrok-with/godaddy",
               "using-ngrok-with/googleColab",
               "using-ngrok-with/java",

--- a/docs.json
+++ b/docs.json
@@ -501,15 +501,48 @@
                 "pages": [
                   "gateway/agent/index",
                   "gateway/agent/overview",
-                  "gateway/agent/upgrade-v2-v3",
-                  "gateway/agent/version-support-policy",
-                  "gateway/agent/deprecation-notices",
-                  "gateway/agent/web-inspection-interface",
-                  "gateway/agent/agent-tls-termination",
-                  "gateway/agent/ssh-reverse-tunnel-agent",
-                  "using-ngrok-with/docker/index",
-                  "using-ngrok-with/docker/compose",
-                  "using-ngrok-with/docker/desktop"
+                  {
+                    "group": "Guides",
+                    "pages": [
+                      "gateway/agent/agent-tls-termination",
+                      "gateway/agent/ssh-reverse-tunnel-agent",
+                      "gateway/agent/web-inspection-interface"
+                    ]
+                  },
+                  {
+                    "group": "Docker",
+                    "pages": [
+                      "using-ngrok-with/docker/index",
+                      "using-ngrok-with/docker/compose",
+                      "using-ngrok-with/docker/desktop"
+                    ]
+                  },
+                  {
+                    "group": "Configuration File",
+                    "pages": [
+                      "gateway/agent/config/index",
+                      "gateway/agent/config/v2",
+                      "gateway/agent/config/v3"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "pages": [
+                      "gateway/agent/cli",
+                      "gateway/agent/cli-api",
+                      "gateway/agent/api",
+                      "gateway/agent/diagnose",
+                      "gateway/agent/changelog"
+                    ]
+                  },
+                  {
+                    "group": "Versions & Upgrades",
+                    "pages": [
+                      "gateway/agent/upgrade-v2-v3",
+                      "gateway/agent/version-support-policy",
+                      "gateway/agent/deprecation-notices"
+                    ]
+                  }
                 ]
               },
               {
@@ -2147,11 +2180,11 @@
     },
     {
       "source": "/secure-tunnels/ngrok-agent/diagnose-command",
-      "destination": "/gateway/agent/#troubleshooting-connectivity"
+      "destination": "/gateway/agent/diagnose"
     },
     {
       "source": "/secure-tunnels/ngrok-agent/installing-as-a-service",
-      "destination": "/gateway/agent/#background-service"
+      "destination": "/gateway/agent/#running-ngrok-in-the-background"
     },
     {
       "source": "/secure-tunnels/ngrok-agent",

--- a/gateway/agent/agent-tls-termination.mdx
+++ b/gateway/agent/agent-tls-termination.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent TLS Termination
-sidebarTitle: Quickstart
+sidebarTitle: TLS Termination
 description: Secure your traffic with end-to-end encryption by allowing your ngrok agents to terminate TLS.
 ---
 

--- a/gateway/agent/cli.mdx
+++ b/gateway/agent/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: ngrok Agent Command Line Interface (CLI)
-sidebarTitle: Reference
+sidebarTitle: CLI
 ---
 
 {/* This file is generated. Do not edit it directly. The templates can be edited in the ngrok-private repo */}
@@ -510,7 +510,7 @@ define where the installed ngrok service looks for its configuration file.
 When the ngrok service runs, it has the same behavior as if it were invoked
 from the command line with the command: "ngrok start --all".
 
-For more information about running ngrok as a service, check out the [ngrok service section in the secure tunnels documentation](/gateway/agent/#background-service)
+For more information about running ngrok as a service, check out the [ngrok service section in the secure tunnels documentation](/gateway/agent/#running-ngrok-in-the-background)
 
 ### Usage
 

--- a/gateway/agent/deprecation-notices.mdx
+++ b/gateway/agent/deprecation-notices.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agent Version Deprecation Notices
+sidebarTitle: Deprecation Notices
 description: What to do if you received an email about your ngrok agent version being deprecated.
 ---
 

--- a/gateway/agent/index.mdx
+++ b/gateway/agent/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ngrok Agent
-sidebarTitle: ngrok Agent
+sidebarTitle: Running the Agent
 description: The ngrok agent is a lightweight command-line program that forwards traffic from endpoints it creates on the ngrok cloud service to your upstream application services.
 ---
 

--- a/gateway/agent/index.mdx
+++ b/gateway/agent/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ngrok Agent
-sidebarTitle: Running the Agent
+sidebarTitle: Usage
 description: The ngrok agent is a lightweight command-line program that forwards traffic from endpoints it creates on the ngrok cloud service to your upstream application services.
 ---
 

--- a/gateway/agent/ssh-reverse-tunnel-agent.mdx
+++ b/gateway/agent/ssh-reverse-tunnel-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: SSH Reverse Tunnel
-sidebarTitle: Using SSH Reverse Tunneling
+sidebarTitle: SSH Reverse Tunnel
 description: A reverse SSH tunnel (ssh -R) exposes a local service through ngrok without installing the ngrok agent.
   Learn how it works, the commands, and its limits versus the agent.
 ---

--- a/gateway/device-gateway/arm64.mdx
+++ b/gateway/device-gateway/arm64.mdx
@@ -158,4 +158,4 @@ Now that you can create ngrok endpoints on your Linux ARM64 device and understan
 
 - Bring a [custom domain](/gateway/domains/custom-domains/) to ngrok to create static endpoints.
 - Learn how to write an [agent configuration file](/gateway/agent/config/v3/) to define and create multiple tunnels from a single command line.
-- Install [ngrok as a service](/gateway/agent/#background-service) to start after your ARM64 device boots and automatically restart after crashes.
+- Install [ngrok as a service](/gateway/agent/#running-ngrok-in-the-background) to start after your ARM64 device boots and automatically restart after crashes.

--- a/gateway/site-to-site-connectivity/end-customers.mdx
+++ b/gateway/site-to-site-connectivity/end-customers.mdx
@@ -295,7 +295,7 @@ site-to-site connectivity architecture.
 
 Your vendor is responsible for helping you configure and maintain your agents.
 
-They might configure your ngrok agent to [run in the background](/gateway/agent/#background-service) as a native operating system service. This functionality works on all Linux, Windows, and macOS systems, and once installed, the ngrok service starts at boot-time, automatically restarts after crashes, and sends logs to your system's native logging service.
+They might configure your ngrok agent to [run in the background](/gateway/agent/#running-ngrok-in-the-background) as a native operating system service. This functionality works on all Linux, Windows, and macOS systems, and once installed, the ngrok service starts at boot-time, automatically restarts after crashes, and sends logs to your system's native logging service.
 
 If they suggest deploying with Docker, they will likely recommend Docker's
 [restart

--- a/pricing-limits/free-plan-limits.mdx
+++ b/pricing-limits/free-plan-limits.mdx
@@ -11,7 +11,7 @@ Learn about the limits and resources included with the free ngrok for developers
 
 <Note>
 Free endpoints have no timeout—they can stay online indefinitely. 
-To keep one running unattended, run it as a [background service](/gateway/agent/#background-service).
+To keep one running unattended, run it as a [background service](/gateway/agent/#running-ngrok-in-the-background).
 </Note>
 
 <Tip>

--- a/using-ngrok-with/docker/index.mdx
+++ b/using-ngrok-with/docker/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using ngrok with Docker
+sidebarTitle: Overview
 description: Learn how to use ngrok with Docker to expose your local applications and services to the internet.
 ---
 


### PR DESCRIPTION
Splits the flat Agents list into Guides, Configuration File, Reference and Versions & Upgrades, and wires the agent's CLI, API, config file and changelog into the section instead of only the Reference tab. The three Docker pages move to Integrations › General Guides with the other `using-ngrok-with` guides. No page moves on disk and no new redirects.

The group's `root` is set to `gateway/agent/index` so the Overview can lead the sidebar without `/gateway/agent` redirecting off the page that owns its 41 anchors. Also relabels the entry that said "Quickstart" but pointed at TLS termination, and repairs two dead anchors into `/gateway/agent/`.
