### PR TITLE
Give Traffic Policy its own section and rename Traffic to Observability

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -612,7 +612,6 @@
             "group": "Traffic Policy",
             "pages": [
               "gateway/traffic-policy/index",
-              "gateway/traffic-policy/how-it-works",
               {
                 "group": "Quickstarts",
                 "pages": [
@@ -620,6 +619,7 @@
                   "gateway/traffic-policy/getting-started/cloud-endpoints"
                 ]
               },
+              "gateway/traffic-policy/how-it-works",
               {
                 "group": "Concepts",
                 "pages": [

--- a/docs.json
+++ b/docs.json
@@ -609,99 +609,94 @@
             ]
           },
           {
-            "group": "Traffic",
+            "group": "Traffic Policy",
             "pages": [
+              "gateway/traffic-policy/index",
+              "gateway/traffic-policy/how-it-works",
+              "gateway/traffic-policy/concepts/expressions",
+              "gateway/traffic-policy/concepts/actions",
+              "gateway/traffic-policy/identities",
               {
-                "group": "Traffic Policy",
+                "group": "Quickstarts",
                 "pages": [
-                  "gateway/traffic-policy/index",
-                  "gateway/traffic-policy/how-it-works",
-                  "gateway/traffic-policy/concepts/expressions",
-                  "gateway/traffic-policy/concepts/actions",
-                  "gateway/traffic-policy/identities",
-                  {
-                    "group": "Quickstarts",
-                    "pages": [
-                      "gateway/traffic-policy/getting-started/agent-endpoints",
-                      "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
-                      "gateway/traffic-policy/getting-started/cloud-endpoints"
-                    ]
-                  },
-                  {
-                    "group": "Actions",
-                    "pages": [
-                      "gateway/traffic-policy/actions/index",
-                      "gateway/traffic-policy/actions/add-headers",
-                      "gateway/traffic-policy/actions/basic-auth",
-                      "gateway/traffic-policy/actions/circuit-breaker",
-                      "gateway/traffic-policy/actions/close-connection",
-                      "gateway/traffic-policy/actions/compress-response",
-                      "gateway/traffic-policy/actions/custom-response",
-                      "gateway/traffic-policy/actions/deny",
-                      "gateway/traffic-policy/actions/forward-internal",
-                      "gateway/traffic-policy/actions/http-request",
-                      "gateway/traffic-policy/actions/jwt-validation",
-                      "gateway/traffic-policy/actions/log",
-                      "gateway/traffic-policy/actions/oauth",
-                      "gateway/traffic-policy/actions/oidc",
-                      "gateway/traffic-policy/actions/owasp-crs-request",
-                      "gateway/traffic-policy/actions/owasp-crs-response",
-                      "gateway/traffic-policy/actions/rate-limit",
-                      "gateway/traffic-policy/actions/redirect",
-                      "gateway/traffic-policy/actions/remove-headers",
-                      "gateway/traffic-policy/actions/request-body-find-replace",
-                      "gateway/traffic-policy/actions/response-body-find-replace",
-                      "gateway/traffic-policy/actions/restrict-ips",
-                      "gateway/traffic-policy/actions/saml",
-                      "gateway/traffic-policy/actions/set-vars",
-                      "gateway/traffic-policy/actions/sse-find-replace",
-                      "gateway/traffic-policy/actions/terminate-tls",
-                      "gateway/traffic-policy/actions/url-rewrite",
-                      "gateway/traffic-policy/actions/verify-webhook"
-                    ]
-                  },
-                  {
-                    "group": "Examples",
-                    "pages": [
-                      "gateway/traffic-policy/examples/index",
-                      "gateway/traffic-policy/examples/a-b-tests",
-                      "gateway/traffic-policy/examples/add-and-remove-headers",
-                      "gateway/traffic-policy/examples/add-authentication",
-                      "gateway/traffic-policy/examples/block-unwanted-requests",
-                      "gateway/traffic-policy/examples/filter-by-ip-category",
-                      "gateway/traffic-policy/examples/compress-json-responses",
-                      "gateway/traffic-policy/examples/enforce-tls",
-                      "gateway/traffic-policy/examples/event-logging",
-                      "gateway/traffic-policy/examples/oauth-protection",
-                      "gateway/traffic-policy/examples/rate-limit-requests",
-                      "gateway/traffic-policy/examples/route-requests",
-                      "gateway/traffic-policy/examples/url-rewrites",
-                      "gateway/traffic-policy/examples/user-agent-filtering"
-                    ]
-                  },
-                  {
-                    "group": "Reference",
-                    "pages": [
-                      "gateway/traffic-policy/macros/index",
-                      "gateway/traffic-policy/variables/index",
-                      "gateway/traffic-policy/variables/action",
-                      "gateway/traffic-policy/variables/connection",
-                      "gateway/traffic-policy/variables/endpoint",
-                      "gateway/traffic-policy/variables/ip-intel",
-                      "gateway/traffic-policy/variables/req",
-                      "gateway/traffic-policy/variables/res",
-                      "gateway/traffic-policy/variables/time"
-                    ]
-                  }
+                  "gateway/traffic-policy/getting-started/agent-endpoints",
+                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
+                  "gateway/traffic-policy/getting-started/cloud-endpoints"
                 ]
               },
               {
-                "group": "Traffic Inspector",
+                "group": "Actions",
                 "pages": [
-                  "obs/index",
-                  "obs/traffic-inspection"
+                  "gateway/traffic-policy/actions/index",
+                  "gateway/traffic-policy/actions/add-headers",
+                  "gateway/traffic-policy/actions/basic-auth",
+                  "gateway/traffic-policy/actions/circuit-breaker",
+                  "gateway/traffic-policy/actions/close-connection",
+                  "gateway/traffic-policy/actions/compress-response",
+                  "gateway/traffic-policy/actions/custom-response",
+                  "gateway/traffic-policy/actions/deny",
+                  "gateway/traffic-policy/actions/forward-internal",
+                  "gateway/traffic-policy/actions/http-request",
+                  "gateway/traffic-policy/actions/jwt-validation",
+                  "gateway/traffic-policy/actions/log",
+                  "gateway/traffic-policy/actions/oauth",
+                  "gateway/traffic-policy/actions/oidc",
+                  "gateway/traffic-policy/actions/owasp-crs-request",
+                  "gateway/traffic-policy/actions/owasp-crs-response",
+                  "gateway/traffic-policy/actions/rate-limit",
+                  "gateway/traffic-policy/actions/redirect",
+                  "gateway/traffic-policy/actions/remove-headers",
+                  "gateway/traffic-policy/actions/request-body-find-replace",
+                  "gateway/traffic-policy/actions/response-body-find-replace",
+                  "gateway/traffic-policy/actions/restrict-ips",
+                  "gateway/traffic-policy/actions/saml",
+                  "gateway/traffic-policy/actions/set-vars",
+                  "gateway/traffic-policy/actions/sse-find-replace",
+                  "gateway/traffic-policy/actions/terminate-tls",
+                  "gateway/traffic-policy/actions/url-rewrite",
+                  "gateway/traffic-policy/actions/verify-webhook"
                 ]
               },
+              {
+                "group": "Examples",
+                "pages": [
+                  "gateway/traffic-policy/examples/index",
+                  "gateway/traffic-policy/examples/a-b-tests",
+                  "gateway/traffic-policy/examples/add-and-remove-headers",
+                  "gateway/traffic-policy/examples/add-authentication",
+                  "gateway/traffic-policy/examples/block-unwanted-requests",
+                  "gateway/traffic-policy/examples/filter-by-ip-category",
+                  "gateway/traffic-policy/examples/compress-json-responses",
+                  "gateway/traffic-policy/examples/enforce-tls",
+                  "gateway/traffic-policy/examples/event-logging",
+                  "gateway/traffic-policy/examples/oauth-protection",
+                  "gateway/traffic-policy/examples/rate-limit-requests",
+                  "gateway/traffic-policy/examples/route-requests",
+                  "gateway/traffic-policy/examples/url-rewrites",
+                  "gateway/traffic-policy/examples/user-agent-filtering"
+                ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "gateway/traffic-policy/macros/index",
+                  "gateway/traffic-policy/variables/index",
+                  "gateway/traffic-policy/variables/action",
+                  "gateway/traffic-policy/variables/connection",
+                  "gateway/traffic-policy/variables/endpoint",
+                  "gateway/traffic-policy/variables/ip-intel",
+                  "gateway/traffic-policy/variables/req",
+                  "gateway/traffic-policy/variables/res",
+                  "gateway/traffic-policy/variables/time"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Observability",
+            "pages": [
+              "obs/index",
+              "obs/traffic-inspection",
               {
                 "group": "Log Exporting",
                 "pages": [

--- a/docs.json
+++ b/docs.json
@@ -613,15 +613,19 @@
             "pages": [
               "gateway/traffic-policy/index",
               "gateway/traffic-policy/how-it-works",
-              "gateway/traffic-policy/concepts/expressions",
-              "gateway/traffic-policy/concepts/actions",
-              "gateway/traffic-policy/identities",
               {
                 "group": "Quickstarts",
                 "pages": [
                   "gateway/traffic-policy/getting-started/agent-endpoints",
-                  "gateway/traffic-policy/getting-started/agent-endpoints/config-file",
                   "gateway/traffic-policy/getting-started/cloud-endpoints"
+                ]
+              },
+              {
+                "group": "Concepts",
+                "pages": [
+                  "gateway/traffic-policy/concepts/expressions",
+                  "gateway/traffic-policy/concepts/actions",
+                  "gateway/traffic-policy/identities"
                 ]
               },
               {
@@ -680,14 +684,19 @@
                 "group": "Reference",
                 "pages": [
                   "gateway/traffic-policy/macros/index",
-                  "gateway/traffic-policy/variables/index",
-                  "gateway/traffic-policy/variables/action",
-                  "gateway/traffic-policy/variables/connection",
-                  "gateway/traffic-policy/variables/endpoint",
-                  "gateway/traffic-policy/variables/ip-intel",
-                  "gateway/traffic-policy/variables/req",
-                  "gateway/traffic-policy/variables/res",
-                  "gateway/traffic-policy/variables/time"
+                  {
+                    "group": "Variables",
+                    "pages": [
+                      "gateway/traffic-policy/variables/index",
+                      "gateway/traffic-policy/variables/action",
+                      "gateway/traffic-policy/variables/connection",
+                      "gateway/traffic-policy/variables/endpoint",
+                      "gateway/traffic-policy/variables/ip-intel",
+                      "gateway/traffic-policy/variables/req",
+                      "gateway/traffic-policy/variables/res",
+                      "gateway/traffic-policy/variables/time"
+                    ]
+                  }
                 ]
               }
             ]

--- a/gateway/traffic-policy/concepts/actions.mdx
+++ b/gateway/traffic-policy/concepts/actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Actions
+sidebarTitle: Terminating Actions
 description: Learn about Traffic Policy Actions that define what happens when rules are matched, including traffic manipulation and routing Actions.
 ---
 


### PR DESCRIPTION
Traffic held a 59-page configuration surface and four pages of observability tooling. Traffic Policy becomes a top-level group, which brings its Actions, Examples and Reference lists up a level, and Traffic takes the name the content was already using: `obs/index` is titled "Traffic Observability Overview", so it now leads the group instead of sitting inside Traffic Inspector.

Then a first pass on Traffic Policy itself, following the Agents section. The section reads Overview, Quickstarts, How It Works, matching the Gateway tab's own Getting Started group. Quickstarts goes from three entries to two—`getting-started/agent-endpoints/config-file` duplicated a tab already on the Agent Endpoints quickstart above it, so it leaves the sidebar while its URL keeps resolving. The unlabeled `concepts/actions` page, which sat next to the Actions group reading as a second "Actions", becomes "Terminating Actions" and joins the other two concept pages in a Concepts group. Reference splits its nine flat rows into Macros plus a Variables group.
